### PR TITLE
Add Repeat and RepeatN

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -81,6 +81,8 @@ mod while_some;
 pub use self::while_some::WhileSome;
 mod extend;
 mod unzip;
+mod repeat;
+pub use self::repeat::{Repeat, repeat};
 
 #[cfg(test)]
 mod test;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -83,6 +83,7 @@ mod extend;
 mod unzip;
 mod repeat;
 pub use self::repeat::{Repeat, repeat};
+pub use self::repeat::{RepeatN, repeatn};
 
 #[cfg(test)]
 mod test;

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -1,11 +1,6 @@
-use super::internal::*;
 use super::*;
-use iter::*;
-use iter::internal::*;
-use std;
-use std::iter;
+use super::internal::*;
 use std::usize;
-
 
 pub struct Repeat<T> {
     element: T,

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -1,0 +1,113 @@
+use super::internal::*;
+use super::*;
+use iter::*;
+use iter::internal::*;
+use std;
+use std::iter;
+use std::usize;
+
+
+pub struct Repeat<T> {
+    element: T,
+}
+
+pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
+    Repeat{element: elt}
+}
+
+impl<T: Clone> Clone for Repeat<T>{
+    fn clone(&self) -> Repeat<T> {
+        Repeat{ element: self.element.clone()}
+    }
+}
+
+impl<T> ParallelIterator for Repeat<T>
+    where T: Clone + Send
+{
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+       where C: UnindexedConsumer<Self::Item>
+   {
+       bridge(self, consumer)
+   }
+}
+
+impl<T> IndexedParallelIterator for Repeat<T>
+    where T: Clone + Send
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+            bridge(self, consumer)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB :: Output
+        where CB: ProducerCallback<Self::Item>
+        {
+            callback.callback(RepeatProducer{ repeat: self})
+        }
+
+    fn len(&mut self) -> usize { usize::MAX }
+}
+
+
+/// Producer
+
+struct RepeatProducer<P> {
+    repeat: Repeat<P>,
+}
+
+impl<T: Clone + Send> Producer for RepeatProducer<T> {
+    type Item = T;
+    type IntoIter = RepeatIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter{
+        RepeatIter{repeat: self.repeat}
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        (
+            RepeatProducer{repeat: self.repeat.clone()},
+            RepeatProducer{repeat: self.repeat.clone()}
+        )
+    }
+}
+
+impl<T: Clone + Send> UnindexedProducer for Repeat<T> {
+    type Item = T;
+
+    fn split(self) -> (Self, Option<Self>) {
+        (Repeat{element: self.element.clone()}, Some(Repeat{element: self.element.clone()}))
+    }
+
+    fn fold_with<F>(self, folder: F) -> F where F: Folder<T> {
+        folder.consume_iter(RepeatIter{repeat: Repeat{element: self.element}})
+    }
+}
+
+/// Repeat Iter Create As Repeat Does Not Have ExactSizeIterator
+
+struct RepeatIter<T> {
+    repeat: Repeat<T>,
+}
+
+impl<T: Clone> Iterator for RepeatIter<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> { Some(self.repeat.element.clone()) }
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+}
+
+impl<A: Clone> DoubleEndedIterator for RepeatIter<A> {
+    #[inline]
+    fn next_back(&mut self) -> Option<A> { Some(self.repeat.element.clone()) }
+}
+
+impl<T: Clone> ExactSizeIterator for RepeatIter<T> {
+    fn len(&self) -> usize {
+        usize::MAX
+    }
+}

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -7,12 +7,12 @@ pub struct Repeat<T> {
 }
 
 pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
-    Repeat{element: elt}
+    Repeat { element: elt }
 }
 
-impl<T: Clone> Clone for Repeat<T>{
+impl<T: Clone> Clone for Repeat<T> {
     fn clone(&self) -> Repeat<T> {
-        Repeat{ element: self.element.clone()}
+        Repeat { element: self.element.clone() }
     }
 }
 
@@ -22,10 +22,10 @@ impl<T> ParallelIterator for Repeat<T>
     type Item = T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
-       where C: UnindexedConsumer<Self::Item>
-   {
-       bridge(self, consumer)
-   }
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
 }
 
 impl<T> IndexedParallelIterator for Repeat<T>
