### PR TITLE
Implement Clone for parallel iterators

### DIFF
--- a/src/collections/binary_heap.rs
+++ b/src/collections/binary_heap.rs
@@ -31,9 +31,15 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a binary heap
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Ord + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
+}
+
+impl<'a, T: Ord + Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/binary_heap.rs
+++ b/src/collections/binary_heap.rs
@@ -10,7 +10,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a binary heap
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Ord + Send> {
     inner: vec::IntoIter<T>,
 }
@@ -31,7 +31,7 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a binary heap
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Ord + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
 }

--- a/src/collections/binary_heap.rs
+++ b/src/collections/binary_heap.rs
@@ -9,6 +9,12 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a binary heap
+#[derive(Debug)]
+pub struct IntoIter<T: Ord + Send> {
+    inner: vec::IntoIter<T>,
+}
+
 impl<T: Ord + Send> IntoParallelIterator for BinaryHeap<T> {
     type Item = T;
     type Iter = IntoIter<T>;
@@ -18,23 +24,27 @@ impl<T: Ord + Send> IntoParallelIterator for BinaryHeap<T> {
     }
 }
 
+delegate_indexed_iterator!{
+    IntoIter<T> => T,
+    impl<T: Ord + Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a binary heap
+#[derive(Debug)]
+pub struct Iter<'a, T: Ord + Sync + 'a> {
+    inner: vec::IntoIter<&'a T>,
+}
+
 into_par_vec!{
     &'a BinaryHeap<T> => Iter<'a, T>,
     impl<'a, T: Ord + Sync>
 }
 
-// `BinaryHeap` doesn't have a mutable `Iterator`
-
-
 delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over a binary heap"]
-    IntoIter<T> => vec::IntoIter<T>,
-    impl<T: Ord + Send>
-}
-
-
-delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a binary heap"]
-    Iter<'a, T> => vec::IntoIter<&'a T>,
+    Iter<'a, T> => &'a T,
     impl<'a, T: Ord + Sync + 'a>
 }
+
+
+// `BinaryHeap` doesn't have a mutable `Iterator`

--- a/src/collections/btree_map.rs
+++ b/src/collections/btree_map.rs
@@ -10,7 +10,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a B-Tree map
-#[derive(Debug)]
+#[derive(Debug)] // std doesn't Clone
 pub struct IntoIter<K: Ord + Send, V: Send> {
     inner: vec::IntoIter<(K, V)>,
 }
@@ -27,7 +27,7 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a B-Tree map
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, K: Ord + Sync + 'a, V: Sync + 'a> {
     inner: vec::IntoIter<(&'a K, &'a V)>,
 }

--- a/src/collections/btree_map.rs
+++ b/src/collections/btree_map.rs
@@ -27,9 +27,15 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a B-Tree map
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, K: Ord + Sync + 'a, V: Sync + 'a> {
     inner: vec::IntoIter<(&'a K, &'a V)>,
+}
+
+impl<'a, K: Ord + Sync, V: Sync> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/btree_map.rs
+++ b/src/collections/btree_map.rs
@@ -9,9 +9,27 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a B-Tree map
+#[derive(Debug)]
+pub struct IntoIter<K: Ord + Send, V: Send> {
+    inner: vec::IntoIter<(K, V)>,
+}
+
 into_par_vec!{
     BTreeMap<K, V> => IntoIter<K, V>,
     impl<K: Ord + Send, V: Send>
+}
+
+delegate_iterator!{
+    IntoIter<K, V> => (K, V),
+    impl<K: Ord + Send, V: Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a B-Tree map
+#[derive(Debug)]
+pub struct Iter<'a, K: Ord + Sync + 'a, V: Sync + 'a> {
+    inner: vec::IntoIter<(&'a K, &'a V)>,
 }
 
 into_par_vec!{
@@ -19,28 +37,24 @@ into_par_vec!{
     impl<'a, K: Ord + Sync, V: Sync>
 }
 
+delegate_iterator!{
+    Iter<'a, K, V> => (&'a K, &'a V),
+    impl<'a, K: Ord + Sync + 'a, V: Sync + 'a>
+}
+
+
+/// Parallel iterator over a mutable reference to a B-Tree map
+#[derive(Debug)]
+pub struct IterMut<'a, K: Ord + Sync + 'a, V: Send + 'a> {
+    inner: vec::IntoIter<(&'a K, &'a mut V)>,
+}
+
 into_par_vec!{
     &'a mut BTreeMap<K, V> => IterMut<'a, K, V>,
     impl<'a, K: Ord + Sync, V: Send>
 }
 
-
 delegate_iterator!{
-    #[doc = "Parallel iterator over a B-Tree map"]
-    IntoIter<K, V> => vec::IntoIter<(K, V)>,
-    impl<K: Ord + Send, V: Send>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a B-Tree map"]
-    Iter<'a, K, V> => vec::IntoIter<(&'a K, &'a V)>,
-    impl<'a, K: Ord + Sync + 'a, V: Sync + 'a>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over a mutable reference to a B-Tree map"]
-    IterMut<'a, K, V> => vec::IntoIter<(&'a K, &'a mut V)>,
+    IterMut<'a, K, V> => (&'a K, &'a mut V),
     impl<'a, K: Ord + Sync + 'a, V: Send + 'a>
 }

