### PR TITLE
Add an Intersperse adaptor

### DIFF
--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -1,0 +1,354 @@
+use super::internal::*;
+use super::*;
+use std::cell::Cell;
+use std::iter::Fuse;
+
+/// `Intersperse` is an iterator that inserts a particular item between each
+/// item of the adapted iterator.  This struct is created by the
+/// [`intersperse()`] method on [`ParallelIterator`]
+///
+/// [`intersperse()`]: trait.ParallelIterator.html#method.intersperse
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
+pub struct Intersperse<I>
+    where I: ParallelIterator,
+          I::Item: Clone
+{
+    base: I,
+    item: I::Item,
+}
+
+/// Create a new `Intersperse` iterator
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I>(base: I, item: I::Item) -> Intersperse<I>
+    where I: ParallelIterator,
+          I::Item: Clone
+{
+    Intersperse { base: base, item: item }
+}
+
+impl<I> ParallelIterator for Intersperse<I>
+    where I: ParallelIterator,
+          I::Item: Clone + Send
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<I::Item>
+    {
+        let consumer1 = IntersperseConsumer::new(consumer, self.item);
+        self.base.drive_unindexed(consumer1)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        match self.base.opt_len() {
+            None => None,
+            Some(0) => Some(0),
+            Some(len) => len.checked_add(len - 1),
+        }
+    }
+}
+
+impl<I> IndexedParallelIterator for Intersperse<I>
+    where I: IndexedParallelIterator,
+          I::Item: Clone + Send
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        let consumer1 = IntersperseConsumer::new(consumer, self.item);
+        self.base.drive(consumer1)
+    }
+
+    fn len(&mut self) -> usize {
+        let len = self.base.len();
+        if len > 0 {
+            len.checked_add(len - 1).expect("overflow")
+        } else {
+            0
+        }
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        return self.base.with_producer(Callback {
+                                           callback: callback,
+                                           item: self.item,
+                                       });
+
+        struct Callback<CB, T> {
+            callback: CB,
+            item: T,
+        }
+
+        impl<T, CB> ProducerCallback<T> for Callback<CB, T>
+            where CB: ProducerCallback<T>,
+                  T: Clone + Send
+        {
+            type Output = CB::Output;
+
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item = T>
+            {
+                let producer = IntersperseProducer::new(base, self.item);
+                self.callback.callback(producer)
+            }
+        }
+    }
+}
+
+
+struct IntersperseProducer<P>
+    where P: Producer
+{
+    base: P,
+    item: P::Item,
+    clone_first: bool,
+    clone_last: bool,
+}
+
+impl<P> IntersperseProducer<P>
+    where P: Producer
+{
+    fn new(base: P, item: P::Item) -> Self {
+        IntersperseProducer {
+            base: base,
+            item: item,
+            clone_first: false,
+            clone_last: false,
+        }
+    }
+}
+
+impl<P> Producer for IntersperseProducer<P>
+    where P: Producer,
+          P::Item: Clone + Send
+{
+    type Item = P::Item;
+    type IntoIter = IntersperseIter<P::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntersperseIter {
+            base: self.base.into_iter().fuse(),
+            item: self.item,
+            clone_first: self.clone_first,
+            clone_last: self.clone_last,
+        }
+    }
+
+    fn min_len(&self) -> usize {
+        self.base.min_len()
+    }
+    fn max_len(&self) -> usize {
+        self.base.max_len()
+    }
+
+    fn split_at(mut self, index: usize) -> (Self, Self) {
+        // We need half of the items from the base producer, and the other half
+        // will be our interspersed item.  If we're not leading with a cloned
+        // item, then we need to round up the base number of items, otherwise
+        // round down.
+        let base_index = (index + !self.clone_first as usize) / 2;
+        let (left, right) = self.base.split_at(base_index);
+
+        // For even indexes, the right will start the same way as the left.
+        // Otherwise, it flips.
+        let right_clone_first = if index % 2 == 0 {
+            self.clone_first
+        } else {
+            !self.clone_first
+        };
+
+        let right = IntersperseProducer {
+            base: right,
+            item: self.item.clone(),
+            clone_first: right_clone_first,
+            clone_last: self.clone_last,
+        };
+        self.base = left;
+        self.clone_last = !right_clone_first;
+        (self, right)
+    }
+}
+
+
+struct IntersperseIter<I>
+    where I: Iterator
+{
+    base: Fuse<I>,
+    item: I::Item,
+    clone_first: bool,
+    clone_last: bool,
+}
+
+impl<I> Iterator for IntersperseIter<I>
+    where I: DoubleEndedIterator + ExactSizeIterator,
+          I::Item: Clone
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.clone_first {
+            self.clone_first = false;
+            Some(self.item.clone())
+        } else if let next @ Some(_) = self.base.next() {
+            // If there are any items left, we'll need another clone in front.
+            self.clone_first = self.base.len() != 0;
+            next
+        } else if self.clone_last {
+            self.clone_last = false;
+            Some(self.item.clone())
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<I> DoubleEndedIterator for IntersperseIter<I>
+    where I: DoubleEndedIterator + ExactSizeIterator,
+          I::Item: Clone
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.clone_last {
+            self.clone_last = false;
+            Some(self.item.clone())
+        } else if let next_back @ Some(_) = self.base.next_back() {
+            // If there are any items left, we'll need another clone in back.
+            self.clone_last = self.base.len() != 0;
+            next_back
+        } else if self.clone_first {
+            self.clone_first = false;
+            Some(self.item.clone())
+        } else {
+            None
+        }
+    }
+}
+
+impl<I> ExactSizeIterator for IntersperseIter<I>
+    where I: DoubleEndedIterator + ExactSizeIterator,
+          I::Item: Clone
+{
+    fn len(&self) -> usize {
+        let len = self.base.len();
+        len + len.saturating_sub(1)
+            + self.clone_first as usize
+            + self.clone_last as usize
+    }
+}
+
+
+struct IntersperseConsumer<C, T> {
+    base: C,
+    item: T,
+    clone_first: Cell<bool>,
+}
+
+impl<C, T> IntersperseConsumer<C, T>
+    where C: Consumer<T>
+{
+    fn new(base: C, item: T) -> Self {
+        IntersperseConsumer {
+            base: base,
+            item: item,
+            clone_first: false.into(),
+        }
+    }
+}
+
+impl<C, T> Consumer<T> for IntersperseConsumer<C, T>
+    where C: Consumer<T>,
+          T: Clone + Send
+{
+    type Folder = IntersperseFolder<C::Folder, T>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(mut self, index: usize) -> (Self, Self, Self::Reducer) {
+        // We'll feed twice as many items to the base consumer, except if we're
+        // not currently leading with a cloned item, then it's one less.
+        let base_index = index + index.saturating_sub(!self.clone_first.get() as usize);
+        let (left, right, reducer) = self.base.split_at(base_index);
+
+        let right = IntersperseConsumer {
+            base: right,
+            item: self.item.clone(),
+            clone_first: true.into(),
+        };
+        self.base = left;
+        (self, right, reducer)
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        IntersperseFolder {
+            base: self.base.into_folder(),
+            item: self.item,
+            clone_first: self.clone_first.get(),
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+impl<C, T> UnindexedConsumer<T> for IntersperseConsumer<C, T>
+    where C: UnindexedConsumer<T>,
+          T: Clone + Send
+{
+    fn split_off_left(&self) -> Self {
+        let left = IntersperseConsumer {
+            base: self.base.split_off_left(),
+            item: self.item.clone(),
+            clone_first: self.clone_first.clone(),
+        };
+        self.clone_first.set(true);
+        left
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct IntersperseFolder<C, T> {
+    base: C,
+    item: T,
+    clone_first: bool,
+}
+
+impl<C, T> Folder<T> for IntersperseFolder<C, T>
+    where C: Folder<T>,
+          T: Clone
+{
+    type Result = C::Result;
+
+    fn consume(mut self, item: T) -> Self {
+        if self.clone_first {
+            self.base = self.base.consume(self.item.clone());
+            if self.base.full() {
+                return self;
+            }
+        } else {
+            self.clone_first = true;
+        }
+        self.base = self.base.consume(item);
+        self
+    }
+
+    fn complete(self) -> C::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -65,6 +65,8 @@ mod interleave;
 pub use self::interleave::Interleave;
 mod interleave_shortest;
 pub use self::interleave_shortest::InterleaveShortest;
+mod intersperse;
+pub use self::intersperse::Intersperse;
 
 mod noop;
 mod rev;
@@ -773,6 +775,22 @@ pub trait ParallelIterator: Sized + Send {
               R: Send
     {
         unzip::partition_map(self, predicate)
+    }
+
+    /// Intersperses clones of an element between items of this iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let x = vec![1, 2, 3];
+    /// let r: Vec<i32> = x.into_par_iter().intersperse(-1).collect();
+    /// assert_eq!(r, vec![1, -1, 2, -1, 3]);
+    /// ```
+    fn intersperse(self, element: Self::Item) -> Intersperse<Self>
+        where Self::Item: Clone
+    {
+        intersperse::new(self, element)
     }
 
     /// Internal method used to define the behavior of this parallel

--- a/tests/compile-fail/must_use.rs
+++ b/tests/compile-fail/must_use.rs
@@ -19,6 +19,9 @@ fn main() {
     v.par_iter().fold(|| 0, |x, _| x);      //~ ERROR must be used
     v.par_iter().fold_with(0, |x, _| x);    //~ ERROR must be used
     v.par_iter().inspect(|_| {});           //~ ERROR must be used
+    v.par_iter().interleave(&v);            //~ ERROR must be used
+    v.par_iter().interleave_shortest(&v);   //~ ERROR must be used
+    v.par_iter().intersperse(&None);        //~ ERROR must be used
     v.par_iter().map(|x| x);                //~ ERROR must be used
     v.par_iter().map_with(0, |_, x| x);     //~ ERROR must be used
     v.par_iter().rev();                     //~ ERROR must be used
@@ -29,6 +32,4 @@ fn main() {
     v.par_iter().with_min_len(1);           //~ ERROR must be used
     v.par_iter().zip(&v);                   //~ ERROR must be used
     v.par_iter().zip_eq(&v);                //~ ERROR must be used
-    v.par_iter().interleave(&v);            //~ ERROR must be used
-    v.par_iter().interleave_shortest(&v);   //~ ERROR must be used
 }

--- a/tests/intersperse.rs
+++ b/tests/intersperse.rs
@@ -1,0 +1,53 @@
+extern crate rayon;
+
+use rayon::prelude::*;
+
+#[test]
+fn check_intersperse() {
+    let v: Vec<_> = (0..1000).into_par_iter().intersperse(-1).collect();
+    assert_eq!(v.len(), 1999);
+    for (i, x) in v.into_iter().enumerate() {
+        assert_eq!(x, if i % 2 == 0 { i as i32 / 2 } else { -1 });
+    }
+}
+
+#[test]
+fn check_intersperse_again() {
+    let v: Vec<_> = (0..1000).into_par_iter().intersperse(-1).intersperse(-2).collect();
+    assert_eq!(v.len(), 3997);
+    for (i, x) in v.into_iter().enumerate() {
+        let y = match i % 4 {
+            0 => i as i32 / 4,
+            2 => -1,
+            _ => -2,
+        };
+        assert_eq!(x, y);
+    }
+}
+
+#[test]
+fn check_intersperse_unindexed() {
+    let v: Vec<_> = (0..1000).map(|i| i.to_string()).collect();
+    let s = v.join(",");
+    let s2 = v.join(";");
+    let par: String = s.par_split(',').intersperse(";").collect();
+    assert_eq!(par, s2);
+}
+
+#[test]
+fn check_intersperse_producer() {
+    (0..1000).into_par_iter().intersperse(-1)
+        .zip_eq(0..1999)
+        .for_each(|(x, i)| {
+            assert_eq!(x, if i % 2 == 0 { i / 2 } else { -1 });
+        });
+}
+
+#[test]
+fn check_intersperse_rev() {
+    (0..1000).into_par_iter().intersperse(-1)
+        .zip_eq(0..1999).rev()
+        .for_each(|(x, i)| {
+            assert_eq!(x, if i % 2 == 0 { i / 2 } else { -1 });
+        });
+}

--- a/tests/intersperse.rs
+++ b/tests/intersperse.rs
@@ -1,6 +1,7 @@
 extern crate rayon;
 
 use rayon::prelude::*;
+use rayon::iter::internal::*;
 
 #[test]
 fn check_intersperse() {
@@ -50,4 +51,45 @@ fn check_intersperse_rev() {
         .for_each(|(x, i)| {
             assert_eq!(x, if i % 2 == 0 { i / 2 } else { -1 });
         });
+}
+
+#[test]
+fn check_producer_splits() {
+    struct Callback(usize, usize, usize);
+
+    impl ProducerCallback<i32> for Callback {
+        type Output = Vec<i32>;
+        fn callback<P>(self, producer: P) -> Self::Output
+            where P: Producer<Item = i32>
+        {
+            println!("splitting {} {} {}", self.0, self.1, self.2);
+
+            // Splitting the outer indexes first gets us an arbitrary mid section,
+            // which we then split further to get full test coverage.
+            let (a, right) = producer.split_at(self.0);
+            let (mid, d) = right.split_at(self.2 - self.0);
+            let (b, c) = mid.split_at(self.1 - self.0);
+
+            let (a, b, c, d) = (a.into_iter(), b.into_iter(), c.into_iter(), d.into_iter());
+            assert_eq!(a.len(), self.0);
+            assert_eq!(b.len(), self.1 - self.0);
+            assert_eq!(c.len(), self.2 - self.1);
+
+            a.chain(b).chain(c).chain(d).collect()
+        }
+    }
+
+    let v = [1, 2, 3, 4, 5];
+    let vi = [1, -1, 2, -1, 3, -1, 4, -1, 5];
+
+    for i in 0 .. vi.len() + 1 {
+        for j in i .. vi.len() + 1 {
+            for k in j .. vi.len() + 1 {
+                let res = v.par_iter().cloned()
+                    .intersperse(-1)
+                    .with_producer(Callback(i, j, k));
+                assert_eq!(res, vi);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Like the same from `itertools`, this inserts clones of an item between
each item of the parallel iterator.

Closes #385.