@@ -34,16 +34,18 @@ impl<T> IndexedParallelIterator for Repeat<T>
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
-            bridge(self, consumer)
+        bridge(self, consumer)
     }
 
-    fn with_producer<CB>(self, callback: CB) -> CB :: Output
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
-        {
-            callback.callback(RepeatProducer{ repeat: self})
-        }
+    {
+        callback.callback(RepeatProducer { repeat: self })
+    }
 
-    fn len(&mut self) -> usize { usize::MAX }
+    fn len(&mut self) -> usize {
+        usize::MAX
+    }
 }
 
 
@@ -57,15 +59,13 @@ impl<T: Clone + Send> Producer for RepeatProducer<T> {
     type Item = T;
     type IntoIter = RepeatIter<T>;
 
-    fn into_iter(self) -> Self::IntoIter{
-        RepeatIter{repeat: self.repeat}
+    fn into_iter(self) -> Self::IntoIter {
+        RepeatIter { repeat: self.repeat }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        (
-            RepeatProducer{repeat: self.repeat.clone()},
-            RepeatProducer{repeat: self.repeat.clone()}
-        )
+        (RepeatProducer { repeat: self.repeat.clone() },
+         RepeatProducer { repeat: self.repeat.clone() })
     }
 }
 
@@ -73,11 +73,13 @@ impl<T: Clone + Send> UnindexedProducer for Repeat<T> {
     type Item = T;
 
     fn split(self) -> (Self, Option<Self>) {
-        (Repeat{element: self.element.clone()}, Some(Repeat{element: self.element.clone()}))
+        (Repeat { element: self.element.clone() }, Some(Repeat { element: self.element.clone() }))
     }
 
-    fn fold_with<F>(self, folder: F) -> F where F: Folder<T> {
-        folder.consume_iter(RepeatIter{repeat: Repeat{element: self.element}})
+    fn fold_with<F>(self, folder: F) -> F
+        where F: Folder<T>
+    {
+        folder.consume_iter(RepeatIter { repeat: Repeat { element: self.element } })
     }
 }
 
@@ -91,14 +93,20 @@ impl<T: Clone> Iterator for RepeatIter<T> {
     type Item = T;
 
     #[inline]
-    fn next(&mut self) -> Option<T> { Some(self.repeat.element.clone()) }
+    fn next(&mut self) -> Option<T> {
+        Some(self.repeat.element.clone())
+    }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (usize::MAX, None)
+    }
 }
 
 impl<A: Clone> DoubleEndedIterator for RepeatIter<A> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { Some(self.repeat.element.clone()) }
+    fn next_back(&mut self) -> Option<A> {
+        Some(self.repeat.element.clone())
+    }
 }
 
 impl<T: Clone> ExactSizeIterator for RepeatIter<T> {

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -1,8 +1,9 @@
-use super::*;
 use super::internal::*;
+use super::*;
+use std::iter;
 use std::usize;
 
-/// Iterator adapter for [the `repeat()` function](fn.split.html).
+/// Iterator adaptor for [the `repeat()` function](fn.repeat.html).
 pub struct Repeat<T: Clone + Send> {
     element: T,
 }
@@ -10,7 +11,8 @@ pub struct Repeat<T: Clone + Send> {
 /// Creates a parallel iterator that endlessly repeats `elt` (by
 /// cloning it). Note that this iterator has "infinite" length, so
 /// typically you would want to use `zip` or `take` or some other
-/// means to shorten it.
+/// means to shorten it, or consider using
+/// [the `repeatn()` function](fn.repeatn.html) instead.
 ///
 /// Example:
 ///
@@ -24,6 +26,31 @@ pub fn repeat<T: Clone + Send>(elt: T) -> Repeat<T> {
     Repeat { element: elt }
 }
 
+impl<T> Repeat<T>
+    where T: Clone + Send
+{
+    /// Take only `n` repeats of the element, similar to the general
+    /// [`take()`](trait.IndexedParallelIterator.html#method.take).
+    ///
+    /// The resulting `RepeatN` is an `IndexedParallelIterator`, allowing
+    /// more functionality than `Repeat` alone.
+    pub fn take(self, n: usize) -> RepeatN<T> {
+        repeatn(self.element, n)
+    }
+
+    /// Iterate tuples repeating the element with items from another
+    /// iterator, similar to the general
+    /// [`zip()`](trait.IndexedParallelIterator.html#method.zip).
+    pub fn zip<Z>(self, zip_op: Z) -> Zip<RepeatN<T>, Z::Iter>
+        where Z: IntoParallelIterator,
+              Z::Iter: IndexedParallelIterator
+    {
+        let mut z = zip_op.into_par_iter();
+        let n = z.len();
+        self.take(n).zip(z)
+    }
+}
+
 impl<T> ParallelIterator for Repeat<T>
     where T: Clone + Send
 {
@@ -32,11 +59,70 @@ impl<T> ParallelIterator for Repeat<T>
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        bridge_unindexed(self, consumer)
+        let producer = RepeatProducer { element: self.element };
+        bridge_unindexed(producer, consumer)
     }
 }
 
-impl<T> IndexedParallelIterator for Repeat<T>
+/// Unindexed producer for `Repeat`.
+struct RepeatProducer<T: Clone + Send> {
+    element: T,
+}
+
+impl<T: Clone + Send> UnindexedProducer for RepeatProducer<T> {
+    type Item = T;
+
+    fn split(self) -> (Self, Option<Self>) {
+        (RepeatProducer { element: self.element.clone() },
+         Some(RepeatProducer { element: self.element }))
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+        where F: Folder<T>
+    {
+        folder.consume_iter(iter::repeat(self.element))
+    }
+}
+
+
+/// Iterator adaptor for [the `repeatn()` function](fn.repeatn.html).
+pub struct RepeatN<T: Clone + Send> {
+    element: T,
+    count: usize,
+}
+
+/// Creates a parallel iterator that produces `n` repeats of `elt`
+/// (by cloning it).
+///
+/// Example:
+///
+/// ```
+/// use rayon::prelude::*;
+/// use rayon::iter::repeatn;
+/// let x: Vec<(i32, i32)> = repeatn(22, 3).zip(0..3).collect();
+/// assert_eq!(x, vec![(22, 0), (22, 1), (22, 2)]);
+/// ```
+pub fn repeatn<T: Clone + Send>(elt: T, n: usize) -> RepeatN<T> {
+    RepeatN { element: elt, count: n }
+}
+
+impl<T> ParallelIterator for RepeatN<T>
+    where T: Clone + Send
+{
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.count)
+    }
+}
+
+impl<T> IndexedParallelIterator for RepeatN<T>
     where T: Clone + Send
 {
     fn drive<C>(self, consumer: C) -> C::Result
@@ -48,79 +134,73 @@ impl<T> IndexedParallelIterator for Repeat<T>
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(RepeatProducer { repeat: self.element })
+        callback.callback(RepeatNProducer { element: self.element, count: self.count })
     }
 
     fn len(&mut self) -> usize {
-        usize::MAX
+        self.count
     }
 }
 
 