--- a/src/collections/btree_set.rs
+++ b/src/collections/btree_set.rs
@@ -9,9 +9,27 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a B-Tree set
+#[derive(Debug)]
+pub struct IntoIter<T: Ord + Send> {
+    inner: vec::IntoIter<T>,
+}
+
 into_par_vec!{
     BTreeSet<T> => IntoIter<T>,
     impl<T: Ord + Send>
+}
+
+delegate_iterator!{
+    IntoIter<T> => T,
+    impl<T: Ord + Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a B-Tree set
+#[derive(Debug)]
+pub struct Iter<'a, T: Ord + Sync + 'a> {
+    inner: vec::IntoIter<&'a T>,
 }
 
 into_par_vec!{
@@ -19,18 +37,10 @@ into_par_vec!{
     impl<'a, T: Ord + Sync>
 }
 
-// `BTreeSet` doesn't have a mutable `Iterator`
-
-
 delegate_iterator!{
-    #[doc = "Parallel iterator over a B-Tree set"]
-    IntoIter<T> => vec::IntoIter<T>,
-    impl<T: Ord + Send>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a B-Tree set"]
-    Iter<'a, T> => vec::IntoIter<&'a T>,
+    Iter<'a, T> => &'a T,
     impl<'a, T: Ord + Sync + 'a>
 }
+
+
+// `BTreeSet` doesn't have a mutable `Iterator`

--- a/src/collections/btree_set.rs
+++ b/src/collections/btree_set.rs
@@ -10,7 +10,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a B-Tree set
-#[derive(Debug)]
+#[derive(Debug)] // std doesn't Clone
 pub struct IntoIter<T: Ord + Send> {
     inner: vec::IntoIter<T>,
 }
@@ -27,7 +27,7 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a B-Tree set
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Ord + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
 }

--- a/src/collections/btree_set.rs
+++ b/src/collections/btree_set.rs
@@ -27,9 +27,15 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a B-Tree set
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Ord + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
+}
+
+impl<'a, T: Ord + Sync + 'a> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/hash_map.rs
+++ b/src/collections/hash_map.rs
@@ -28,9 +28,15 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a hash map
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, K: Hash + Eq + Sync + 'a, V: Sync + 'a> {
     inner: vec::IntoIter<(&'a K, &'a V)>,
+}
+
+impl<'a, K: Hash + Eq + Sync, V: Sync> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/hash_map.rs
+++ b/src/collections/hash_map.rs
@@ -10,9 +10,27 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a hash map
+#[derive(Debug)]
+pub struct IntoIter<K: Hash + Eq + Send, V: Send> {
+    inner: vec::IntoIter<(K, V)>,
+}
+
 into_par_vec!{
     HashMap<K, V, S> => IntoIter<K, V>,
     impl<K: Hash + Eq + Send, V: Send, S: BuildHasher>
+}
+
+delegate_iterator!{
+    IntoIter<K, V> => (K, V),
+    impl<K: Hash + Eq + Send, V: Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a hash map
+#[derive(Debug)]
+pub struct Iter<'a, K: Hash + Eq + Sync + 'a, V: Sync + 'a> {
+    inner: vec::IntoIter<(&'a K, &'a V)>,
 }
 
 into_par_vec!{
@@ -20,28 +38,24 @@ into_par_vec!{
     impl<'a, K: Hash + Eq + Sync, V: Sync, S: BuildHasher>
 }
 
+delegate_iterator!{
+    Iter<'a, K, V> => (&'a K, &'a V),
+    impl<'a, K: Hash + Eq + Sync + 'a, V: Sync + 'a>
+}
+
+
+/// Parallel iterator over a mutable reference to a hash map
+#[derive(Debug)]
+pub struct IterMut<'a, K: Hash + Eq + Sync + 'a, V: Send + 'a> {
+    inner: vec::IntoIter<(&'a K, &'a mut V)>,
+}
+
 into_par_vec!{
     &'a mut HashMap<K, V, S> => IterMut<'a, K, V>,
     impl<'a, K: Hash + Eq + Sync, V: Send, S: BuildHasher>
 }
 
-
 delegate_iterator!{
-    #[doc = "Parallel iterator over a hash map"]
-    IntoIter<K, V> => vec::IntoIter<(K, V)>,
-    impl<K: Hash + Eq + Send, V: Send>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a hash map"]
-    Iter<'a, K, V> => vec::IntoIter<(&'a K, &'a V)>,
-    impl<'a, K: Hash + Eq + Sync + 'a, V: Sync + 'a>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over a mutable reference to a hash map"]
-    IterMut<'a, K, V> => vec::IntoIter<(&'a K, &'a mut V)>,
+    IterMut<'a, K, V> => (&'a K, &'a mut V),
     impl<'a, K: Hash + Eq + Sync + 'a, V: Send + 'a>
 }

--- a/src/collections/hash_map.rs
+++ b/src/collections/hash_map.rs
@@ -11,7 +11,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a hash map
-#[derive(Debug)]
+#[derive(Debug)] // std doesn't Clone
 pub struct IntoIter<K: Hash + Eq + Send, V: Send> {
     inner: vec::IntoIter<(K, V)>,
 }
@@ -28,7 +28,7 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a hash map
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, K: Hash + Eq + Sync + 'a, V: Sync + 'a> {
     inner: vec::IntoIter<(&'a K, &'a V)>,
 }

--- a/src/collections/hash_set.rs
+++ b/src/collections/hash_set.rs
@@ -28,9 +28,15 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a hash set
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Hash + Eq + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
+}
+
+impl<'a, T: Hash + Eq + Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/hash_set.rs
+++ b/src/collections/hash_set.rs
@@ -10,9 +10,27 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a hash set
+#[derive(Debug)]
+pub struct IntoIter<T: Hash + Eq + Send> {
+    inner: vec::IntoIter<T>,
+}
+
 into_par_vec!{
     HashSet<T, S> => IntoIter<T>,
     impl<T: Hash + Eq + Send, S: BuildHasher>
+}
+
+delegate_iterator!{
+    IntoIter<T> => T,
+    impl<T: Hash + Eq + Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a hash set
+#[derive(Debug)]
+pub struct Iter<'a, T: Hash + Eq + Sync + 'a> {
+    inner: vec::IntoIter<&'a T>,
 }
 
 into_par_vec!{
@@ -20,18 +38,10 @@ into_par_vec!{
     impl<'a, T: Hash + Eq + Sync, S: BuildHasher>
 }
 
-// `HashSet` doesn't have a mutable `Iterator`
-
-
 delegate_iterator!{
-    #[doc = "Parallel iterator over a hash set"]
-    IntoIter<T> => vec::IntoIter<T>,
-    impl<T: Hash + Eq + Send>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a hash set"]
-    Iter<'a, T> => vec::IntoIter<&'a T>,
+    Iter<'a, T> => &'a T,
     impl<'a, T: Hash + Eq + Sync + 'a>
 }
+
+
+// `HashSet` doesn't have a mutable `Iterator`

--- a/src/collections/hash_set.rs
+++ b/src/collections/hash_set.rs
@@ -11,7 +11,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a hash set
-#[derive(Debug)]
+#[derive(Debug)] // std doesn't Clone
 pub struct IntoIter<T: Hash + Eq + Send> {
     inner: vec::IntoIter<T>,
 }
@@ -28,7 +28,7 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a hash set
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Hash + Eq + Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
 }

--- a/src/collections/linked_list.rs
+++ b/src/collections/linked_list.rs
@@ -10,7 +10,7 @@ use iter::internal::*;
 use vec;
 
 /// Parallel iterator over a linked list
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     inner: vec::IntoIter<T>,
 }
