### PR TITLE
introduce custom schedulers for parallel iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ docopt = "0.7"
 futures = "0.1.7"
 rand = "0.3"
 rustc-serialize = "0.3"
+thread-id = "3.1.0"
 
 [features]
 # Unstable APIs that have not yet

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -299,13 +299,6 @@ pub fn initialize(config: Configuration) -> Result<(), Box<Error>> {
     Ok(())
 }
 
-/// This is a debugging API not really intended for end users. It will
-/// dump some performance statistics out using `println`.
-#[cfg(feature = "unstable")]
-pub fn dump_stats() {
-    dump_stats!();
-}
-
 impl fmt::Debug for Configuration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Configuration { ref num_threads, ref get_thread_name, ref panic_handler, ref stack_size,

--- a/rayon-core/src/log.rs
+++ b/rayon-core/src/log.rs
@@ -9,7 +9,6 @@
 //! variable, which is still supported for backwards compatibility.
 
 use std::env;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
 #[derive(Debug)]
 pub enum Event {
@@ -57,29 +56,3 @@ macro_rules! log {
     }
 }
 
-pub static STOLEN_JOB: AtomicUsize = ATOMIC_USIZE_INIT;
-
-macro_rules! stat_stolen {
-    () => {
-        ::log::STOLEN_JOB.fetch_add(1, ::std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-pub static POPPED_JOB: AtomicUsize = ATOMIC_USIZE_INIT;
-
-macro_rules! stat_popped {
-    () => {
-        ::log::POPPED_JOB.fetch_add(1, ::std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-macro_rules! dump_stats {
-    () => {
-        {
-            let stolen = ::log::STOLEN_JOB.load(::std::sync::atomic::Ordering::SeqCst);
-            println!("Jobs stolen: {:?}", stolen);
-            let popped = ::log::POPPED_JOB.load(::std::sync::atomic::Ordering::SeqCst);
-            println!("Jobs popped: {:?}", popped);
-        }
-    }
-}

--- a/src/collections/binary_heap.rs
+++ b/src/collections/binary_heap.rs
@@ -12,6 +12,7 @@ use vec;
 impl<T: Ord + Send> IntoParallelIterator for BinaryHeap<T> {
     type Item = T;
     type Iter = IntoIter<T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         IntoIter { inner: Vec::from(self).into_par_iter() }

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -9,6 +9,7 @@ macro_rules! into_par_vec {
         impl $($args)* IntoParallelIterator for $t {
             type Item = <$t as IntoIterator>::Item;
             type Iter = $iter<$($i),*>;
+            type Scheduler = DefaultScheduler;
 
             fn into_par_iter(self) -> Self::Iter {
                 use std::iter::FromIterator;

--- a/src/collections/vec_deque.rs
+++ b/src/collections/vec_deque.rs
@@ -18,6 +18,7 @@ into_par_vec!{
 impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
     type Item = &'a T;
     type Iter = Iter<'a, T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         let (a, b) = self.as_slices();
@@ -28,6 +29,7 @@ impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
 impl<'a, T: Send> IntoParallelIterator for &'a mut VecDeque<T> {
     type Item = &'a mut T;
     type Iter = IterMut<'a, T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         let (a, b) = self.as_mut_slices();

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -71,11 +71,12 @@ macro_rules! delegate_iterator_item {
 
         impl $( $args )* ParallelIterator for $iter < $( $i ),* > {
             type Item = $item;
+            type Scheduler = <$inner as ParallelIterator>::Scheduler;
 
-            fn drive_unindexed<C>(self, consumer: C) -> C::Result
-                where C: UnindexedConsumer<Self::Item>
+            fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+                where C: UnindexedConsumer<Self::Item>, S: Scheduler,
             {
-                self.inner.drive_unindexed(consumer)
+                self.inner.drive_unindexed(consumer, scheduler)
             }
 
             fn opt_len(&mut self) -> Option<usize> {
@@ -99,20 +100,20 @@ macro_rules! delegate_indexed_iterator_item {
         }
 
         impl $( $args )* IndexedParallelIterator for $iter < $( $i ),* > {
-            fn drive<C>(self, consumer: C) -> C::Result
-                where C: Consumer<Self::Item>
+            fn drive<C, S>(self, consumer: C, scheduler: S) -> C::Result
+                where C: Consumer<Self::Item>, S: Scheduler,
             {
-                self.inner.drive(consumer)
+                self.inner.drive(consumer, scheduler)
             }
 
             fn len(&mut self) -> usize {
                 self.inner.len()
             }
 
-            fn with_producer<CB>(self, callback: CB) -> CB::Output
-                where CB: ProducerCallback<Self::Item>
+            fn with_producer<CB, S>(self, callback: CB, scheduler: S) -> CB::Output
+                where CB: ProducerCallback<Self::Item>, S: Scheduler,
             {
-                self.inner.with_producer(callback)
+                self.inner.with_producer(callback, scheduler)
             }
         }
     }

--- a/src/iter/README.md
+++ b/src/iter/README.md
@@ -171,8 +171,8 @@ impl<I, F> IndexedParallelIterator for Map<I, F>
     where I: IndexedParallelIterator,
           F: MapOp<I::Item>,
 {
-    fn with_producer<CB>(self, callback: CB) -> CB::Output {
-        let map_op = &self.map_op;
+    fn with_producer<CB, S>(self, callback: CB, scheduler: S) -> CB::Output {
+        let map_op = &self.map_op;, S: Scheduler,
         self.base_iter.with_producer(|base_producer| {
             // Here `producer` is the producer for `self.base_iter`.
             // Wrap that to make a `MapProducer`
@@ -275,10 +275,10 @@ impl<I, F> IndexedParallelIterator for Map<I, F>
     where I: IndexedParallelIterator,
           F: MapOp<I::Item>,
 {
-    fn with_producer<CB>(self, callback: CB) -> CB::Output
-        where CB: ProducerCallback<Self::Item>
+    fn with_producer<CB, S>(self, callback: CB, scheduler: S) -> CB::Output
+        where CB: ProducerCallback<Self::Item>, S: Scheduler,
     {
-        return self.base.with_producer(Callback { callback: callback, map_op: self.map_op });
+        return self.base.with_producer(Callback { callback: callback, map_op: self.map_op }, scheduler);
         //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         //                             Manual version of the closure sugar: create an instance
         //                             of a struct that implements `ProducerCallback`.

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -179,14 +179,6 @@ impl<A, B> Producer for ChainProducer<A, B>
         ChainSeq::new(self.a.into_iter(), self.b.into_iter())
     }
 
-    fn min_len(&self) -> usize {
-        cmp::max(self.a.min_len(), self.b.min_len())
-    }
-
-    fn max_len(&self) -> usize {
-        cmp::min(self.a.max_len(), self.b.max_len())
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         if index <= self.a_len {
             let a_rem = self.a_len - index;

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -1,6 +1,5 @@
 use super::internal::*;
 use super::*;
-use std::cmp;
 use std::iter;
 use rayon_core::join;
 

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -98,14 +98,6 @@ impl<'a, T, P> Producer for ClonedProducer<P>
         self.base.into_iter().cloned()
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (ClonedProducer { base: left }, ClonedProducer { base: right })

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -27,12 +27,13 @@ impl<'a, T, I> ParallelIterator for Cloned<I>
           T: 'a + Clone + Send + Sync
 {
     type Item = T;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = ClonedConsumer::new(consumer);
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 
     fn opt_len(&mut self) -> Option<usize> {
@@ -44,21 +45,21 @@ impl<'a, T, I> IndexedParallelIterator for Cloned<I>
     where I: IndexedParallelIterator<Item = &'a T>,
           T: 'a + Clone + Send + Sync
 {
-    fn drive<C>(self, consumer: C) -> C::Result
-        where C: Consumer<Self::Item>
+    fn drive<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: Consumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = ClonedConsumer::new(consumer);
-        self.base.drive(consumer1)
+        self.base.drive(consumer1, scheduler)
     }
 
     fn len(&mut self) -> usize {
         self.base.len()
     }
 
-    fn with_producer<CB>(self, callback: CB) -> CB::Output
-        where CB: ProducerCallback<Self::Item>
+    fn with_producer<CB, S>(self, callback: CB, scheduler: S) -> CB::Output
+        where CB: ProducerCallback<Self::Item>, S: Scheduler,
     {
-        return self.base.with_producer(Callback { callback: callback });
+        return self.base.with_producer(Callback { callback: callback }, scheduler);
 
         struct Callback<CB> {
             callback: CB,
@@ -70,11 +71,11 @@ impl<'a, T, I> IndexedParallelIterator for Cloned<I>
         {
             type Output = CB::Output;
 
-            fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = &'a T>
+            fn callback<P, S>(self, base: P, scheduler: S) -> CB::Output
+                where P: Producer<Item = &'a T>, S: Scheduler
             {
                 let producer = ClonedProducer { base: base };
-                self.callback.callback(producer)
+                self.callback.callback(producer, scheduler)
             }
         }
     }

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -1,4 +1,6 @@
 use super::{ParallelIterator, IndexedParallelIterator, IntoParallelIterator, ParallelExtend};
+use super::internal::DefaultScheduler;
+
 use std::collections::LinkedList;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -18,7 +20,7 @@ pub fn collect_into<I, T>(mut pi: I, v: &mut Vec<T>)
 {
     v.truncate(0); // clear any old data
     let mut collect = Collect::new(v, pi.len());
-    pi.drive(collect.as_consumer());
+    pi.drive(collect.as_consumer(), DefaultScheduler);
     collect.complete();
 }
 
@@ -38,7 +40,7 @@ fn special_extend<I, T>(pi: I, len: usize, v: &mut Vec<T>)
           T: Send
 {
     let mut collect = Collect::new(v, len);
-    pi.drive_unindexed(collect.as_consumer());
+    pi.drive_unindexed(collect.as_consumer(), DefaultScheduler);
     collect.complete();
 }
 

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -103,13 +103,6 @@ impl<P> Producer for EnumerateProducer<P>
         (self.offset..usize::MAX).zip(self.base.into_iter())
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (EnumerateProducer {

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -28,12 +28,13 @@ impl<I, P> ParallelIterator for Filter<I, P>
           P: Fn(&I::Item) -> bool + Sync + Send
 {
     type Item = I::Item;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = FilterConsumer::new(consumer, &self.filter_op);
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 }
 

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -29,12 +29,13 @@ impl<I, P, R> ParallelIterator for FilterMap<I, P>
           R: Send
 {
     type Item = R;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer = FilterMapConsumer::new(consumer, &self.filter_op);
-        self.base.drive_unindexed(consumer)
+        self.base.drive_unindexed(consumer, scheduler)
     }
 }
 

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -8,7 +8,7 @@ pub fn find<I, P>(pi: I, find_op: P) -> Option<I::Item>
 {
     let found = AtomicBool::new(false);
     let consumer = FindConsumer::new(&find_op, &found);
-    pi.drive_unindexed(consumer)
+    pi.drive_unindexed(consumer, DefaultScheduler)
 }
 
 struct FindConsumer<'p, P: 'p> {

--- a/src/iter/find_first_last/mod.rs
+++ b/src/iter/find_first_last/mod.rs
@@ -43,7 +43,7 @@ pub fn find_first<I, P>(pi: I, find_op: P) -> Option<I::Item>
 {
     let best_found = AtomicUsize::new(usize::max_value());
     let consumer = FindConsumer::new(&find_op, MatchPosition::Leftmost, &best_found);
-    pi.drive_unindexed(consumer)
+    pi.drive_unindexed(consumer, DefaultScheduler)
 }
 
 pub fn find_last<I, P>(pi: I, find_op: P) -> Option<I::Item>
@@ -52,7 +52,7 @@ pub fn find_last<I, P>(pi: I, find_op: P) -> Option<I::Item>
 {
     let best_found = AtomicUsize::new(0);
     let consumer = FindConsumer::new(&find_op, MatchPosition::Rightmost, &best_found);
-    pi.drive_unindexed(consumer)
+    pi.drive_unindexed(consumer, DefaultScheduler)
 }
 
 struct FindConsumer<'p, P: 'p> {

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -26,51 +26,56 @@ pub fn new<I, F>(base: I, map_op: F) -> FlatMap<I, F>
 impl<I, F, PI> ParallelIterator for FlatMap<I, F>
     where I: ParallelIterator,
           F: Fn(I::Item) -> PI + Sync + Send,
-          PI: IntoParallelIterator
+          PI: IntoParallelIterator<Scheduler = DefaultScheduler>,
 {
     type Item = PI::Item;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer = FlatMapConsumer {
             base: consumer,
             map_op: &self.map_op,
+            scheduler: scheduler,
         };
-        self.base.drive_unindexed(consumer)
+        self.base.drive_unindexed(consumer, scheduler)
     }
 }
 
 /// ////////////////////////////////////////////////////////////////////////
 /// Consumer implementation
 
-struct FlatMapConsumer<'f, C, F: 'f> {
+struct FlatMapConsumer<'f, C, F: 'f, S> {
     base: C,
     map_op: &'f F,
+    scheduler: S,
 }
 
-impl<'f, C, F> FlatMapConsumer<'f, C, F> {
-    fn new(base: C, map_op: &'f F) -> Self {
+impl<'f, C, F, S> FlatMapConsumer<'f, C, F, S> {
+    fn new(base: C, map_op: &'f F, scheduler: S) -> Self {
         FlatMapConsumer {
             base: base,
             map_op: map_op,
+            scheduler: scheduler,
         }
     }
 }
 
-impl<'f, T, U, C, F> Consumer<T> for FlatMapConsumer<'f, C, F>
+impl<'f, T, U, C, F, S> Consumer<T> for FlatMapConsumer<'f, C, F, S>
     where C: UnindexedConsumer<U::Item>,
           F: Fn(T) -> U + Sync,
-          U: IntoParallelIterator
+          U: IntoParallelIterator,
+          S: Scheduler,
 {
-    type Folder = FlatMapFolder<'f, C, F, C::Result>;
+    type Folder = FlatMapFolder<'f, C, F, C::Result, S>;
     type Reducer = C::Reducer;
     type Result = C::Result;
 
     fn split_at(self, index: usize) -> (Self, Self, C::Reducer) {
         let (left, right, reducer) = self.base.split_at(index);
-        (FlatMapConsumer::new(left, self.map_op),
-         FlatMapConsumer::new(right, self.map_op),
+        (FlatMapConsumer::new(left, self.map_op, self.scheduler),
+         FlatMapConsumer::new(right, self.map_op, self.scheduler),
          reducer)
     }
 
@@ -78,6 +83,7 @@ impl<'f, T, U, C, F> Consumer<T> for FlatMapConsumer<'f, C, F>
         FlatMapFolder {
             base: self.base,
             map_op: self.map_op,
+            scheduler: self.scheduler,
             previous: None,
         }
     }
@@ -87,13 +93,14 @@ impl<'f, T, U, C, F> Consumer<T> for FlatMapConsumer<'f, C, F>
     }
 }
 
-impl<'f, T, U, C, F> UnindexedConsumer<T> for FlatMapConsumer<'f, C, F>
+impl<'f, T, U, C, F, S> UnindexedConsumer<T> for FlatMapConsumer<'f, C, F, S>
     where C: UnindexedConsumer<U::Item>,
           F: Fn(T) -> U + Sync,
-          U: IntoParallelIterator
+          U: IntoParallelIterator,
+          S: Scheduler,
 {
     fn split_off_left(&self) -> Self {
-        FlatMapConsumer::new(self.base.split_off_left(), self.map_op)
+        FlatMapConsumer::new(self.base.split_off_left(), self.map_op, self.scheduler)
     }
 
     fn to_reducer(&self) -> Self::Reducer {
@@ -102,23 +109,25 @@ impl<'f, T, U, C, F> UnindexedConsumer<T> for FlatMapConsumer<'f, C, F>
 }
 
 
-struct FlatMapFolder<'f, C, F: 'f, R> {
+struct FlatMapFolder<'f, C, F: 'f, R, S> {
     base: C,
     map_op: &'f F,
     previous: Option<R>,
+    scheduler: S,
 }
 
-impl<'f, T, U, C, F> Folder<T> for FlatMapFolder<'f, C, F, C::Result>
+impl<'f, T, U, C, F, S> Folder<T> for FlatMapFolder<'f, C, F, C::Result, S>
     where C: UnindexedConsumer<U::Item>,
           F: Fn(T) -> U + Sync,
-          U: IntoParallelIterator
+          U: IntoParallelIterator,
+          S: Scheduler,
 {
     type Result = C::Result;
 
     fn consume(self, item: T) -> Self {
         let map_op = self.map_op;
         let par_iter = map_op(item).into_par_iter();
-        let result = par_iter.drive_unindexed(self.base.split_off_left());
+        let result = par_iter.drive_unindexed(self.base.split_off_left(), self.scheduler);
 
         // We expect that `previous` is `None`, because we drive
         // the cost up so high, but just in case.
@@ -134,6 +143,7 @@ impl<'f, T, U, C, F> Folder<T> for FlatMapFolder<'f, C, F, C::Result>
             base: self.base,
             map_op: map_op,
             previous: previous,
+            scheduler: self.scheduler,
         }
     }
 

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -32,16 +32,17 @@ impl<U, I, ID, F> ParallelIterator for Fold<I, ID, F>
           U: Send
 {
     type Item = U;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = FoldConsumer {
             base: consumer,
             fold_op: &self.fold_op,
             identity: &self.identity,
         };
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 }
 
@@ -155,16 +156,17 @@ impl<U, I, F> ParallelIterator for FoldWith<I, U, F>
           U: Send + Clone
 {
     type Item = U;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = FoldWithConsumer {
             base: consumer,
             item: self.item,
             fold_op: &self.fold_op,
         };
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 }
 

--- a/src/iter/for_each.rs
+++ b/src/iter/for_each.rs
@@ -8,7 +8,7 @@ pub fn for_each<I, F, T>(pi: I, op: &F)
           T: Send
 {
     let consumer = ForEachConsumer { op: op };
-    pi.drive_unindexed(consumer)
+    pi.drive_unindexed(consumer, DefaultScheduler)
 }
 
 struct ForEachConsumer<'f, F: 'f> {

--- a/src/iter/in_scheduler/mod.rs
+++ b/src/iter/in_scheduler/mod.rs
@@ -1,8 +1,6 @@
 use super::internal::*;
 use super::*;
 
-use std::iter;
-
 mod test;
 
 /// `InScheduler` is a parallel iterator that switches to use the
@@ -78,14 +76,14 @@ impl<I, S> IndexedParallelIterator for InScheduler<I, S>
 // wacky. Also, this perhaps needs to be exported.
 #[derive(Copy, Clone)]
 pub struct CustomScheduler {
-    dummy: () // intentionally imposible to construct
+    _dummy: () // intentionally imposible to construct
 }
 
 impl Scheduler for CustomScheduler {
     fn execute_indexed<P, C>(self,
-                             len: usize,
-                             producer: P,
-                             consumer: C)
+                             _len: usize,
+                             _producer: P,
+                             _consumer: C)
                              -> C::Result
         where P: Producer,
               C: Consumer<P::Item>,
@@ -94,8 +92,8 @@ impl Scheduler for CustomScheduler {
     }
 
     fn execute_unindexed<P, C>(self,
-                               producer: P,
-                               consumer: C)
+                               _producer: P,
+                               _consumer: C)
                                -> C::Result
         where P: UnindexedProducer,
               C: UnindexedConsumer<P::Item>,

--- a/src/iter/in_scheduler/mod.rs
+++ b/src/iter/in_scheduler/mod.rs
@@ -1,0 +1,107 @@
+use super::internal::*;
+use super::*;
+
+use std::iter;
+
+mod test;
+
+/// `InScheduler` is a parallel iterator that switches to use the
+/// given scheduler, rather than the default (rayon-core).
+///
+/// This struct is created by the [`in_scheduler()`] method on [`ParallelIterator`]
+///
+/// [`in_scheduler()`]: trait.ParallelIterator.html#method.in_scheduler
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+pub struct InScheduler<I, S>
+    where I: ParallelIterator<Scheduler = DefaultScheduler>,
+          S: Scheduler,
+{
+    base: I,
+    scheduler: S,
+}
+
+/// Create a new `InScheduler` iterator.
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I, S>(base: I, scheduler: S) -> InScheduler<I, S>
+    where I: ParallelIterator<Scheduler = DefaultScheduler>, S: Scheduler,
+{
+    InScheduler { base: base, scheduler: scheduler }
+}
+
+impl<I, S> ParallelIterator for InScheduler<I, S>
+    where I: ParallelIterator<Scheduler = DefaultScheduler>,
+          S: Scheduler,
+{
+    type Item = I::Item;
+
+    // Note: it is not actually important to reflect `S` in this type
+    // here. The only thing is that the type is **not**
+    // `DefaultScheduler`, so that we can't call `in_scheduler()`
+    // twice.
+    type Scheduler = CustomScheduler;
+
+    fn drive_unindexed<C, S1>(self, consumer: C, _scheduler: S1) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
+    {
+        self.base.drive_unindexed(consumer, self.scheduler)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        self.base.opt_len()
+    }
+}
+
+impl<I, S> IndexedParallelIterator for InScheduler<I, S>
+    where I: IndexedParallelIterator<Scheduler = DefaultScheduler>,
+          S: Scheduler,
+{
+    fn drive<C, S1>(self, consumer: C, _scheduler: S1) -> C::Result
+        where C: Consumer<Self::Item>, S: Scheduler,
+    {
+        self.base.drive(consumer, self.scheduler)
+    }
+
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+
+    fn with_producer<CB, S1>(self, callback: CB, _scheduler: S1) -> CB::Output
+        where CB: ProducerCallback<Self::Item>, S: Scheduler,
+    {
+        self.base.with_producer(callback, self.scheduler)
+    }
+}
+
+// This is a "sentinel" type that we use as the value of
+// `Scheduler`. It's not a real scheduler, actually. This is a bit
+// wacky. Also, this perhaps needs to be exported.
+#[derive(Copy, Clone)]
+pub struct CustomScheduler {
+    dummy: () // intentionally imposible to construct
+}
+
+impl Scheduler for CustomScheduler {
+    fn execute_indexed<P, C>(self,
+                             len: usize,
+                             producer: P,
+                             consumer: C)
+                             -> C::Result
+        where P: Producer,
+              C: Consumer<P::Item>,
+    {
+        panic!("impossible")
+    }
+
+    fn execute_unindexed<P, C>(self,
+                               producer: P,
+                               consumer: C)
+                               -> C::Result
+        where P: UnindexedProducer,
+              C: UnindexedConsumer<P::Item>,
+    {
+        panic!("impossible")
+    }
+}
+
+

--- a/src/iter/in_scheduler/test.rs
+++ b/src/iter/in_scheduler/test.rs
@@ -1,0 +1,55 @@
+#![cfg(test)]
+
+use iter::internal::*;
+use prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+extern crate thread_id;
+
+struct SequentialScheduler {
+    indexed: AtomicUsize,
+    unindexed: AtomicUsize,
+}
+
+impl<'a> Scheduler for &'a SequentialScheduler {
+    fn execute_indexed<P, C>(self,
+                             len: usize,
+                             producer: P,
+                             consumer: C)
+                             -> C::Result
+        where P: Producer,
+              C: Consumer<P::Item>
+    {
+        self.indexed.fetch_add(1, Ordering::SeqCst);
+        consumer.into_folder().consume_iter(producer.into_iter()).complete()
+    }
+
+    fn execute_unindexed<P, C>(self,
+                               producer: P,
+                               consumer: C)
+                               -> C::Result
+        where P: UnindexedProducer,
+              C: UnindexedConsumer<P::Item>
+    {
+        self.unindexed.fetch_add(1, Ordering::SeqCst);
+        producer.fold_with(consumer.into_folder()).complete()
+    }
+}
+
+#[test]
+fn seq_scheduler() {
+    let scheduler = SequentialScheduler {
+        indexed: AtomicUsize::new(0),
+        unindexed: AtomicUsize::new(0),
+    };
+
+    let this_id = thread_id::get();
+
+    (0..512).into_par_iter()
+            .map(|i| i * 2)
+            .in_scheduler(&scheduler)
+            .for_each(|_| assert_eq!(thread_id::get(), this_id));
+
+    assert!(scheduler.indexed.load(Ordering::SeqCst) == 1);
+    assert!(scheduler.unindexed.load(Ordering::SeqCst) == 0);
+}

--- a/src/iter/in_scheduler/test.rs
+++ b/src/iter/in_scheduler/test.rs
@@ -13,7 +13,7 @@ struct SequentialScheduler {
 
 impl<'a> Scheduler for &'a SequentialScheduler {
     fn execute_indexed<P, C>(self,
-                             len: usize,
+                             _len: usize,
                              producer: P,
                              consumer: C)
                              -> C::Result

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -113,14 +113,6 @@ impl<'f, P, F> Producer for InspectProducer<'f, P, F>
         self.base.into_iter().inspect(self.inspect_op)
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (InspectProducer {

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -166,9 +166,16 @@ impl<R: Runtime> FixedLenScheduler<R> {
 }
 
 impl FixedLenScheduler<RayonRuntime> {
-    #[inline]
-    pub fn rayon(min_len: usize, max_len: usize) -> Self {
-        FixedLenScheduler { min_len, max_len, runtime: RayonRuntime }
+    pub fn with_min(min_len: usize) -> Self {
+        Self::new(min_len, usize::MAX, RayonRuntime)
+    }
+
+    pub fn with_max(max_len: usize) -> Self {
+        Self::new(1, max_len, RayonRuntime)
+    }
+
+    pub fn with_min_max(min_len: usize, max_len: usize) -> Self {
+        Self::new(min_len, max_len, RayonRuntime)
     }
 }
 
@@ -239,13 +246,6 @@ pub trait Producer: Send + Sized {
     type IntoIter: Iterator<Item = Self::Item> + DoubleEndedIterator + ExactSizeIterator;
 
     fn into_iter(self) -> Self::IntoIter;
-
-    fn min_len(&self) -> usize {
-        1
-    }
-    fn max_len(&self) -> usize {
-        usize::MAX
-    }
 
     /// Split into two producers; one produces items `0..index`, the
     /// other `index..N`. Index must be less than or equal to `N`.

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -88,13 +88,13 @@ impl Scheduler for DefaultScheduler {
 
 #[derive(Copy, Clone)]
 pub struct AdaptiveScheduler {
-    dummy: ()
+    _dummy: ()
 }
 
 impl AdaptiveScheduler {
     #[inline]
     pub fn new() -> Self {
-        AdaptiveScheduler { dummy: () }
+        AdaptiveScheduler { _dummy: () }
     }
 }
 

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -129,7 +129,7 @@ pub struct FixedLenScheduler {
 
 impl FixedLenScheduler {
     pub fn new(min_len: usize, max_len: usize) -> Self {
-        FixedLenScheduler { min_len, max_len }
+        FixedLenScheduler { min_len: min_len, max_len: max_len }
     }
 
     pub fn with_min(min_len: usize) -> Self {

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -129,7 +129,7 @@ pub struct FixedLenScheduler {
 
 impl FixedLenScheduler {
     pub fn new(min_len: usize, max_len: usize) -> Self {
-        Self::new(min_len, max_len)
+        FixedLenScheduler { min_len, max_len }
     }
 
     pub fn with_min(min_len: usize) -> Self {

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -102,14 +102,6 @@ impl<P> Producer for MinLenProducer<P>
         self.base.into_iter()
     }
 
-    fn min_len(&self) -> usize {
-        cmp::max(self.min, self.base.min_len())
-    }
-
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (MinLenProducer {
@@ -222,14 +214,6 @@ impl<P> Producer for MaxLenProducer<P>
 
     fn into_iter(self) -> Self::IntoIter {
         self.base.into_iter()
-    }
-
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-
-    fn max_len(&self) -> usize {
-        cmp::min(self.max, self.base.max_len())
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -1,6 +1,5 @@
 use super::internal::*;
 use super::*;
-use std::cmp;
 
 /// `MinLen` is an iterator that imposes a minimum length on iterator splits.
 /// This struct is created by the [`min_len()`] method on [`IndexedParallelIterator`]
@@ -10,18 +9,6 @@ use std::cmp;
 pub struct MinLen<I: IndexedParallelIterator> {
     base: I,
     min: usize,
-}
-
-/// Create a new `MinLen` iterator.
-///
-/// NB: a free fn because it is NOT part of the end-user API.
-pub fn new_min_len<I>(base: I, min: usize) -> MinLen<I>
-    where I: IndexedParallelIterator
-{
-    MinLen {
-        base: base,
-        min: min,
-    }
 }
 
 impl<I> ParallelIterator for MinLen<I>
@@ -124,18 +111,6 @@ impl<P> Producer for MinLenProducer<P>
 pub struct MaxLen<I: IndexedParallelIterator> {
     base: I,
     max: usize,
-}
-
-/// Create a new `MaxLen` iterator.
-///
-/// NB: a free fn because it is NOT part of the end-user API.
-pub fn new_max_len<I>(base: I, max: usize) -> MaxLen<I>
-    where I: IndexedParallelIterator
-{
-    MaxLen {
-        base: base,
-        max: max,
-    }
 }
 
 impl<I> ParallelIterator for MaxLen<I>

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -33,12 +33,13 @@ impl<I, F, R> ParallelIterator for Map<I, F>
           R: Send
 {
     type Item = F::Output;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = MapConsumer::new(consumer, &self.map_op);
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 
     fn opt_len(&mut self) -> Option<usize> {
@@ -51,24 +52,24 @@ impl<I, F, R> IndexedParallelIterator for Map<I, F>
           F: Fn(I::Item) -> R + Sync + Send,
           R: Send
 {
-    fn drive<C>(self, consumer: C) -> C::Result
-        where C: Consumer<Self::Item>
+    fn drive<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: Consumer<Self::Item>, S: Scheduler,
     {
         let consumer1 = MapConsumer::new(consumer, &self.map_op);
-        self.base.drive(consumer1)
+        self.base.drive(consumer1, scheduler)
     }
 
     fn len(&mut self) -> usize {
         self.base.len()
     }
 
-    fn with_producer<CB>(self, callback: CB) -> CB::Output
-        where CB: ProducerCallback<Self::Item>
+    fn with_producer<CB, S>(self, callback: CB, scheduler: S) -> CB::Output
+        where CB: ProducerCallback<Self::Item>, S: Scheduler,
     {
         return self.base.with_producer(Callback {
                                            callback: callback,
                                            map_op: self.map_op,
-                                       });
+                                       }, scheduler);
 
         struct Callback<CB, F> {
             callback: CB,
@@ -82,14 +83,14 @@ impl<I, F, R> IndexedParallelIterator for Map<I, F>
         {
             type Output = CB::Output;
 
-            fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = T>
+            fn callback<P, S>(self, base: P, scheduler: S) -> CB::Output
+                where P: Producer<Item = T>, S: Scheduler,
             {
                 let producer = MapProducer {
                     base: base,
                     map_op: &self.map_op,
                 };
-                self.callback.callback(producer)
+                self.callback.callback(producer, scheduler)
             }
         }
     }

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -115,13 +115,6 @@ impl<'f, P, F, R> Producer for MapProducer<'f, P, F>
         self.base.into_iter().map(self.map_op)
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (MapProducer {

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -127,13 +127,6 @@ impl<'f, P, U, F, R> Producer for MapWithProducer<'f, P, U, F>
         }
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (MapWithProducer {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1002,8 +1002,11 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// Sets the minimum length of iterators desired to process in each
     /// thread.  Rayon will not split any smaller than this length, but
     /// of course an iterator could already be smaller to begin with.
-    fn with_min_len(self, min: usize) -> MinLen<Self> {
-        len::new_min_len(self, min)
+    fn with_min_len(self, min: usize)
+                    -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+        where Self: ParallelIterator<Scheduler = DefaultScheduler>,
+    {
+        self.in_scheduler(FixedLenScheduler::with_min(min))
     }
 
     /// Sets the maximum length of iterators desired to process in each
@@ -1011,8 +1014,21 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// unless that would put it below the length from `with_min_len()`.
     /// For example, given min=10 and max=15, a length of 16 will not be
     /// split any further.
-    fn with_max_len(self, max: usize) -> MaxLen<Self> {
-        len::new_max_len(self, max)
+    fn with_max_len(self, max: usize)
+                    -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+        where Self: ParallelIterator<Scheduler = DefaultScheduler>,
+    {
+        self.in_scheduler(FixedLenScheduler::with_max(max))
+    }
+
+    /// Sets both the minimum and maximum length of iterators desired
+    /// to process in each thread. See `with_min_len()` and
+    /// `with_max_len()` for details.
+    fn with_min_max_len(self, min: usize, max: usize)
+                        -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+        where Self: ParallelIterator<Scheduler = DefaultScheduler>,
+    {
+        self.in_scheduler(FixedLenScheduler::with_min_max(min, max))
     }
 
     /// Produces an exact count of how many items this iterator will

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1003,7 +1003,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// thread.  Rayon will not split any smaller than this length, but
     /// of course an iterator could already be smaller to begin with.
     fn with_min_len(self, min: usize)
-                    -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+                    -> InScheduler<Self, internal::FixedLenScheduler>
         where Self: ParallelIterator<Scheduler = DefaultScheduler>,
     {
         self.in_scheduler(FixedLenScheduler::with_min(min))
@@ -1015,7 +1015,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// For example, given min=10 and max=15, a length of 16 will not be
     /// split any further.
     fn with_max_len(self, max: usize)
-                    -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+                    -> InScheduler<Self, internal::FixedLenScheduler>
         where Self: ParallelIterator<Scheduler = DefaultScheduler>,
     {
         self.in_scheduler(FixedLenScheduler::with_max(max))
@@ -1025,10 +1025,10 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// to process in each thread. See `with_min_len()` and
     /// `with_max_len()` for details.
     fn with_min_max_len(self, min: usize, max: usize)
-                        -> InScheduler<Self, internal::FixedLenScheduler<internal::RayonRuntime>>
+                        -> InScheduler<Self, internal::FixedLenScheduler>
         where Self: ParallelIterator<Scheduler = DefaultScheduler>,
     {
-        self.in_scheduler(FixedLenScheduler::with_min_max(min, max))
+        self.in_scheduler(FixedLenScheduler::new(min, max))
     }
 
     /// Produces an exact count of how many items this iterator will

--- a/src/iter/product.rs
+++ b/src/iter/product.rs
@@ -9,7 +9,7 @@ pub fn product<PI, P>(pi: PI) -> P
     where PI: ParallelIterator,
           P: Send + Product<PI::Item> + Product
 {
-    pi.drive_unindexed(ProductConsumer::new())
+    pi.drive_unindexed(ProductConsumer::new(), DefaultScheduler)
 }
 
 fn mul<T: Product>(left: T, right: T) -> T {

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -11,7 +11,7 @@ pub fn reduce<PI, R, ID, T>(pi: PI, identity: ID, reduce_op: R) -> T
         identity: &identity,
         reduce_op: &reduce_op,
     };
-    pi.drive_unindexed(consumer)
+    pi.drive_unindexed(consumer, DefaultScheduler)
 }
 
 struct ReduceConsumer<'r, R: 'r, ID: 'r> {

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -19,11 +19,12 @@ impl<I> ParallelIterator for Rev<I>
     where I: IndexedParallelIterator
 {
     type Item = I::Item;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
-        bridge(self, consumer)
+        scheduler.execute(self, consumer)
     }
 
     fn opt_len(&mut self) -> Option<usize> {
@@ -34,22 +35,24 @@ impl<I> ParallelIterator for Rev<I>
 impl<I> IndexedParallelIterator for Rev<I>
     where I: IndexedParallelIterator
 {
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        bridge(self, consumer)
+    fn drive<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: Consumer<Self::Item>, S: Scheduler
+    {
+        scheduler.execute(self, consumer)
     }
 
     fn len(&mut self) -> usize {
         self.base.len()
     }
 
-    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
-        where CB: ProducerCallback<Self::Item>
+    fn with_producer<CB, S>(mut self, callback: CB, scheduler: S) -> CB::Output
+        where CB: ProducerCallback<Self::Item>, S: Scheduler,
     {
         let len = self.base.len();
         return self.base.with_producer(Callback {
                                            callback: callback,
                                            len: len,
-                                       });
+                                       }, scheduler);
 
         struct Callback<CB> {
             callback: CB,
@@ -60,14 +63,14 @@ impl<I> IndexedParallelIterator for Rev<I>
             where CB: ProducerCallback<T>
         {
             type Output = CB::Output;
-            fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = T>
+            fn callback<P, S>(self, base: P, scheduler: S) -> CB::Output
+                where P: Producer<Item = T>, S: Scheduler,
             {
                 let producer = RevProducer {
                     base: base,
                     len: self.len,
                 };
-                self.callback.callback(producer)
+                self.callback.callback(producer, scheduler)
             }
         }
     }

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -91,13 +91,6 @@ impl<P> Producer for RevProducer<P>
         self.base.into_iter().rev()
     }
 
-    fn min_len(&self) -> usize {
-        self.base.min_len()
-    }
-    fn max_len(&self) -> usize {
-        self.base.max_len()
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(self.len - index);
         (RevProducer {

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -27,15 +27,16 @@ impl<D, S> ParallelIterator for Split<D, S>
           S: Fn(D) -> (D, Option<D>) + Sync + Send
 {
     type Item = D;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, SC>(self, consumer: C, scheduler: SC) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, SC: Scheduler,
     {
         let producer = SplitProducer {
             data: self.data,
             splitter: &self.splitter,
         };
-        bridge_unindexed(producer, consumer)
+        scheduler.execute_unindexed(producer, consumer)
     }
 }
 

--- a/src/iter/sum.rs
+++ b/src/iter/sum.rs
@@ -9,7 +9,7 @@ pub fn sum<PI, S>(pi: PI) -> S
     where PI: ParallelIterator,
           S: Send + Sum<PI::Item> + Sum
 {
-    pi.drive_unindexed(SumConsumer::new())
+    pi.drive_unindexed(SumConsumer::new(), DefaultScheduler)
 }
 
 fn add<T: Sum>(left: T, right: T) -> T {

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1451,8 +1451,7 @@ fn check_lengths() {
         let max_check = cmp::max(max, min_check.saturating_add(min_check - 1));
 
         assert!(range.into_par_iter()
-                    .with_min_len(min)
-                    .with_max_len(max)
+                    .with_min_max_len(min, max)
                     .fold(|| 0, |count, _| count + 1)
                     .all(|c| c >= min_check && c <= max_check),
                 "check_lengths failed {:?} -> {:?} ",

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -216,7 +216,7 @@ pub fn check_indices_after_enumerate_split() {
     struct WithProducer;
     impl<'a> ProducerCallback<(usize, &'a i32)> for WithProducer {
         type Output = ();
-        fn callback<P, S>(self, producer: P, scheduler: S)
+        fn callback<P, S>(self, producer: P, _scheduler: S)
             where P: Producer<Item = (usize, &'a i32)>, S: Scheduler,
         {
             let (a, b) = producer.split_at(512);
@@ -342,7 +342,7 @@ pub fn check_drops() {
     struct Partial;
     impl<'a> ProducerCallback<DropCounter<'a>> for Partial {
         type Output = ();
-        fn callback<P, S>(self, producer: P, scheduler: S)
+        fn callback<P, S>(self, producer: P, _scheduler: S)
             where P: Producer<Item = DropCounter<'a>>, S: Scheduler,
         {
             let (a, _) = producer.split_at(5);

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -27,16 +27,17 @@ impl<I, T> ParallelIterator for WhileSome<I>
           T: Send
 {
     type Item = T;
+    type Scheduler = I::Scheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let full = AtomicBool::new(false);
         let consumer1 = WhileSomeConsumer {
             base: consumer,
             full: &full,
         };
-        self.base.drive_unindexed(consumer1)
+        self.base.drive_unindexed(consumer1, scheduler)
     }
 }
 

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -118,14 +118,6 @@ impl<A: Producer, B: Producer> Producer for ZipProducer<A, B> {
         self.a.into_iter().zip(self.b.into_iter())
     }
 
-    fn min_len(&self) -> usize {
-        cmp::max(self.a.min_len(), self.b.min_len())
-    }
-
-    fn max_len(&self) -> usize {
-        cmp::min(self.a.max_len(), self.b.max_len())
-    }
-
     fn split_at(self, index: usize) -> (Self, Self) {
         let (a_left, a_right) = self.a.split_at(index);
         let (b_left, b_right) = self.b.split_at(index);

--- a/src/result.rs
+++ b/src/result.rs
@@ -11,6 +11,7 @@ use option;
 impl<T: Send, E> IntoParallelIterator for Result<T, E> {
     type Item = T;
     type Iter = IntoIter<T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         IntoIter { inner: self.ok().into_par_iter() }
@@ -20,6 +21,7 @@ impl<T: Send, E> IntoParallelIterator for Result<T, E> {
 impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {
     type Item = &'a T;
     type Iter = Iter<'a, T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         Iter { inner: self.as_ref().ok().into_par_iter() }
@@ -29,6 +31,7 @@ impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {
 impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
     type Item = &'a mut T;
     type Iter = IterMut<'a, T>;
+    type Scheduler = DefaultScheduler;
 
     fn into_par_iter(self) -> Self::Iter {
         IterMut { inner: self.as_mut().ok().into_par_iter() }

--- a/src/str.rs
+++ b/src/str.rs
@@ -193,11 +193,12 @@ struct CharsProducer<'ch> {
 
 impl<'ch> ParallelIterator for Chars<'ch> {
     type Item = char;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
-        bridge_unindexed(CharsProducer { chars: self.chars }, consumer)
+        scheduler.execute_unindexed(CharsProducer { chars: self.chars }, consumer)
     }
 }
 
@@ -242,12 +243,13 @@ impl<'ch, P: Pattern> Split<'ch, P> {
 
 impl<'ch, P: Pattern> ParallelIterator for Split<'ch, P> {
     type Item = &'ch str;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let producer = SplitProducer::new(self.chars, &self.separator);
-        bridge_unindexed(producer, consumer)
+        scheduler.execute_unindexed(producer, consumer)
     }
 }
 
@@ -318,12 +320,13 @@ impl<'ch, 'sep, P: Pattern + 'sep> SplitTerminatorProducer<'ch, 'sep, P> {
 
 impl<'ch, P: Pattern> ParallelIterator for SplitTerminator<'ch, P> {
     type Item = &'ch str;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         let producer = SplitTerminatorProducer::new(self.chars, &self.terminator);
-        bridge_unindexed(producer, consumer)
+        scheduler.execute_unindexed(producer, consumer)
     }
 }
 
@@ -359,9 +362,10 @@ pub struct Lines<'ch>(&'ch str);
 
 impl<'ch> ParallelIterator for Lines<'ch> {
     type Item = &'ch str;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         self.0
             .par_split_terminator('\n')
@@ -370,7 +374,7 @@ impl<'ch> ParallelIterator for Lines<'ch> {
                  } else {
                      line
                  })
-            .drive_unindexed(consumer)
+            .drive_unindexed(consumer, scheduler)
     }
 }
 
@@ -382,13 +386,14 @@ pub struct SplitWhitespace<'ch>(&'ch str);
 
 impl<'ch> ParallelIterator for SplitWhitespace<'ch> {
     type Item = &'ch str;
+    type Scheduler = DefaultScheduler;
 
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-        where C: UnindexedConsumer<Self::Item>
+    fn drive_unindexed<C, S>(self, consumer: C, scheduler: S) -> C::Result
+        where C: UnindexedConsumer<Self::Item>, S: Scheduler,
     {
         self.0
             .par_split(char::is_whitespace)
             .filter(|string| !string.is_empty())
-            .drive_unindexed(consumer)
+            .drive_unindexed(consumer, scheduler)
     }
 }

--- a/tests/compile-fail/in_scheduler_abuse.rs
+++ b/tests/compile-fail/in_scheduler_abuse.rs
@@ -1,0 +1,81 @@
+extern crate rayon;
+
+use rayon::prelude::*;
+use rayon::iter::internal::*;
+
+struct DummyScheduler;
+
+impl<'a> Scheduler for &'a DummyScheduler {
+    fn execute_indexed<P, C>(self,
+                             len: usize,
+                             producer: P,
+                             consumer: C)
+                             -> C::Result
+        where P: Producer,
+              C: Consumer<P::Item>
+    {
+        DefaultScheduler.execute_indexed(len, producer, consumer)
+    }
+
+    fn execute_unindexed<P, C>(self,
+                               producer: P,
+                               consumer: C)
+                               -> C::Result
+        where P: UnindexedProducer,
+              C: UnindexedConsumer<P::Item>
+    {
+        DefaultScheduler.execute_unindexed(producer, consumer)
+    }
+}
+
+fn zip_lhs() {
+    (0..512).into_par_iter()
+            .in_scheduler(&DummyScheduler)
+            .zip(0..512) //~ ERROR E0271
+            .for_each(|_| ());
+}
+
+fn zip_rhs() {
+    (0..512).into_par_iter()
+            .in_scheduler(&DummyScheduler)
+            .zip((0..512).into_par_iter().in_scheduler(&DummyScheduler)) //~ ERROR E0271
+    //~^ ERROR E0271
+            .for_each(|_| ());
+}
+
+fn chain_lhs() {
+    (0..512).into_par_iter()
+            .in_scheduler(&DummyScheduler)
+            .chain(0..512); //~ ERROR E0271
+}
+
+fn chain_rhs() {
+    (0..512).into_par_iter()
+            .in_scheduler(&DummyScheduler)
+            .chain((0..512).into_par_iter().in_scheduler(&DummyScheduler)); //~ ERROR E0271
+    //~^ ERROR E0271
+    //~| ERROR type mismatch
+}
+
+fn dummy_and_dummy() {
+    (0..512).into_par_iter()
+            .map(|i| i * 2)
+            .in_scheduler(&DummyScheduler)
+            .in_scheduler(&DummyScheduler); //~ ERROR type mismatch
+}
+
+fn default_and_dummy() {
+    (0..512).into_par_iter()
+            .map(|i| i * 2)
+            .in_scheduler(DefaultScheduler)
+            .in_scheduler(&DummyScheduler); //~ ERROR type mismatch
+}
+
+fn default_twice() {
+    (0..512).into_par_iter()
+            .map(|i| i * 2)
+            .in_scheduler(DefaultScheduler)
+            .in_scheduler(DefaultScheduler); //~ ERROR type mismatch
+}
+
+fn main() { }


### PR DESCRIPTION
This PR introduces the notion of "custom schedulers". The idea is that you can invoke, for any parallel iterator `iter`, `iter.in_scheduler(S)`, and it will run with the **scheduler** `S`. The scheduler basically takes the place of the (currently hard-coded) "bridge" functions -- it connects a parallel producer and a parallel consumer.

We introduce a `Scheduler` associated type into the `ParallelIterator` trait. This is used to ensure that the user cannot invoke `in_scheduler()` twice on any given parallel iterator. For implicity, we also forbid customized schedulers from the "inputs" where mutiple parallel iterators are "joined" (like `zip()` or `chain()`). Hence `a.in_scheduler().zip(b)` is illegal, but `a.zip(b).in_scheduler()` is fine. We could alter these rules to permit both (but we want to avoid `a.in_scheduler().zip(b.in_scheduler())`).

In this PR, Rayon exposes three schedulers: 

- `DefaultScheduler` -- what you get if you don't say anything; also encodes the fact that `in_scheduler` has never been called. Currently, this delegates to `AdaptiveScheduler`.
- `AdaptiveScheduler` -- the default strategy of "split to depth N, and more if stolen"
- `FixedLenScheduler` -- like above, but where we adjust N to try and respect the user's min/max requests

Originally, the idea here was to allow you to swap out the Rayon runtime completely. In fact, you can still see this in the `Runtime` trait introduced by the first commit, though I've removed it by the end -- basically because I don't feel we're ready to commit to this trait yet (and in principle no flexibility is lost). I imagine we'll probably add this back at some point in some form.

Some unknowns:

- [ ] Module structure. I feel like we should move most of these things to `iter::scheduler`.
- [ ] What should be done with the `Scheduler` associated type in `ParallelIterator`?
    - It's kind of weird right now. It *sounds* like it specifies the scheduler, but really it's always one of two values: `DefaultScheduler` or `CustomScheduler`. This is just used to prevent multiple `in_scheduler()` calls. I think I'd rather just give a semantics to multiple calls in some useful way. This interacts with the next question.
- [ ] Can we support "layering" schedulers?
    - Right now, we prohibit multiple calls to `in_scheduler`, but I was thinking that it'd also be possible to permit "combining" schedulers (e.g., `with_min` and `with_max`). I have to play around with this a bit more.
- [ ] What to do with `chain()` and other ad-hoc calls to `join()`?
    - @cuviper recently modified the `drive()` impl of `chain()` so that it will drive in parallel, using `join()`. This kind of goes against the grain of this PR, so we probably want to either extend the scheduler interface with a `join` method *or* reframe that as a parallel producer consumer, or something like that.

cc #93 -- this permits a user-provided "backend", though I think ultimately more flexibility might be desired. (This only works for parallel iterators, for one thing.)