### PR TITLE
Inherent mutability -> Interior mutablility

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ However, this safety does have some implications. You will not be able
 to use types which are not thread-safe (i.e., do not implement `Send`)
 from inside a `join` closure. Note that almost all types *are* in fact
 thread-safe in Rust; the only exception is those types that employ
-"inherent mutability" without some form of synchronization, such as
+"interior mutability" without some form of synchronization, such as
 `RefCell` or `Rc`. Here is a list of the most common types in the
 standard library that are not `Send`, along with an alternative that
 you can use instead which *is* `Send` (but which also has higher


### PR DESCRIPTION
The rust book calls this "interior mutability". I think that the two terms were just confused because they sound awfully similar.

First edition: https://doc.rust-lang.org/book/first-edition/mutability.html
Second edition: https://doc.rust-lang.org/book/second-edition/ch15-05-interior-mutability.html#refcellt-and-the-interior-mutability-pattern