### PR TITLE
 ParallelExtend with map-reduce 

### DIFF
--- a/rayon-demo/src/vec_collect.rs
+++ b/rayon-demo/src/vec_collect.rs
@@ -12,8 +12,8 @@ mod util {
         pi.collect()
     }
 
-    /// Use a linked list of vectors intermediary.
-    pub fn linked_list_vec<T, PI>(pi: PI) -> Vec<T>
+    /// Collect a linked list of vectors intermediary.
+    pub fn linked_list_collect_vec<T, PI>(pi: PI) -> Vec<T>
         where T: Send,
               PI: ParallelIterator<Item = T> + Send
     {
@@ -26,8 +26,8 @@ mod util {
                   |mut vec, mut sub| { vec.append(&mut sub); vec })
     }
 
-    /// Use a linked list of vectors intermediary, with a size hint.
-    pub fn linked_list_vec_sized<T, PI>(pi: PI) -> Vec<T>
+    /// Collect a linked list of vectors intermediary, with a size hint.
+    pub fn linked_list_collect_vec_sized<T, PI>(pi: PI) -> Vec<T>
         where T: Send,
               PI: ParallelIterator<Item = T> + Send
     {
@@ -42,7 +42,31 @@ mod util {
                   |mut vec, mut sub| { vec.append(&mut sub); vec })
     }
 
-    /// Use a vector of vectors intermediary, with a size hint.
+    /// Map-Reduce a linked list of vectors intermediary, with a size hint.
+    pub fn linked_list_map_reduce_vec_sized<T, PI>(pi: PI) -> Vec<T>
+        where T: Send,
+              PI: ParallelIterator<Item = T> + Send
+    {
+        let list: LinkedList<Vec<_>> = pi
+            .fold(|| Vec::new(),
+                  |mut vec, elem| { vec.push(elem); vec })
+            .map(|vec| {
+                let mut list = LinkedList::new();
+                list.push_back(vec);
+                list
+            })
+            .reduce(LinkedList::new, |mut list1, mut list2| {
+                list1.append(&mut list2);
+                list1
+            });
+
+        let len = list.iter().map(Vec::len).sum();
+        list.into_iter()
+            .fold(Vec::with_capacity(len),
+                  |mut vec, mut sub| { vec.append(&mut sub); vec })
+    }
+
+    /// Map-Reduce a vector of vectors intermediary, with a size hint.
     pub fn vec_vec_sized<T, PI>(pi: PI) -> Vec<T>
         where T: Send,
               PI: ParallelIterator<Item = T> + Send
@@ -87,18 +111,26 @@ macro_rules! make_bench {
         }
 
         #[bench]
-        fn with_linked_list_vec(b: &mut ::test::Bencher) {
+        fn with_linked_list_collect_vec(b: &mut ::test::Bencher) {
             use vec_collect::util;
             let mut vec = None;
-            b.iter(|| vec = Some(util::linked_list_vec($generate())));
+            b.iter(|| vec = Some(util::linked_list_collect_vec($generate())));
             $check(&vec.unwrap());
         }
 
         #[bench]
-        fn with_linked_list_vec_sized(b: &mut ::test::Bencher) {
+        fn with_linked_list_collect_vec_sized(b: &mut ::test::Bencher) {
             use vec_collect::util;
             let mut vec = None;
-            b.iter(|| vec = Some(util::linked_list_vec_sized($generate())));
+            b.iter(|| vec = Some(util::linked_list_collect_vec_sized($generate())));
+            $check(&vec.unwrap());
+        }
+
+        #[bench]
+        fn with_linked_list_map_reduce_vec_sized(b: &mut ::test::Bencher) {
+            use vec_collect::util;
+            let mut vec = None;
+            b.iter(|| vec = Some(util::linked_list_map_reduce_vec_sized($generate())));
             $check(&vec.unwrap());
         }
 

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -138,7 +138,15 @@ impl<T> ParallelExtend<T> for Vec<T>
                         vec.push(elem);
                         vec
                     })
