### PR TITLE
Introduce `join_context` which tells whether jobs were stolen

### DIFF
--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -54,7 +54,21 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
           RA: Send,
           RB: Send
 {
-    registry::in_worker(|worker_thread| unsafe {
+    join_notify(|_| oper_a(), |_| oper_b())
+}
+
+/// The `join_notify` function is identical to `join`, except the closures
+/// have a parameter that indicates whether they're executing on a different
+/// thread than where `join_notify` was called.  This will occur if the second
+/// job is stolen by a different thread, or if `join_notify` was called from
+/// outside the thread pool to begin with.
+pub fn join_notify<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+    where A: FnOnce(bool) -> RA + Send,
+          B: FnOnce(bool) -> RB + Send,
+          RA: Send,
+          RB: Send
+{
+    registry::in_worker(|worker_thread, injected| unsafe {
         log!(Join { worker: worker_thread.index() });
 
         // Create virtual wrapper for task b; this all has to be
@@ -65,7 +79,7 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
         worker_thread.push(job_b_ref);
 
         // Execute task a; hopefully b gets stolen in the meantime.
-        let result_a = match unwind::halt_unwinding(oper_a) {
+        let result_a = match unwind::halt_unwinding(move || oper_a(injected)) {
             Ok(v) => v,
             Err(err) => join_recover_from_panic(worker_thread, &job_b.latch, err),
         };
@@ -82,7 +96,7 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
                     //
                     // Note that this could panic, but it's ok if we unwind here.
                     log!(PoppedRhs { worker: worker_thread.index() });
-                    let result_b = job_b.run_inline();
+                    let result_b = job_b.run_inline(injected);
                     return (result_a, result_b);
                 } else {
                     log!(PoppedJob { worker: worker_thread.index() });

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -6,6 +6,8 @@ use registry::{self, WorkerThread};
 use std::any::Any;
 use unwind;
 
+use FnContext;
+
 #[cfg(test)]
 mod test;
 
@@ -54,17 +56,18 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
           RA: Send,
           RB: Send
 {
-    join_notify(|_| oper_a(), |_| oper_b())
+    join_context(|_| oper_a(), |_| oper_b())
 }
 
-/// The `join_notify` function is identical to `join`, except the closures
-/// have a parameter that indicates whether they're executing on a different
-/// thread than where `join_notify` was called.  This will occur if the second
-/// job is stolen by a different thread, or if `join_notify` was called from
+/// The `join_context` function is identical to `join`, except the closures
+/// have a parameter that provides context for the way the closure has been
+/// called, especially indicating whether they're executing on a different
+/// thread than where `join_context` was called.  This will occur if the second
+/// job is stolen by a different thread, or if `join_context` was called from
 /// outside the thread pool to begin with.
-pub fn join_notify<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
-    where A: FnOnce(bool) -> RA + Send,
-          B: FnOnce(bool) -> RB + Send,
+pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+    where A: FnOnce(FnContext) -> RA + Send,
+          B: FnOnce(FnContext) -> RB + Send,
           RA: Send,
           RB: Send
 {
@@ -74,12 +77,14 @@ pub fn join_notify<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(oper_b, SpinLatch::new());
+        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)),
+                                  SpinLatch::new());
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 
         // Execute task a; hopefully b gets stolen in the meantime.
-        let result_a = match unwind::halt_unwinding(move || oper_a(injected)) {
+        let status_a = unwind::halt_unwinding(move || oper_a(FnContext::new(injected)));
+        let result_a = match status_a {
             Ok(v) => v,
             Err(err) => join_recover_from_panic(worker_thread, &job_b.latch, err),
         };

--- a/rayon-core/src/join/test.rs
+++ b/rayon-core/src/join/test.rs
@@ -77,3 +77,33 @@ fn panic_b_still_executes() {
         Err(_) => assert!(x, "closure b failed to execute"),
     }
 }
+
+#[test]
+fn join_notify_both() {
+    // If we're not in a pool, both should be marked stolen as they're injected.
+    let (a, b) = join_notify(|a| a, |b| b);
+    assert!(a);
+    assert!(b);
+}
+
+#[test]
+fn join_notify_neither() {
+    // If we're already in a 1-thread pool, neither job should be stolen.
+    let pool = ThreadPool::new(Configuration::new().num_threads(1)).unwrap();
+    let (a, b) = pool.install(|| join_notify(|a| a, |b| b));
+    assert!(!a);
+    assert!(!b);
+}
+
+#[test]
+fn join_notify_second() {
+    use std::sync::Barrier;
+
+    // If we're already in a 2-thread pool, the second job should be stolen.
+    let barrier = Barrier::new(2);
+    let pool = ThreadPool::new(Configuration::new().num_threads(2)).unwrap();
+    let (a, b) = pool.install(|| join_notify(|a| { barrier.wait(); a },
+                                             |b| { barrier.wait(); b }));
+    assert!(!a);
+    assert!(b);
+}

--- a/rayon-core/src/join/test.rs
+++ b/rayon-core/src/join/test.rs
@@ -79,31 +79,31 @@ fn panic_b_still_executes() {
 }
 
 #[test]
-fn join_notify_both() {
+fn join_context_both() {
     // If we're not in a pool, both should be marked stolen as they're injected.
-    let (a, b) = join_notify(|a| a, |b| b);
+    let (a, b) = join_context(|a| a, |b| b);
     assert!(a);
     assert!(b);
 }
 
 #[test]
-fn join_notify_neither() {
+fn join_context_neither() {
     // If we're already in a 1-thread pool, neither job should be stolen.
     let pool = ThreadPool::new(Configuration::new().num_threads(1)).unwrap();
-    let (a, b) = pool.install(|| join_notify(|a| a, |b| b));
+    let (a, b) = pool.install(|| join_context(|a| a, |b| b));
     assert!(!a);
     assert!(!b);
 }
 
 #[test]
-fn join_notify_second() {
+fn join_context_second() {
     use std::sync::Barrier;
 
     // If we're already in a 2-thread pool, the second job should be stolen.
     let barrier = Barrier::new(2);
     let pool = ThreadPool::new(Configuration::new().num_threads(2)).unwrap();
-    let (a, b) = pool.install(|| join_notify(|a| { barrier.wait(); a },
-                                             |b| { barrier.wait(); b }));
+    let (a, b) = pool.install(|| join_context(|a| { barrier.wait(); a },
+                                              |b| { barrier.wait(); b }));
     assert!(!a);
     assert!(b);
 }

--- a/rayon-core/src/join/test.rs
+++ b/rayon-core/src/join/test.rs
@@ -82,8 +82,8 @@ fn panic_b_still_executes() {
 fn join_context_both() {
     // If we're not in a pool, both should be marked stolen as they're injected.
     let (a, b) = join_context(|a| a, |b| b);
-    assert!(a);
-    assert!(b);
+    assert!(a.migrated());
+    assert!(b.migrated());
 }
 
 #[test]
@@ -91,8 +91,8 @@ fn join_context_neither() {
     // If we're already in a 1-thread pool, neither job should be stolen.
     let pool = ThreadPool::new(Configuration::new().num_threads(1)).unwrap();
     let (a, b) = pool.install(|| join_context(|a| a, |b| b));
-    assert!(!a);
-    assert!(!b);
+    assert!(!a.migrated());
+    assert!(!b.migrated());
 }
 
 #[test]
@@ -104,6 +104,6 @@ fn join_context_second() {
     let pool = ThreadPool::new(Configuration::new().num_threads(2)).unwrap();
     let (a, b) = pool.install(|| join_context(|a| { barrier.wait(); a },
                                               |b| { barrier.wait(); b }));
-    assert!(!a);
-    assert!(b);
+    assert!(!a.migrated());
+    assert!(b.migrated());
 }

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -377,22 +377,12 @@ pub struct FnContext {
     _marker: PhantomData<*mut ()>,
 }
 
-impl Default for FnContext {
-    #[inline]
-    fn default() -> Self {
-        FnContext {
-            migrated: false,
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl FnContext {
     #[inline]
     fn new(migrated: bool) -> Self {
         FnContext {
             migrated: migrated,
-            ..FnContext::default()
+            _marker: PhantomData,
         }
     }
 }

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -64,7 +64,7 @@ pub mod internal;
 pub use thread_pool::ThreadPool;
 pub use thread_pool::current_thread_index;
 pub use thread_pool::current_thread_has_pending_tasks;
-pub use join::{join, join_notify};
+pub use join::{join, join_context};
 pub use scope::{scope, Scope};
 pub use spawn::spawn;
 
@@ -364,5 +364,36 @@ impl fmt::Debug for Configuration {
          .field("exit_handler", &exit_handler)
          .field("breadth_first", &breadth_first)
          .finish()
+    }
+}
+
+/// Provides the calling context to a closure called by `join_context`.
+#[derive(Debug)]
+pub struct FnContext {
+    migrated: bool
+}
+
+impl Default for FnContext {
+    #[inline]
+    fn default() -> Self {
+        FnContext {
+            migrated: false
+        }
+    }
+}
+
+impl FnContext {
+    #[inline]
+    fn new(migrated: bool) -> Self {
+        FnContext { migrated: migrated }
+    }
+}
+
+impl FnContext {
+    /// Returns `true` if the closure was called from a different thread
+    /// than it was provided from.
+    #[inline]
+    pub fn migrated(&self) -> bool {
+        self.migrated
     }
 }

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -34,6 +34,7 @@ use log::Event::*;
 use std::any::Any;
 use std::env;
 use std::error::Error;
+use std::marker::PhantomData;
 use std::str::FromStr;
 use std::fmt;
 
@@ -370,14 +371,18 @@ impl fmt::Debug for Configuration {
 /// Provides the calling context to a closure called by `join_context`.
 #[derive(Debug)]
 pub struct FnContext {
-    migrated: bool
+    migrated: bool,
+
+    /// disable `Send` and `Sync`, just for a little future-proofing.
+    _marker: PhantomData<*mut ()>,
 }
 
 impl Default for FnContext {
     #[inline]
     fn default() -> Self {
         FnContext {
-            migrated: false
+            migrated: false,
+            _marker: PhantomData,
         }
     }
 }
@@ -385,7 +390,10 @@ impl Default for FnContext {
 impl FnContext {
     #[inline]
     fn new(migrated: bool) -> Self {
-        FnContext { migrated: migrated }
+        FnContext {
+            migrated: migrated,
+            ..FnContext::default()
+        }
     }
 }
 

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -64,7 +64,7 @@ pub mod internal;
 pub use thread_pool::ThreadPool;
 pub use thread_pool::current_thread_index;
 pub use thread_pool::current_thread_has_pending_tasks;
-pub use join::join;
+pub use join::{join, join_notify};
 pub use scope::{scope, Scope};
 pub use spawn::spawn;
 

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -253,7 +253,7 @@ pub struct Scope<'scope> {
 pub fn scope<'scope, OP, R>(op: OP) -> R
     where OP: for<'s> FnOnce(&'s Scope<'scope>) -> R + 'scope + Send, R: Send,
 {
-    in_worker(|owner_thread| {
+    in_worker(|owner_thread, _| {
         unsafe {
             let scope: Scope<'scope> = Scope {
                 owner_thread_index: owner_thread.index(),

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -110,7 +110,7 @@ impl ThreadPool {
         where OP: FnOnce() -> R + Send,
               R: Send
     {
-        self.registry.in_worker(|_| op())
+        self.registry.in_worker(|_, _| op())
     }
 
     /// Returns the (current) number of threads in the thread pool.

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -3,7 +3,7 @@
 //! parallel iterators should not need to interact with them directly.
 //! See `README.md` for a high-level overview.
 
-use rayon_core::join;
+use rayon_core::join_notify;
 use super::IndexedParallelIterator;
 
 use std::cmp;
@@ -132,10 +132,6 @@ pub trait UnindexedProducer: Send + Sized {
 /// job is actually stolen into a different thread.
 #[derive(Clone, Copy)]
 struct Splitter {
-    /// The `origin` tracks the ID of the thread that started this job,
-    /// so we can tell when we've been stolen to a new thread.
-    origin: usize,
-
     /// The `splits` tell us approximately how many remaining times we'd
     /// like to split this job.  We always just divide it by two though, so
     /// the effective number of pieces will be `next_power_of_two()`.
@@ -144,31 +140,19 @@ struct Splitter {
 
 impl Splitter {
     #[inline]
-    fn thief_id() -> usize {
-        // The actual `ID` value is irrelevant.  We're just using its TLS
-        // address as a unique thread key, faster than a real thread-id call.
-        thread_local!{ static ID: bool = false }
-        ID.with(|id| id as *const bool as usize)
-    }
-
-    #[inline]
     fn new() -> Splitter {
         Splitter {
-            origin: Splitter::thief_id(),
             splits: ::current_num_threads(),
         }
     }
 
     #[inline]
-    fn try(&mut self) -> bool {
-        let Splitter { origin, splits } = *self;
+    fn try(&mut self, stolen: bool) -> bool {
+        let Splitter { splits } = *self;
 
-        let id = Splitter::thief_id();
-        if origin != id {
-            // This job was stolen!  Set a new origin and reset the number
-            // of desired splits to the thread count, if that's more than
-            // we had remaining anyway.
-            self.origin = id;
+        if stolen {
+            // This job was stolen!  Reset the number of desired splits to the
+            // thread count, if that's more than we had remaining anyway.
             self.splits = cmp::max(::current_num_threads(), self.splits / 2);
             true
         } else if splits > 0 {
@@ -225,9 +209,9 @@ impl LengthSplitter {
     }
 
     #[inline]
-    fn try(&mut self, len: usize) -> bool {
+    fn try(&mut self, len: usize, stolen: bool) -> bool {
         // If splitting wouldn't make us too small, try the inner splitter.
-        len / 2 >= self.min && self.inner.try()
+        len / 2 >= self.min && self.inner.try(stolen)
     }
 }
 
@@ -263,21 +247,28 @@ pub fn bridge_producer_consumer<P, C>(len: usize, producer: P, consumer: C) -> C
           C: Consumer<P::Item>
 {
     let splitter = LengthSplitter::new(producer.min_len(), producer.max_len(), len);
-    return helper(len, splitter, producer, consumer);
+    return helper(len, false, splitter, producer, consumer);
 
-    fn helper<P, C>(len: usize, mut splitter: LengthSplitter, producer: P, consumer: C) -> C::Result
+    fn helper<P, C>(len: usize,
+                    stolen: bool,
+                    mut splitter: LengthSplitter,
+                    producer: P,
+                    consumer: C)
+                    -> C::Result
         where P: Producer,
               C: Consumer<P::Item>
     {
         if consumer.full() {
             consumer.into_folder().complete()
-        } else if splitter.try(len) {
+        } else if splitter.try(len, stolen) {
             let mid = len / 2;
             let (left_producer, right_producer) = producer.split_at(mid);
             let (left_consumer, right_consumer, reducer) = consumer.split_at(mid);
             let (left_result, right_result) =
-                join(|| helper(mid, splitter, left_producer, left_consumer),
-                     || helper(len - mid, splitter, right_producer, right_consumer));
+                join_notify(|stolen| helper(mid, stolen, splitter, left_producer, left_consumer),
+                            |stolen| {
+                                helper(len - mid, stolen, splitter, right_producer, right_consumer)
+                            });
             reducer.reduce(left_result, right_result)
         } else {
             producer.fold_with(consumer.into_folder()).complete()
@@ -290,10 +281,11 @@ pub fn bridge_unindexed<P, C>(producer: P, consumer: C) -> C::Result
           C: UnindexedConsumer<P::Item>
 {
     let splitter = Splitter::new();
-    bridge_unindexed_producer_consumer(splitter, producer, consumer)
+    bridge_unindexed_producer_consumer(false, splitter, producer, consumer)
 }
 
-fn bridge_unindexed_producer_consumer<P, C>(mut splitter: Splitter,
+fn bridge_unindexed_producer_consumer<P, C>(stolen: bool,
+                                            mut splitter: Splitter,
                                             producer: P,
                                             consumer: C)
                                             -> C::Result
@@ -302,15 +294,15 @@ fn bridge_unindexed_producer_consumer<P, C>(mut splitter: Splitter,
 {
     if consumer.full() {
         consumer.into_folder().complete()
-    } else if splitter.try() {
+    } else if splitter.try(stolen) {
         match producer.split() {
             (left_producer, Some(right_producer)) => {
                 let (reducer, left_consumer, right_consumer) =
                     (consumer.to_reducer(), consumer.split_off_left(), consumer);
                 let bridge = bridge_unindexed_producer_consumer;
                 let (left_result, right_result) =
-                    join(|| bridge(splitter, left_producer, left_consumer),
-                         || bridge(splitter, right_producer, right_consumer));
+                    join_notify(|stolen| bridge(stolen, splitter, left_producer, left_consumer),
+                                |stolen| bridge(stolen, splitter, right_producer, right_consumer));
                 reducer.reduce(left_result, right_result)
             }
             (producer, None) => producer.fold_with(consumer.into_folder()).complete(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ pub use rayon_core::current_num_threads;
 pub use rayon_core::Configuration;
 pub use rayon_core::initialize;
 pub use rayon_core::ThreadPool;
-pub use rayon_core::join;
+pub use rayon_core::{join, join_context};
+pub use rayon_core::FnContext;
 pub use rayon_core::{scope, Scope};
 pub use rayon_core::spawn;


### PR DESCRIPTION
This removes the need for tracking thread-id or hacky TLS variables in
the adaptive splitter.  Instead, with `join_context` the parallel
iterator internals are directly informed whether a job is executing on
its original thread or stolen elsewhere.

Note that this is insta-stable since we want to use it ourselves.  We
could hide docs and/or mark it deprecated to approach stability a little
differently than the usual "unstable" feature.