@@ -27,7 +27,7 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a linked list
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
 }

--- a/src/collections/linked_list.rs
+++ b/src/collections/linked_list.rs
@@ -27,9 +27,15 @@ delegate_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a linked list
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: vec::IntoIter<&'a T>,
+}
+
+impl<'a, T: Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 into_par_vec!{

--- a/src/collections/linked_list.rs
+++ b/src/collections/linked_list.rs
@@ -9,9 +9,27 @@ use iter::internal::*;
 
 use vec;
 
+/// Parallel iterator over a linked list
+#[derive(Debug)]
+pub struct IntoIter<T: Send> {
+    inner: vec::IntoIter<T>,
+}
+
 into_par_vec!{
     LinkedList<T> => IntoIter<T>,
     impl<T: Send>
+}
+
+delegate_iterator!{
+    IntoIter<T> => T,
+    impl<T: Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a linked list
+#[derive(Debug)]
+pub struct Iter<'a, T: Sync + 'a> {
+    inner: vec::IntoIter<&'a T>,
 }
 
 into_par_vec!{
@@ -19,29 +37,24 @@ into_par_vec!{
     impl<'a, T: Sync>
 }
 
+delegate_iterator!{
+    Iter<'a, T> => &'a T,
+    impl<'a, T: Sync + 'a>
+}
+
+
+/// Parallel iterator over a mutable reference to a linked list
+#[derive(Debug)]
+pub struct IterMut<'a, T: Send + 'a> {
+    inner: vec::IntoIter<&'a mut T>,
+}
+
 into_par_vec!{
     &'a mut LinkedList<T> => IterMut<'a, T>,
     impl<'a, T: Send>
 }
 
-
-
 delegate_iterator!{
-    #[doc = "Parallel iterator over a linked list"]
-    IntoIter<T> => vec::IntoIter<T>,
-    impl<T: Send>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a linked list"]
-    Iter<'a, T> => vec::IntoIter<&'a T>,
-    impl<'a, T: Sync + 'a>
-}
-
-
-delegate_iterator!{
-    #[doc = "Parallel iterator over a mutable reference to a linked list"]
-    IterMut<'a, T> => vec::IntoIter<&'a mut T>,
+    IterMut<'a, T> => &'a mut T,
     impl<'a, T: Send + 'a>
 }

--- a/src/collections/vec_deque.rs
+++ b/src/collections/vec_deque.rs
@@ -11,7 +11,7 @@ use slice;
 use vec;
 
 /// Parallel iterator over a double-ended queue
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     inner: vec::IntoIter<T>,
 }
@@ -28,7 +28,7 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a double-ended queue
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: Chain<slice::Iter<'a, T>, slice::Iter<'a, T>>,
 }

--- a/src/collections/vec_deque.rs
+++ b/src/collections/vec_deque.rs
@@ -28,9 +28,15 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a double-ended queue
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: Chain<slice::Iter<'a, T>, slice::Iter<'a, T>>,
+}
+
+impl<'a, T: Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {

--- a/src/collections/vec_deque.rs
+++ b/src/collections/vec_deque.rs
@@ -10,9 +10,27 @@ use iter::internal::*;
 use slice;
 use vec;
 
+/// Parallel iterator over a double-ended queue
+#[derive(Debug)]
+pub struct IntoIter<T: Send> {
+    inner: vec::IntoIter<T>,
+}
+
 into_par_vec!{
     VecDeque<T> => IntoIter<T>,
     impl<T: Send>
+}
+
+delegate_indexed_iterator!{
+    IntoIter<T> => T,
+    impl<T: Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a double-ended queue
+#[derive(Debug)]
+pub struct Iter<'a, T: Sync + 'a> {
+    inner: Chain<slice::Iter<'a, T>, slice::Iter<'a, T>>,
 }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
@@ -25,6 +43,18 @@ impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
     }
 }
 
+delegate_indexed_iterator!{
+    Iter<'a, T> => &'a T,
+    impl<'a, T: Sync + 'a>
+}
+
+
+/// Parallel iterator over a mutable reference to a double-ended queue
+#[derive(Debug)]
+pub struct IterMut<'a, T: Send + 'a> {
+    inner: Chain<slice::IterMut<'a, T>, slice::IterMut<'a, T>>,
+}
+
 impl<'a, T: Send> IntoParallelIterator for &'a mut VecDeque<T> {
     type Item = &'a mut T;
     type Iter = IterMut<'a, T>;
@@ -35,23 +65,7 @@ impl<'a, T: Send> IntoParallelIterator for &'a mut VecDeque<T> {
     }
 }
 
-
 delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over a double-ended queue"]