-                    .collect();
+                    .map(|vec| {
+                        let mut list = LinkedList::new();
+                        list.push_back(vec);
+                        list
+                    })
+                    .reduce(LinkedList::new, |mut list1, mut list2| {
+                        list1.append(&mut list2);
+                        list1
+                    });
 
                 self.reserve(list.iter().map(Vec::len).sum());
                 for mut vec in list {

--- a/src/iter/extend.rs
+++ b/src/iter/extend.rs
@@ -18,7 +18,15 @@ fn extend<C, I, F>(collection: &mut C, par_iter: I, reserve: F)
             vec.push(elem);
             vec
         })
-        .collect();
+        .map(|vec| {
+            let mut list = LinkedList::new();
+            list.push_back(vec);
+            list
+        })
+        .reduce(LinkedList::new, |mut list1, mut list2| {
+            list1.append(&mut list2);
+            list1
+        });
 
     reserve(collection, &list);
     for vec in list {
@@ -212,7 +220,15 @@ impl ParallelExtend<char> for String {
                 string.push(ch);
                 string
             })
-            .collect();
+            .map(|vec| {
+                let mut list = LinkedList::new();
+                list.push_back(vec);
+                list
+            })
+            .reduce(LinkedList::new, |mut list1, mut list2| {
+                list1.append(&mut list2);
+                list1
+            });
 
         self.reserve(list.iter().map(String::len).sum());
         self.extend(list)


### PR DESCRIPTION
We were using a `LinkedList<Vec<_>>` intermediary for general `ParallelExtend` implementations, gathered using a `fold` to a vector and `collect` the list -- effectively a `fold`-`fold`-`reduce`.  Now we explicitly `fold`-`map`-`reduce` it for better performance.

Thanks to @bluss for [ridiculing](https://github.com/bluss/ordermap/pull/45#discussion_r152104375) the use of `LinkedList`, which got me to look at this again.  At first I tried `Vec<Vec<_>>` instead, which did perform better, but I had to do this using `fold`-`map`-`reduce` to avoid infinite `collect` recursion.  Then I tried that same tweak on the original code, finding it slightly better yet.  So I stand by the use of `LinkedList`. :smile:

```
test map_collect::i_mod_10_to_i::with_linked_list_collect_vec_sized     ... bench:   5,112,790 ns/iter (+/- 78,988)
test map_collect::i_mod_10_to_i::with_linked_list_map_reduce_vec_sized  ... bench:   4,954,336 ns/iter (+/- 103,285)
test map_collect::i_mod_10_to_i::with_vec_vec_sized                     ... bench:   4,965,241 ns/iter (+/- 80,797)
test map_collect::i_to_i::with_linked_list_collect_vec_sized            ... bench:   9,837,088 ns/iter (+/- 283,665)
test map_collect::i_to_i::with_linked_list_map_reduce_vec_sized         ... bench:   9,687,170 ns/iter (+/- 328,236)
test map_collect::i_to_i::with_vec_vec_sized                            ... bench:   9,690,253 ns/iter (+/- 242,379)
test vec_collect::vec_i::with_linked_list_collect_vec_sized             ... bench:  12,639,762 ns/iter (+/- 260,212)
test vec_collect::vec_i::with_linked_list_map_reduce_vec_sized          ... bench:   9,805,660 ns/iter (+/- 170,434)
test vec_collect::vec_i::with_vec_vec_sized                             ... bench:   9,904,740 ns/iter (+/- 226,382)
test vec_collect::vec_i_filtered::with_linked_list_collect_vec_sized    ... bench:  12,486,357 ns/iter (+/- 239,281)
test vec_collect::vec_i_filtered::with_linked_list_map_reduce_vec_sized ... bench:   9,794,605 ns/iter (+/- 306,361)
test vec_collect::vec_i_filtered::with_vec_vec_sized                    ... bench:   9,986,733 ns/iter (+/- 1,142,244)
```