### PR TITLE
Remove `rayon::split`, leaving only `rayon::iter::split`

### DIFF
--- a/rayon-demo/src/fibonacci/mod.rs
+++ b/rayon-demo/src/fibonacci/mod.rs
@@ -79,12 +79,12 @@ fn fibonacci_join_2_1(b: &mut test::Bencher) {
 
 
 #[bench]
-/// Compute the Fibonacci number recursively, using rayon::split to parallelize.
+/// Compute the Fibonacci number recursively, using rayon::iter::split to parallelize.
 fn fibonacci_split_recursive(b: &mut test::Bencher) {
     fn fib(n: u32) -> u32 {
         use rayon::iter::ParallelIterator;
 
-        rayon::split(n, |n| {
+        rayon::iter::split(n, |n| {
                 if n < 2 {
                     (n, None)
                 } else {
@@ -100,12 +100,12 @@ fn fibonacci_split_recursive(b: &mut test::Bencher) {
 
 
 #[bench]
-/// Compute the Fibonacci number iteratively, using rayon::split to parallelize.
+/// Compute the Fibonacci number iteratively, using rayon::iter::split to parallelize.
 fn fibonacci_split_iterative(b: &mut test::Bencher) {
     fn fib(n: u32) -> u32 {
         use rayon::iter::ParallelIterator;
 
-        rayon::split(n, |n| {
+        rayon::iter::split(n, |n| {
                 if n < 2 {
                     (n, None)
                 } else {

--- a/rayon-demo/src/quicksort/bench.rs
+++ b/rayon-demo/src/quicksort/bench.rs
@@ -31,7 +31,7 @@ fn quick_sort_splitter(b: &mut test::Bencher) {
     use rayon::iter::ParallelIterator;
 
     bench_harness(|vec| {
-        ::rayon::split(vec, |vec| {
+        ::rayon::iter::split(vec, |vec| {
             if vec.len() > 1 {
                 let mid = super::partition(vec);
                 let (left, right) = vec.split_at_mut(mid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,6 @@ pub mod vec;
 mod par_either;
 mod test;
 
-pub use iter::split;
-
 pub use rayon_core::current_num_threads;
 pub use rayon_core::Configuration;
 pub use rayon_core::initialize;


### PR DESCRIPTION
The `split` function creates a `ParallelIterator`, which better
justifies its place in `rayon::iter`.  It's not really used enough to
justify its place in the crate root.

Fixes #432.