-    IntoIter<T> => vec::IntoIter<T>,
-    impl<T: Send>
-}
-
-
-delegate_indexed_iterator_item!{
-    #[doc = "Parallel iterator over an immutable reference to a double-ended queue"]
-    Iter<'a, T> => Chain<slice::Iter<'a, T>, slice::Iter<'a, T>> : &'a T,
-    impl<'a, T: Sync + 'a>
-}
-
-
-delegate_indexed_iterator_item!{
-    #[doc = "Parallel iterator over a mutable reference to a double-ended queue"]
-    IterMut<'a, T> => Chain<slice::IterMut<'a, T>, slice::IterMut<'a, T>> : &'a mut T,
+    IterMut<'a, T> => &'a mut T,
     impl<'a, T: Send + 'a>
 }

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -10,7 +10,7 @@ use rayon_core::join;
 /// [`chain()`]: trait.ParallelIterator.html#method.chain
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chain<A, B>
     where A: ParallelIterator,
           B: ParallelIterator<Item = A::Item>

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -10,7 +10,7 @@ use std::iter;
 /// [`cloned()`]: trait.ParallelIterator.html#method.cloned
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Cloned<I: ParallelIterator> {
     base: I,
 }

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -10,7 +10,7 @@ use std::usize;
 /// [`enumerate()`]: trait.ParallelIterator.html#method.enumerate
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Enumerate<I: IndexedParallelIterator> {
     base: I,
 }

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -1,16 +1,26 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 /// `Filter` takes a predicate `filter_op` and filters out elements that match.
 /// This struct is created by the [`filter()`] method on [`ParallelIterator`]
 ///
 /// [`filter()`]: trait.ParallelIterator.html#method.filter
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Filter<I: ParallelIterator, P> {
     base: I,
     filter_op: P,
+}
+
+impl<I: ParallelIterator + Debug, P> Debug for Filter<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Filter")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 /// Create a new `Filter` iterator.

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -7,7 +7,7 @@ use super::*;
 /// [`filter()`]: trait.ParallelIterator.html#method.filter
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Filter<I: ParallelIterator, P> {
     base: I,
     filter_op: P,

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -1,16 +1,26 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 /// `FilterMap` creates an iterator that uses `filter_op` to both filter and map elements.
 /// This struct is created by the [`filter_map()`] method on [`ParallelIterator`].
 ///
 /// [`filter_map()`]: trait.ParallelIterator.html#method.filter_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FilterMap<I: ParallelIterator, P> {
     base: I,
     filter_op: P,
+}
+
+impl<I: ParallelIterator + Debug, P> Debug for FilterMap<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FilterMap")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 /// Create a new `FilterMap` iterator.

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -7,7 +7,7 @@ use super::*;
 /// [`filter_map()`]: trait.ParallelIterator.html#method.filter_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FilterMap<I: ParallelIterator, P> {
     base: I,
     filter_op: P,

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -7,7 +7,7 @@ use super::*;
 /// [`flat_map()`]: trait.ParallelIterator.html#method.flat_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FlatMap<I: ParallelIterator, F> {
     base: I,
     map_op: F,

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -1,16 +1,26 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 /// `FlatMap` maps each element to an iterator, then flattens these iterators together.
 /// This struct is created by the [`flat_map()`] method on [`ParallelIterator`]
 ///
 /// [`flat_map()`]: trait.ParallelIterator.html#method.flat_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FlatMap<I: ParallelIterator, F> {
     base: I,
     map_op: F,
+}
+
+impl<I: ParallelIterator + Debug, F> Debug for FlatMap<I, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FlatMap")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 /// Create a new `FlatMap` iterator.

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -8,7 +8,7 @@ use super::*;
 /// [`flatten()`]: trait.ParallelIterator.html#method.flatten
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Flatten<I: ParallelIterator> {
     base: I,
 }

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -20,7 +20,7 @@ pub fn fold<U, I, ID, F>(base: I, identity: ID, fold_op: F) -> Fold<I, ID, F>
 /// [`fold()`]: trait.ParallelIterator.html#method.fold
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fold<I, ID, F> {
     base: I,
     identity: ID,
@@ -146,7 +146,7 @@ pub fn fold_with<U, I, F>(base: I, item: U, fold_op: F) -> FoldWith<I, U, F>
 /// [`fold_with()`]: trait.ParallelIterator.html#method.fold_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FoldWith<I, U, F> {
     base: I,
     item: U,

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -1,6 +1,8 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 pub fn fold<U, I, ID, F>(base: I, identity: ID, fold_op: F) -> Fold<I, ID, F>
     where I: ParallelIterator,
           F: Fn(U, I::Item) -> U + Sync + Send,
@@ -20,11 +22,19 @@ pub fn fold<U, I, ID, F>(base: I, identity: ID, fold_op: F) -> Fold<I, ID, F>
 /// [`fold()`]: trait.ParallelIterator.html#method.fold
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Fold<I, ID, F> {
     base: I,
     identity: ID,
     fold_op: F,
+}
+
+impl<I: ParallelIterator + Debug, ID, F> Debug for Fold<I, ID, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Fold")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 impl<U, I, ID, F> ParallelIterator for Fold<I, ID, F>
@@ -146,11 +156,20 @@ pub fn fold_with<U, I, F>(base: I, item: U, fold_op: F) -> FoldWith<I, U, F>
 /// [`fold_with()`]: trait.ParallelIterator.html#method.fold_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FoldWith<I, U, F> {
     base: I,
     item: U,
     fold_op: F,
+}
+
+impl<I: ParallelIterator + Debug, U: Debug, F> Debug for FoldWith<I, U, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FoldWith")
+            .field("base", &self.base)
+            .field("item", &self.item)
+            .finish()
+    }
 }
 
 impl<U, I, F> ParallelIterator for FoldWith<I, U, F>

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -12,7 +12,7 @@ use std::iter;
 /// [`inspect()`]: trait.ParallelIterator.html#method.inspect
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Inspect<I: ParallelIterator, F> {
     base: I,
     inspect_op: F,

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -1,6 +1,7 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
 use std::iter;
 
 
@@ -12,10 +13,18 @@ use std::iter;
 /// [`inspect()`]: trait.ParallelIterator.html#method.inspect
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Inspect<I: ParallelIterator, F> {
     base: I,
     inspect_op: F,
+}
+
+impl<I: ParallelIterator + Debug, F> Debug for Inspect<I, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Inspect")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 /// Create a new `Inspect` iterator.

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -10,7 +10,7 @@ use std::iter::Fuse;
 /// [`interleave()`]: trait.IndexedParallelIterator.html#method.interleave
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Interleave<I, J>
     where I: IndexedParallelIterator,
           J: IndexedParallelIterator<Item = I::Item>

--- a/src/iter/interleave_shortest.rs
+++ b/src/iter/interleave_shortest.rs
@@ -11,7 +11,7 @@ use super::*;
 /// [`interleave_shortest()`]: trait.IndexedParallelIterator.html#method.interleave_shortest
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InterleaveShortest<I, J>
     where I: IndexedParallelIterator,
           J: IndexedParallelIterator<Item = I::Item>

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -10,7 +10,7 @@ use std::iter::Fuse;
 /// [`intersperse()`]: trait.ParallelIterator.html#method.intersperse
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Intersperse<I>
     where I: ParallelIterator,
           I::Item: Clone

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -8,7 +8,7 @@ use std::cmp;
 /// [`min_len()`]: trait.IndexedParallelIterator.html#method.min_len
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinLen<I: IndexedParallelIterator> {
     base: I,
     min: usize,
@@ -129,7 +129,7 @@ impl<P> Producer for MinLenProducer<P>
 /// [`max_len()`]: trait.IndexedParallelIterator.html#method.max_len
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxLen<I: IndexedParallelIterator> {
     base: I,
     max: usize,

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -11,7 +11,7 @@ use std::iter;
 /// [`map()`]: trait.ParallelIterator.html#method.map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Map<I: ParallelIterator, F> {
     base: I,
     map_op: F,

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -1,6 +1,7 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
 use std::iter;
 
 
@@ -11,10 +12,18 @@ use std::iter;
 /// [`map()`]: trait.ParallelIterator.html#method.map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Map<I: ParallelIterator, F> {
     base: I,
     map_op: F,
+}
+
+impl<I: ParallelIterator + Debug, F> Debug for Map<I, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Map")
+            .field("base", &self.base)
+            .finish()
+    }
 }
 
 /// Create a new `Map` iterator.

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -1,6 +1,8 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 
 /// `MapWith` is an iterator that transforms the elements of an underlying iterator.
 ///
