### PR TITLE
Build without +nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
 script:
   - cargo build --features="$FEATURES"
+  - cargo build --features="$FEATURES" --manifest-path=rayon-demo/Cargo.toml
   - |
     if [ $TRAVIS_RUST_VERSION == nightly ]; then
       cargo test --features="$FEATURES" &&

--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(test, feature(test))]
-#![feature(conservative_impl_trait)]
+#![cfg_attr(test, feature(conservative_impl_trait))]
 
 use std::env;
 use std::io;


### PR DESCRIPTION
First, thanks for a great library everybody! 😄 

I happened to see this, and I tried the examples. They seem to run just fine on stable Rust nowadays. Any particular reason why we'd want to keep running these on nightly, or is just a remnant from the past?