-/// Producer
-
-struct RepeatProducer<T: Clone + Send> {
-    repeat: T,
+/// Producer for `RepeatN`.
+struct RepeatNProducer<T: Clone + Send> {
+    element: T,
+    count: usize,
 }
 
-impl<T: Clone + Send> Producer for RepeatProducer<T> {
+impl<T: Clone + Send> Producer for RepeatNProducer<T> {
     type Item = T;
-    type IntoIter = RepeatIter<T>;
+    type IntoIter = Iter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        RepeatIter { repeat: self.repeat }
+        Iter { element: self.element, count: self.count }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        (RepeatProducer { repeat: self.repeat.clone() }, RepeatProducer { repeat: self.repeat })
+        (RepeatNProducer { element: self.element.clone(), count: index },
+         RepeatNProducer { element: self.element, count: self.count - index })
     }
 }
 
-impl<T: Clone + Send> UnindexedProducer for Repeat<T> {
-    type Item = T;
-
-    fn split(self) -> (Self, Option<Self>) {
-        (Repeat { element: self.element.clone() }, Some(Repeat { element: self.element }))
-    }
-
-    fn fold_with<F>(self, folder: F) -> F
-        where F: Folder<T>
-    {
-        folder.consume_iter(RepeatIter { repeat: self.element })
-    }
+/// Iterator for `RepeatN`.
+///
+/// This is conceptually like `std::iter::Take<std::iter::Repeat<T>>`, but
+/// we need `DoubleEndedIterator` and unconditional `ExactSizeIterator`.
+struct Iter<T: Clone> {
+    element: T,
+    count: usize,
 }
 
-/// Repeat Iter Create As Repeat Does Not Have ExactSizeIterator
-
-struct RepeatIter<T> {
-    repeat: T,
-}
-
-impl<T: Clone> Iterator for RepeatIter<T> {
+impl<T: Clone> Iterator for Iter<T> {
     type Item = T;
 
     #[inline]
     fn next(&mut self) -> Option<T> {
-        Some(self.repeat.clone())
+        if self.count > 0 {
+            self.count -= 1;
+            Some(self.element.clone())
+        } else {
+            None
+        }
     }
+
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::MAX, None)
+        (self.count, Some(self.count))
     }
 }
 
-impl<A: Clone> DoubleEndedIterator for RepeatIter<A> {
+impl<T: Clone> DoubleEndedIterator for Iter<T> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> {
-        Some(self.repeat.clone())
+    fn next_back(&mut self) -> Option<T> {
+        self.next()
     }
 }
 
-impl<T: Clone> ExactSizeIterator for RepeatIter<T> {
+impl<T: Clone> ExactSizeIterator for Iter<T> {
+    #[inline]
     fn len(&self) -> usize {
-        // FIXME this is .. sort of wrong. After all, we produce
-        // *more* than `usize::MAX`, potentially. Is there a better
-        // alternative?
-        usize::MAX
+        self.count
     }
 }

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -15,7 +15,7 @@ pub struct Repeat<T: Clone + Send> {
 /// means to shorten it, or consider using
 /// [the `repeatn()` function](fn.repeatn.html) instead.
 ///
-/// Example:
+/// # Examples
 ///
 /// ```
 /// use rayon::prelude::*;
@@ -96,7 +96,7 @@ pub struct RepeatN<T: Clone + Send> {
 /// Creates a parallel iterator that produces `n` repeats of `elt`
 /// (by cloning it).
 ///
-/// Example:
+/// # Examples
 ///
 /// ```
 /// use rayon::prelude::*;

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -4,6 +4,7 @@ use std::iter;
 use std::usize;
 
 /// Iterator adaptor for [the `repeat()` function](fn.repeat.html).
+#[derive(Debug)]
 pub struct Repeat<T: Clone + Send> {
     element: T,
 }
@@ -86,6 +87,7 @@ impl<T: Clone + Send> UnindexedProducer for RepeatProducer<T> {
 
 
 /// Iterator adaptor for [the `repeatn()` function](fn.repeatn.html).
+#[derive(Debug)]
 pub struct RepeatN<T: Clone + Send> {
     element: T,
     count: usize,

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -10,12 +10,6 @@ pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
     Repeat { element: elt }
 }
 
-impl<T: Clone> Clone for Repeat<T> {
-    fn clone(&self) -> Repeat<T> {
-        Repeat { element: self.element.clone() }
-    }
-}
-
 impl<T> ParallelIterator for Repeat<T>
     where T: Clone + Send
 {
@@ -24,7 +18,7 @@ impl<T> ParallelIterator for Repeat<T>
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        bridge(self, consumer)
+        bridge_unindexed(self, consumer)
     }
 }
 
@@ -40,7 +34,7 @@ impl<T> IndexedParallelIterator for Repeat<T>
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(RepeatProducer { repeat: self })
+        callback.callback(RepeatProducer { repeat: self.element })
     }
 
     fn len(&mut self) -> usize {
@@ -52,7 +46,7 @@ impl<T> IndexedParallelIterator for Repeat<T>
 /// Producer
 
 struct RepeatProducer<P> {
-    repeat: Repeat<P>,
+    repeat: P,
 }
 
 impl<T: Clone + Send> Producer for RepeatProducer<T> {
@@ -64,8 +58,7 @@ impl<T: Clone + Send> Producer for RepeatProducer<T> {
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        (RepeatProducer { repeat: self.repeat.clone() },
-         RepeatProducer { repeat: self.repeat.clone() })
+        (RepeatProducer { repeat: self.repeat.clone() }, RepeatProducer { repeat: self.repeat })
     }
 }
 
@@ -73,20 +66,20 @@ impl<T: Clone + Send> UnindexedProducer for Repeat<T> {
     type Item = T;
 
     fn split(self) -> (Self, Option<Self>) {
-        (Repeat { element: self.element.clone() }, Some(Repeat { element: self.element.clone() }))
+        (Repeat { element: self.element.clone() }, Some(Repeat { element: self.element }))
     }
 
     fn fold_with<F>(self, folder: F) -> F
         where F: Folder<T>
     {
-        folder.consume_iter(RepeatIter { repeat: Repeat { element: self.element } })
+        folder.consume_iter(RepeatIter { repeat: self.element })
     }
 }
 
 /// Repeat Iter Create As Repeat Does Not Have ExactSizeIterator
 
 struct RepeatIter<T> {
-    repeat: Repeat<T>,
+    repeat: T,
 }
 
 impl<T: Clone> Iterator for RepeatIter<T> {
@@ -94,7 +87,7 @@ impl<T: Clone> Iterator for RepeatIter<T> {
 
     #[inline]
     fn next(&mut self) -> Option<T> {
-        Some(self.repeat.element.clone())
+        Some(self.repeat.clone())
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -105,7 +98,7 @@ impl<T: Clone> Iterator for RepeatIter<T> {
 impl<A: Clone> DoubleEndedIterator for RepeatIter<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
-        Some(self.repeat.element.clone())
+        Some(self.repeat.clone())
     }
 }
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1824,10 +1824,7 @@ fn check_interleave_shortest() {
 #[test]
 fn check_repeat_eq() {
     let v = vec!(4,4,4,4);
-    let mut fours: Vec<_> = repeat(4)
-    .take(4)
-    .zip(v)
-    .collect();
+    let mut fours: Vec<_> = v.into_par_iter().zip(repeat(4)).collect();
     assert_eq!(fours.len(), 4);
     assert_eq!(fours.pop(), Some((4, 4)));
 }

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1820,3 +1820,14 @@ fn check_interleave_shortest() {
         assert_eq!(expected.into_iter().rev().collect::<Vec<usize>>(), res, "Case {} reversed failed", i);
     }
 }
+
+#[test]
+fn check_repeat_eq() {
+    let v = vec!(4,4,4,4);
+    let mut fours: Vec<_> = repeat(4)
+    .take(4)
+    .zip(v)
+    .collect();
+    assert_eq!(fours.len(), 4);
+    assert_eq!(fours.pop(), Some((4, 4)));
+}


### PR DESCRIPTION
This adds:
- unindexed, infinite `iter::repeat(elt) -> Repeat`
- indexed, finite `iter::repeatn(elt, n) -> RepeatN`
- `Repeat` methods `take(n)` and `zip(iter)` convert to `RepeatN`

This extends #337, opened separately for review since it's a fairly major change.