@@ -9,11 +11,20 @@ use super::*;
 /// [`map_with()`]: trait.ParallelIterator.html#method.map_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MapWith<I: ParallelIterator, T, F> {
     base: I,
     item: T,
     map_op: F,
+}
+
+impl<I: ParallelIterator + Debug, T: Debug, F> Debug for MapWith<I, T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapWith")
+            .field("base", &self.base)
+            .field("item", &self.item)
+            .finish()
+    }
 }
 
 /// Create a new `MapWith` iterator.

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -9,7 +9,7 @@ use super::*;
 /// [`map_with()`]: trait.ParallelIterator.html#method.map_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MapWith<I: ParallelIterator, T, F> {
     base: I,
     item: T,

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::usize;
 
 /// Iterator adaptor for [the `repeat()` function](fn.repeat.html).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Repeat<T: Clone + Send> {
     element: T,
 }
@@ -87,7 +87,7 @@ impl<T: Clone + Send> UnindexedProducer for RepeatProducer<T> {
 
 
 /// Iterator adaptor for [the `repeatn()` function](fn.repeatn.html).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepeatN<T: Clone + Send> {
     element: T,
     count: usize,

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -8,7 +8,7 @@ use std::iter;
 /// [`rev()`]: trait.IndexedParallelIterator.html#method.rev
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rev<I: IndexedParallelIterator> {
     base: I,
 }

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -9,7 +9,7 @@ use std::cmp::min;
 /// [`skip()`]: trait.ParallelIterator.html#method.skip
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Skip<I> {
     base: I,
     n: usize,

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -1,6 +1,8 @@
 use super::internal::*;
 use super::*;
 
+use std::fmt::{self, Debug};
+
 /// The `split` function takes arbitrary data and a closure that knows how to
 /// split it, and turns this into a `ParallelIterator`.
 pub fn split<D, S>(data: D, splitter: S) -> Split<D, S>
@@ -17,10 +19,18 @@ pub fn split<D, S>(data: D, splitter: S) -> Split<D, S>
 /// This struct is created by the [`split()`] function.
 ///
 /// [`split()`]: fn.split.html
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Split<D, S> {
     data: D,
     splitter: S,
+}
+
+impl<D: Debug, S> Debug for Split<D, S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Split")
+            .field("data", &self.data)
+            .finish()
+    }
 }
 
 impl<D, S> ParallelIterator for Split<D, S>

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -17,7 +17,7 @@ pub fn split<D, S>(data: D, splitter: S) -> Split<D, S>
 /// This struct is created by the [`split()`] function.
 ///
 /// [`split()`]: fn.split.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Split<D, S> {
     data: D,
     splitter: S,

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -8,7 +8,7 @@ use std::cmp::min;
 /// [`take()`]: trait.ParallelIterator.html#method.take
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Take<I> {
     base: I,
     n: usize,

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -10,7 +10,7 @@ use super::*;
 /// [`while_some()`]: trait.ParallelIterator.html#method.while_some
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WhileSome<I: ParallelIterator> {
     base: I,
 }

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -10,7 +10,7 @@ use std::iter;
 /// [`zip()`]: trait.IndexedParallelIterator.html#method.zip
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Zip<A: IndexedParallelIterator, B: IndexedParallelIterator> {
     a: A,
     b: B,

--- a/src/iter/zip_eq.rs
+++ b/src/iter/zip_eq.rs
@@ -11,7 +11,7 @@ use super::*;
 /// [`zip_eq`]: trait.IndexedParallelIterator.html#method.zip_eq
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ZipEq<A: IndexedParallelIterator, B: IndexedParallelIterator> {
     zip: Zip<A, B>
 }

--- a/src/option.rs
+++ b/src/option.rs
@@ -60,9 +60,15 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
 
 
 /// Parallel iterator over an immutable reference to an option
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: IntoIter<&'a T>,
+}
+
+impl<'a, T: Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a Option<T> {

--- a/src/option.rs
+++ b/src/option.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 
 /// Parallel iterator over an option
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     opt: Option<T>,
 }
@@ -60,7 +60,7 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
 
 
 /// Parallel iterator over an immutable reference to an option
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: IntoIter<&'a T>,
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -38,7 +38,7 @@ use std::ops::Range;
 ///
 /// assert_eq!(p, s);
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<T> {
     range: Range<T>,
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -8,6 +8,12 @@ use std::sync::Mutex;
 
 use option;
 
+/// Parallel iterator over a result
+#[derive(Debug)]
+pub struct IntoIter<T: Send> {
+    inner: option::IntoIter<T>,
+}
+
 impl<T: Send, E> IntoParallelIterator for Result<T, E> {
     type Item = T;
     type Iter = IntoIter<T>;
@@ -15,6 +21,18 @@ impl<T: Send, E> IntoParallelIterator for Result<T, E> {
     fn into_par_iter(self) -> Self::Iter {
         IntoIter { inner: self.ok().into_par_iter() }
     }
+}
+
+delegate_indexed_iterator!{
+    IntoIter<T> => T,
+    impl<T: Send>
+}
+
+
+/// Parallel iterator over an immutable reference to a result
+#[derive(Debug)]
+pub struct Iter<'a, T: Sync + 'a> {
+    inner: option::IntoIter<&'a T>,
 }
 
 impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {
@@ -26,6 +44,18 @@ impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {
     }
 }
 
+delegate_indexed_iterator!{
+    Iter<'a, T> => &'a T,
+    impl<'a, T: Sync + 'a>
+}
+
+
+/// Parallel iterator over a mutable reference to a result
+#[derive(Debug)]
+pub struct IterMut<'a, T: Send + 'a> {
+    inner: option::IntoIter<&'a mut T>,
+}
+
 impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
     type Item = &'a mut T;
     type Iter = IterMut<'a, T>;
@@ -35,24 +65,8 @@ impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
     }
 }
 
-
 delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over a result"]
-    IntoIter<T> => option::IntoIter<T>,
-    impl<T: Send>
-}
-
-
-delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over an immutable reference to a result"]
-    Iter<'a, T> => option::IntoIter<&'a T>,
-    impl<'a, T: Sync + 'a>
-}
-
-
-delegate_indexed_iterator!{
-    #[doc = "Parallel iterator over a mutable reference to a result"]
-    IterMut<'a, T> => option::IntoIter<&'a mut T>,
+    IterMut<'a, T> => &'a mut T,
     impl<'a, T: Send + 'a>
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -30,9 +30,15 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a result
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: option::IntoIter<&'a T>,
+}
+
+impl<'a, T: Sync> Clone for Iter<'a, T> {
+    fn clone(&self) -> Self {
+        Iter { inner: self.inner.clone() }
+    }
 }
 
 impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use option;
 
 /// Parallel iterator over a result
-#[derive(Debug)]
+#[derive(Debug)] // std doesn't Clone yet -- rust-lang/rust#45179
 pub struct IntoIter<T: Send> {
     inner: option::IntoIter<T>,
 }
@@ -30,7 +30,7 @@ delegate_indexed_iterator!{
 
 
 /// Parallel iterator over an immutable reference to a result
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: option::IntoIter<&'a T>,
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use option;
 
 /// Parallel iterator over a result
-#[derive(Debug)] // std doesn't Clone yet -- rust-lang/rust#45179
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     inner: option::IntoIter<T>,
 }

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -376,9 +376,15 @@ impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut Vec<T> {
 
 
 /// Parallel iterator over immutable items in a slice
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Iter<'data, T: 'data + Sync> {
     slice: &'data [T],
+}
+
+impl<'data, T: Sync> Clone for Iter<'data, T> {
+    fn clone(&self) -> Self {
+        Iter { ..*self }
+    }
 }
 
 impl<'data, T: Sync + 'data> ParallelIterator for Iter<'data, T> {
@@ -433,10 +439,16 @@ impl<'data, T: 'data + Sync> Producer for IterProducer<'data, T> {
 
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Chunks<'data, T: 'data + Sync> {
     chunk_size: usize,
     slice: &'data [T],
+}
+
+impl<'data, T: Sync> Clone for Chunks<'data, T> {
+    fn clone(&self) -> Self {
+        Chunks { ..*self }
+    }
 }
 
 impl<'data, T: Sync + 'data> ParallelIterator for Chunks<'data, T> {
@@ -503,10 +515,16 @@ impl<'data, T: 'data + Sync> Producer for ChunksProducer<'data, T> {
 
 
 /// Parallel iterator over immutable overlapping windows of a slice
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Windows<'data, T: 'data + Sync> {
     window_size: usize,
     slice: &'data [T],
+}
+
+impl<'data, T: Sync> Clone for Windows<'data, T> {
+    fn clone(&self) -> Self {
+        Windows { ..*self }
+    }
 }
 
 impl<'data, T: Sync + 'data> ParallelIterator for Windows<'data, T> {
@@ -702,10 +720,16 @@ impl<'data, T: 'data + Send> Producer for ChunksMutProducer<'data, T> {
 
 
 /// Parallel iterator over slices separated by a predicate
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Split<'data, T: 'data, P> {
     slice: &'data [T],
     separator: P,
+}
+
+impl<'data, T, P: Clone> Clone for Split<'data, T, P> {
+    fn clone(&self) -> Self {
+        Split { separator: self.separator.clone(), ..*self }
+    }
 }
 
 impl<'data, T, P> ParallelIterator for Split<'data, T, P>

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -14,6 +14,7 @@ use self::quicksort::par_quicksort;
 use split_producer::*;
 use std::cmp;
 use std::cmp::Ordering;
+use std::fmt::{self, Debug};
 
 /// Parallel extensions for slices.
 pub trait ParallelSlice<T: Sync> {
@@ -720,7 +721,6 @@ impl<'data, T: 'data + Send> Producer for ChunksMutProducer<'data, T> {
 
 
 /// Parallel iterator over slices separated by a predicate
-#[derive(Debug)]
 pub struct Split<'data, T: 'data, P> {
     slice: &'data [T],
     separator: P,
@@ -729,6 +729,14 @@ pub struct Split<'data, T: 'data, P> {
 impl<'data, T, P: Clone> Clone for Split<'data, T, P> {
     fn clone(&self) -> Self {
         Split { separator: self.separator.clone(), ..*self }
+    }
+}
+
+impl<'data, T: Debug, P> Debug for Split<'data, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Split")
+            .field("slice", &self.slice)
+            .finish()
     }
 }
 
@@ -785,10 +793,17 @@ impl<'data, T, P> Fissile<P> for &'data [T]
 
 
 /// Parallel iterator over mutable slices separated by a predicate
-#[derive(Debug)]
 pub struct SplitMut<'data, T: 'data, P> {
     slice: &'data mut [T],
     separator: P,
+}
+
+impl<'data, T: Debug, P> Debug for SplitMut<'data, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SplitMut")
+            .field("slice", &self.slice)
+            .finish()
+    }
 }
 
 impl<'data, T, P> ParallelIterator for SplitMut<'data, T, P>

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -376,7 +376,7 @@ impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut Vec<T> {
 
 
 /// Parallel iterator over immutable items in a slice
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Iter<'data, T: 'data + Sync> {
     slice: &'data [T],
 }
@@ -433,7 +433,7 @@ impl<'data, T: 'data + Sync> Producer for IterProducer<'data, T> {
 
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chunks<'data, T: 'data + Sync> {
     chunk_size: usize,
     slice: &'data [T],
@@ -503,7 +503,7 @@ impl<'data, T: 'data + Sync> Producer for ChunksProducer<'data, T> {
 
 
 /// Parallel iterator over immutable overlapping windows of a slice
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Windows<'data, T: 'data + Sync> {
     window_size: usize,
     slice: &'data [T],
@@ -702,7 +702,7 @@ impl<'data, T: 'data + Send> Producer for ChunksMutProducer<'data, T> {
 
 
 /// Parallel iterator over slices separated by a predicate
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Split<'data, T: 'data, P> {
     slice: &'data [T],
     separator: P,

--- a/src/str.rs
+++ b/src/str.rs
@@ -183,7 +183,7 @@ impl<FN: Sync + Send + Fn(char) -> bool> Pattern for FN {
 // /////////////////////////////////////////////////////////////////////////
 
 /// Parallel iterator over the characters of a string
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Chars<'ch> {
     chars: &'ch str,
 }
@@ -227,7 +227,7 @@ impl<'ch> UnindexedProducer for CharsProducer<'ch> {
 // /////////////////////////////////////////////////////////////////////////
 
 /// Parallel iterator over substrings separated by a pattern
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Split<'ch, P: Pattern> {
     chars: &'ch str,
     separator: P,
@@ -290,7 +290,7 @@ impl<'ch, P: Pattern> Fissile<P> for &'ch str {
 // /////////////////////////////////////////////////////////////////////////
 
 /// Parallel iterator over substrings separated by a terminator pattern
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SplitTerminator<'ch, P: Pattern> {
     chars: &'ch str,
     terminator: P,
@@ -358,7 +358,7 @@ impl<'ch, 'sep, P: Pattern + 'sep> UnindexedProducer for SplitTerminatorProducer
 // /////////////////////////////////////////////////////////////////////////
 
 /// Parallel iterator over lines in a string
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Lines<'ch>(&'ch str);
 
 impl<'ch> ParallelIterator for Lines<'ch> {
@@ -382,7 +382,7 @@ impl<'ch> ParallelIterator for Lines<'ch> {
 // /////////////////////////////////////////////////////////////////////////
 
 /// Parallel iterator over substrings separated by whitespace
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SplitWhitespace<'ch>(&'ch str);
 
 impl<'ch> ParallelIterator for SplitWhitespace<'ch> {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -7,7 +7,7 @@ use iter::internal::*;
 use std;
 
 /// Parallel iterator that moves out of a vector.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     vec: Vec<T>,
 }

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -76,8 +76,7 @@ fn clone_option() {
 fn clone_result() {
     let result = Ok::<_, ()>(0);
     check(result.par_iter());
-    // rust-lang/rust#45179
-    // check(result.into_par_iter());
+    check(result.into_par_iter());
 }
 
 #[test]

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -1,0 +1,147 @@
+#![feature(clone_closures)]
+
+extern crate rayon;
+
+use rayon::prelude::*;
+
+fn check<I>(iter: I)
+    where I: ParallelIterator + Clone,
+          I::Item: std::fmt::Debug + PartialEq
+{
+    let a: Vec<_> = iter.clone().collect();
+    let b: Vec<_> = iter.collect();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn clone_binary_heap() {
+    use std::collections::BinaryHeap;
+    let heap: BinaryHeap<_> = (0..1000).collect();
+    check(heap.par_iter());
+    check(heap.into_par_iter());
+}
+
+#[test]
+fn clone_btree_map() {
+    use std::collections::BTreeMap;
+    let map: BTreeMap<_,_> = (0..1000).enumerate().collect();
+    check(map.par_iter());
+}
+
+#[test]
+fn clone_btree_set() {
+    use std::collections::BTreeSet;
+    let set: BTreeSet<_> = (0..1000).collect();
+    check(set.par_iter());
+}
+
+#[test]
+fn clone_hash_map() {
+    use std::collections::HashMap;
+    let map: HashMap<_,_> = (0..1000).enumerate().collect();
+    check(map.par_iter());
+}
+
+#[test]
+fn clone_hash_set() {
+    use std::collections::HashSet;
+    let set: HashSet<_> = (0..1000).collect();
+    check(set.par_iter());
+}
+
+#[test]
+fn clone_linked_list() {
+    use std::collections::LinkedList;
+    let list: LinkedList<_> = (0..1000).collect();
+    check(list.par_iter());
+    check(list.into_par_iter());
+}
+
+#[test]
+fn clone_vec_deque() {
+    use std::collections::VecDeque;
+    let deque: VecDeque<_> = (0..1000).collect();
+    check(deque.par_iter());
+    check(deque.into_par_iter());
+}
+
+#[test]
+fn clone_option() {
+    let option = Some(0);
+    check(option.par_iter());
+    check(option.into_par_iter());
+}
+
+#[test]
+fn clone_result() {
+    let result = Ok::<_, ()>(0);
+    check(result.par_iter());
+    // rust-lang/rust#45179
+    // check(result.into_par_iter());
+}
+
+#[test]
+fn clone_range() {
+    check((0..1000).into_par_iter());
+}
+
+#[test]
+fn clone_str() {
+    let s = include_str!("clones.rs");
+    check(s.par_chars());
+    check(s.par_lines());
+    check(s.par_split('\n'));
+    check(s.par_split_terminator('\n'));
+    check(s.par_split_whitespace());
+}
+
+#[test]
+fn clone_vec() {
+    let v: Vec<_> = (0..1000).collect();
+    check(v.par_iter());
+    check(v.par_chunks(42));
+    check(v.par_windows(42));
+    check(v.par_split(|x| x % 3 == 0));
+    check(v.into_par_iter());
+}
+
+#[test]
+fn clone_adaptors() {
+    let v: Vec<_> = (0..1000).map(Some).collect();
+    check(v.par_iter().chain(&v));
+    check(v.par_iter().cloned());
+    check(v.par_iter().enumerate());
+    check(v.par_iter().filter(|_| true));
+    check(v.par_iter().filter_map(|x| *x));
+    check(v.par_iter().flat_map(|x| *x));
+    check(v.par_iter().flatten());
+    check(v.par_iter().with_max_len(1).fold(|| 0, |x, _| x));
+    check(v.par_iter().with_max_len(1).fold_with(0, |x, _| x));
+    check(v.par_iter().inspect(|_| ()));
+    check(v.par_iter().interleave(&v));
+    check(v.par_iter().interleave_shortest(&v));
+    check(v.par_iter().intersperse(&None));
+    check(v.par_iter().map(|x| x));
+    check(v.par_iter().map_with(0, |_, x| x));
+    check(v.par_iter().rev());
+    check(v.par_iter().skip(1));
+    check(v.par_iter().take(1));
+    check(v.par_iter().cloned().while_some());
+    check(v.par_iter().with_max_len(1));
+    check(v.par_iter().with_min_len(1));
+    check(v.par_iter().zip(&v));
+    check(v.par_iter().zip_eq(&v));
+}
+
+#[test]
+fn clone_repeat() {
+    let x: Option<i32> = None;
+    check(rayon::iter::repeat(x).while_some());
+    check(rayon::iter::repeatn(x, 1000));
+}
+
+#[test]
+fn clone_splitter() {
+    check(rayon::iter::split((0..1000), |x| (x, None)));
+}
+

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,0 +1,155 @@
+extern crate rayon;
+
+use rayon::prelude::*;
+use std::fmt::Debug;
+
+fn check<I>(iter: I)
+    where I: ParallelIterator + Debug
+{
+    println!("{:?}", iter);
+}
+
+#[test]
+fn debug_binary_heap() {
+    use std::collections::BinaryHeap;
+    let heap: BinaryHeap<_> = (0..10).collect();
+    check(heap.par_iter());
+    check(heap.into_par_iter());
+}
+
+#[test]
+fn debug_btree_map() {
+    use std::collections::BTreeMap;
+    let mut map: BTreeMap<_,_> = (0..10).enumerate().collect();
+    check(map.par_iter());
+    check(map.par_iter_mut());
+    check(map.into_par_iter());
+}
+
+#[test]
+fn debug_btree_set() {
+    use std::collections::BTreeSet;
+    let set: BTreeSet<_> = (0..10).collect();
+    check(set.par_iter());
+    check(set.into_par_iter());
+}
+
+#[test]
+fn debug_hash_map() {
+    use std::collections::HashMap;
+    let mut map: HashMap<_,_> = (0..10).enumerate().collect();
+    check(map.par_iter());
+    check(map.par_iter_mut());
+    check(map.into_par_iter());
+}
+
+#[test]
+fn debug_hash_set() {
+    use std::collections::HashSet;
+    let set: HashSet<_> = (0..10).collect();
+    check(set.par_iter());
+    check(set.into_par_iter());
+}
+
+#[test]
+fn debug_linked_list() {
+    use std::collections::LinkedList;
+    let mut list: LinkedList<_> = (0..10).collect();
+    check(list.par_iter());
+    check(list.par_iter_mut());
+    check(list.into_par_iter());
+}
+
+#[test]
+fn debug_vec_deque() {
+    use std::collections::VecDeque;
+    let mut deque: VecDeque<_> = (0..10).collect();
+    check(deque.par_iter());
+    check(deque.par_iter_mut());
+    check(deque.into_par_iter());
+}
+
+#[test]
+fn debug_option() {
+    let mut option = Some(0);
+    check(option.par_iter());
+    check(option.par_iter_mut());
+    check(option.into_par_iter());
+}
+
+#[test]
+fn debug_result() {
+    let mut result = Ok::<_, ()>(0);
+    check(result.par_iter());
+    check(result.par_iter_mut());
+    check(result.into_par_iter());
+}
+
+#[test]
+fn debug_range() {
+    check((0..10).into_par_iter());
+}
+
+#[test]
+fn debug_str() {
+    let s = "a b c d\ne f g";
+    check(s.par_chars());
+    check(s.par_lines());
+    check(s.par_split('\n'));
+    check(s.par_split_terminator('\n'));
+    check(s.par_split_whitespace());
+}
+
+#[test]
+fn debug_vec() {
+    let mut v: Vec<_> = (0..10).collect();
+    check(v.par_iter());
+    check(v.par_iter_mut());
+    check(v.par_chunks(42));
+    check(v.par_chunks_mut(42));
+    check(v.par_windows(42));
+    check(v.par_split(|x| x % 3 == 0));
+    check(v.par_split_mut(|x| x % 3 == 0));
+    check(v.into_par_iter());
+}
+
+#[test]
+fn debug_adaptors() {
+    let v: Vec<_> = (0..10).collect();
+    check(v.par_iter().chain(&v));
+    check(v.par_iter().cloned());
+    check(v.par_iter().enumerate());
+    check(v.par_iter().filter(|_| true));
+    check(v.par_iter().filter_map(|x| Some(x)));
+    check(v.par_iter().flat_map(|x| Some(x)));
+    check(v.par_iter().map(Some).flatten());
+    check(v.par_iter().fold(|| 0, |x, _| x));
+    check(v.par_iter().fold_with(0, |x, _| x));
+    check(v.par_iter().inspect(|_| ()));
+    check(v.par_iter().interleave(&v));
+    check(v.par_iter().interleave_shortest(&v));
+    check(v.par_iter().intersperse(&-1));
+    check(v.par_iter().map(|x| x));
+    check(v.par_iter().map_with(0, |_, x| x));
+    check(v.par_iter().rev());
+    check(v.par_iter().skip(1));
+    check(v.par_iter().take(1));
+    check(v.par_iter().map(Some).while_some());
+    check(v.par_iter().with_max_len(1));
+    check(v.par_iter().with_min_len(1));
+    check(v.par_iter().zip(&v));
+    check(v.par_iter().zip_eq(&v));
+}
+
+#[test]
+fn debug_repeat() {
+    let x: Option<i32> = None;
+    check(rayon::iter::repeat(x));
+    check(rayon::iter::repeatn(x, 10));
+}
+
+#[test]
+fn debug_splitter() {
+    check(rayon::iter::split((0..10), |x| (x, None)));
+}
+


### PR DESCRIPTION
Most are simply `#[derive(Clone)]`, except for `&T` sorts of iterators where we don't want the derived `T: Clone`.

Fixes #416.