### PR TITLE
WIP: rustc changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rayon"
+name = "rustc-rayon"
 # Reminder to update html_rool_url in lib.rs when updating version
 version = "0.9.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
@@ -13,11 +13,11 @@ keywords = ["parallel", "thread", "concurrency", "join", "performance"]
 categories = ["concurrency"]
 
 [workspace]
-members = ["rayon-demo", "rayon-core", "rayon-futures"]
+members = ["rayon-core"]
 exclude = ["ci"]
 
 [dependencies]
-rayon-core = { version = "1.3", path = "rayon-core", features=[] }
+rustc-rayon-core = { version = "1.3", path = "rayon-core", features=[] }
 
 # This is a public dependency!
 [dependencies.either]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["rayon-demo", "rayon-core", "rayon-futures"]
 exclude = ["ci"]
 
 [dependencies]
-rayon-core = { version = "1.3", path = "rayon-core" }
+rayon-core = { version = "1.3", path = "rayon-core", features=[] }
 
 # This is a public dependency!
 [dependencies.either]

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -19,5 +19,23 @@ num_cpus = "1.2"
 coco = "0.3.2"
 libc = "0.2.16"
 lazy_static = "1"
+context = { git = "https://github.com/Zoxc/context-rs.git" }
+ctrlc = "3.0.3"
+scoped-tls = { git = "https://github.com/Zoxc/scoped-tls.git", features=["nightly"] }
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"
+winapi = "0.2.8"
+
+[dependencies.parking_lot]
+version = "0.5"
+features = ["nightly"]
+
+[build-dependencies]
+gcc = "0.3.10"
+
+[features]
+debug = []
+tlv = []
 
 [dev-dependencies]

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -36,6 +36,7 @@ features = ["nightly"]
 gcc = "0.3.10"
 
 [features]
+default = ["tlv"]
 debug = ["ctrlc"]
 tlv = []
 

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rayon-core"
+name = "rustc-rayon-core"
 version = "1.3.0" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1"
 context = { git = "https://github.com/Zoxc/context-rs.git" }
 ctrlc = "3.0.3"
 scoped-tls = { git = "https://github.com/Zoxc/scoped-tls.git", features=["nightly"] }
+crossbeam-channel = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -20,7 +20,7 @@ coco = "0.3.2"
 libc = "0.2.16"
 lazy_static = "1"
 context = { git = "https://github.com/Zoxc/context-rs.git" }
-scoped-tls = { git = "https://github.com/Zoxc/scoped-tls.git", features=["nightly"] }
+scoped-tls = { version = "0.1.1", features=["nightly"] }
 crossbeam-channel = "0.1"
 ctrlc = { version = "3.0.3", optional = true }
 

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -20,9 +20,9 @@ coco = "0.3.2"
 libc = "0.2.16"
 lazy_static = "1"
 context = { git = "https://github.com/Zoxc/context-rs.git" }
-ctrlc = "3.0.3"
 scoped-tls = { git = "https://github.com/Zoxc/scoped-tls.git", features=["nightly"] }
 crossbeam-channel = "0.1"
+ctrlc = { version = "3.0.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"
@@ -36,7 +36,7 @@ features = ["nightly"]
 gcc = "0.3.10"
 
 [features]
-debug = []
+debug = ["ctrlc"]
 tlv = []
 
 [dev-dependencies]

--- a/rayon-core/build.rs
+++ b/rayon-core/build.rs
@@ -1,7 +1,21 @@
+extern crate gcc;
+
+use std::env;
+
 // We need a build script to use `link = "rayon-core"`.  But we're not
 // *actually* linking to anything, just making sure that we're the only
 // rayon-core in use.
 fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    let mut cfg = gcc::Build::new();
+
+    if target.contains("windows") {
+        cfg.file("src/fiber/windows.c");
+    }
+
+    cfg.compile("librayon_core_c.a");
+
     // we don't need to rebuild for anything else
-    println!("cargo:rerun-if-changed=build.rs");
+    //println!("cargo:rerun-if-changed=build.rs");
 }

--- a/rayon-core/src/fiber/debug.rs
+++ b/rayon-core/src/fiber/debug.rs
@@ -1,0 +1,246 @@
+use super::*;
+use std::collections::HashMap;
+
+pub type FiberInfoType = Arc<FiberInfo>;
+
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum FiberId {
+    Worker(usize),
+    Job(usize),
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum FiberStatus {
+    WaitingOnLatch(Ptr),
+    OnQueue(usize),
+    New,
+    Complete,
+    Resumed,
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum FiberAction {
+    Working,
+    WaitUntil(Ptr),
+}
+
+#[derive(Debug)]
+pub struct FiberInfo {
+    pub id: FiberId,
+    pub status: Mutex<FiberStatus>,
+    pub action: Mutex<FiberAction>,
+    pub stack_low: Mutex<Ptr>,
+    pub stack_high: Mutex<Ptr>,
+}
+
+impl FiberInfo {
+    pub fn new(id: FiberId, stack_low: usize, stack_high: usize) -> Self {
+        FiberInfo {
+            id,
+            status: Mutex::new(FiberStatus::New),
+            action: Mutex::new(FiberAction::Working),
+            stack_low: Mutex::new(Ptr(stack_low)),
+            stack_high: Mutex::new(Ptr(stack_high)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SingleWaiterLatch {
+    pub data: Arc<Mutex<(bool, Option<(usize, Fiber)>, Ptr)>>,
+}
+
+impl SingleWaiterLatch {
+    pub fn new() -> SingleWaiterLatch {
+        let r = SingleWaiterLatch {
+            data: Arc::new(Mutex::new((false, None, Ptr(0)))),
+        };
+        let id = &*r.data as *const _ as usize;
+        fiber_log!("starting latch {:x}", id);
+        #[cfg(feature = "debug")]
+        LATCHES.lock().insert(id, r.data.clone());
+        r
+    }
+
+    pub fn start(&self) {
+        self.data.lock().2 = Ptr(self as *const _ as usize);
+    }
+}
+
+impl Drop for SingleWaiterLatch {
+    fn drop(&mut self) {
+        let id = &*self.data as *const _ as usize;
+        fiber_log!("dropping latch {:x}", id);
+        #[cfg(feature = "debug")]
+        LATCHES.lock().remove(&id);
+    }
+}
+
+impl LatchProbe for SingleWaiterLatch {
+    #[inline]
+    fn probe(&self) -> bool {
+        self.data.lock().0
+    }
+}
+
+impl Latch for SingleWaiterLatch {
+    fn set(&self) {
+        let mut data = self.data.lock();
+        let id = &*self.data as *const _ as usize;
+        fiber_log!("setting latch {:x} {:?}", id, *data);
+        debug_assert!(!data.0);
+        data.0 = true;
+        if let Some((worker_index, fiber)) = data.1.take() {
+            fiber_log!("resuming fiber {} (worker {}) from latch {:x}", fiber, worker_index, self as *const _ as usize);
+            let registry = Registry::current();
+            registry.resume_fiber(worker_index, fiber);
+        }
+        // FIXME: Find out why this is needed. Rayon tickles all jobs after they are complete.
+        // Perhaps this is unsufficient when jobs can wait multiple times?
+        // Perhaps a job sets this latch then waits on something else?
+        // registry.sleep.tickle(usize::MAX);
+    }
+}
+
+impl Waitable for SingleWaiterLatch {
+    fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+        self.probe()
+    }
+
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+        let mut data = self.data.lock();
+        if data.0 {
+            #[cfg(feature = "debug")]
+            {
+                *waiter.1.status.lock() = FiberStatus::OnQueue(worker_thread.index());
+            }
+            fiber_log!("resuming fiber {} (worker {}) because it tried to await on a complete latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+            worker_thread.registry.resume_fiber(worker_thread.index(), waiter);
+        } else {
+            #[cfg(feature = "debug")]
+            {
+                *waiter.1.status.lock() = FiberStatus::WaitingOnLatch(Ptr(self as *const _ as _));
+            }
+            fiber_log!("fiber {} (worker {}) is waiting on latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+            data.1 = Some((worker_thread.index(), waiter));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WaiterLatch {
+    pub data: Arc<Mutex<(bool, Vec<(usize, Fiber)>, Ptr)>>,
+}
+
+impl WaiterLatch {
+    pub fn new() -> WaiterLatch {
+        let r = WaiterLatch {
+            data: Arc::new(Mutex::new((false, Vec::new(), Ptr(0)))),
+        };
+        let id = &*r.data as *const _ as usize;
+        fiber_log!("starting latch {:x}", id);
+        #[cfg(feature = "debug")]
+        WAITER_LATCHES.lock().insert(id, r.data.clone());
+        r
+    }
+
+    pub fn start(&self) {
+        self.data.lock().2 = Ptr(self as *const _ as usize);
+    }
+}
+
+impl Drop for WaiterLatch {
+    fn drop(&mut self) {
+        let id = &*self.data as *const _ as usize;
+        fiber_log!("dropping latch {:x}", id);
+        #[cfg(feature = "debug")]
+        WAITER_LATCHES.lock().remove(&id);
+    }
+}
+
+impl LatchProbe for WaiterLatch {
+    #[inline]
+    fn probe(&self) -> bool {
+        self.data.lock().0
+    }
+}
+
+impl Latch for WaiterLatch {
+    fn set(&self) {
+        let mut data = self.data.lock();
+        debug_assert!(!data.0);
+        data.0 = true;
+        for (worker_index, fiber) in data.1.drain(..) {
+            fiber_log!("resuming fiber {} (worker {}) from latch {:x}", fiber, worker_index, self as *const _ as usize);
+            let registry = Registry::current();
+            registry.resume_fiber(worker_index, fiber);
+        }
+    }
+}
+
+impl Waitable for WaiterLatch {
+    fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+        self.probe()
+    }
+
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+        let mut data = self.data.lock();
+        if data.0 {
+            #[cfg(feature = "debug")]
+            {
+                *waiter.1.status.lock() = FiberStatus::OnQueue(worker_thread.index());
+            }
+            fiber_log!("resuming fiber {} (worker {}) because it tried to await on a complete latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+            worker_thread.registry.resume_fiber(worker_thread.index(), waiter);
+        } else {
+            #[cfg(feature = "debug")]
+            {
+                *waiter.1.status.lock() = FiberStatus::WaitingOnLatch(Ptr(self as *const _ as _));
+            }
+            fiber_log!("fiber {} (worker {}) is waiting on latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+            data.1.push((worker_thread.index(), waiter));
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref FIBERS: Mutex<HashMap<FiberId, Arc<FiberInfo>>> = {
+        Mutex::new(HashMap::new())
+    };
+    pub static ref LATCHES: Mutex<HashMap<usize, Arc<Mutex<(bool, Option<(usize, Fiber)>, Ptr)>>>> = {
+        Mutex::new(HashMap::new())
+    };
+    pub static ref COUNT_LATCHES: Mutex<HashMap<usize, Arc<Mutex<(usize, Option<(usize, Fiber)>)>>>> = {
+        Mutex::new(HashMap::new())
+    };
+    pub static ref WAITER_LATCHES: Mutex<HashMap<usize, Arc<Mutex<(bool, Vec<(usize, Fiber)>, Ptr)>>>> = {
+        Mutex::new(HashMap::new())
+    };
+}
+
+pub fn ctrlc() {
+    debug_log!("------ fibers ------");
+    for (&id, data) in &*FIBERS.lock() {
+        debug_log!("fiber {:?}", id);
+        debug_log!("   status {:?}", *data.status.lock());
+        debug_log!("   action: {:?}", *data.action.lock());
+        debug_log!("   stack_low: {:?}", *data.stack_low.lock());
+        debug_log!("   stack_high: {:?}", *data.stack_high.lock());
+    }
+    debug_log!("------ end fibers ------");
+    debug_log!("------ latches ------");
+    for (&id, data) in &*LATCHES.lock() {
+        debug_log!("latch {:x}, info {:?}", id, *data);
+    }
+    for (&id, data) in &*WAITER_LATCHES.lock() {
+        debug_log!("waiter latch {:x}, info {:?}", id, *data);
+    }
+    for (&id, data) in &*COUNT_LATCHES.lock() {
+        debug_log!("count latch {:x}, info {:?}", id, *data);
+    }
+    for (&id, data) in &*LATCHES.lock() {
+        debug_log!("deref latch {:x}", id);
+        unsafe { ptr::read_volatile((data.lock().2).0 as *const bool); }
+    }
+    debug_log!("------ end latches ------");
+}

--- a/rayon-core/src/fiber/debug.rs
+++ b/rayon-core/src/fiber/debug.rs
@@ -107,7 +107,7 @@ impl Waitable for SingleWaiterLatch {
         self.probe()
     }
 
-    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, _tlv: usize) {
         let mut data = self.data.lock();
         if data.0 {
             #[cfg(feature = "debug")]
@@ -183,7 +183,7 @@ impl Waitable for WaiterLatch {
         self.probe()
     }
 
-    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, _tlv: usize) {
         let mut data = self.data.lock();
         if data.0 {
             #[cfg(feature = "debug")]
@@ -218,7 +218,7 @@ lazy_static! {
     };
 }
 
-pub fn ctrlc() {
+pub fn debug_print_state() {
     debug_log!("------ fibers ------");
     for (&id, data) in &*FIBERS.lock() {
         debug_log!("fiber {:?}", id);

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -191,7 +191,7 @@ mod normal {
                     _ => panic!(),
                 }
             }
-            Registry::current().sleep.tickle(usize::MAX);
+            Registry::current().signal();
         }
     }
 
@@ -336,7 +336,7 @@ impl Latch for SingleWaiterCountLatch {
                 Registry::current().resume_fiber(worker_index, fiber);
             }
         }
-        Registry::current().sleep.tickle(usize::MAX);
+        Registry::current().signal();
     }
 }
 

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -200,14 +200,6 @@ mod normal {
             self.probe()
         }
 
-        fn can_deadlock(&self) -> bool {
-            true
-        }
-
-        fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
-            panic!();
-        }
-
         fn await(&self, worker_thread: &WorkerThread, mut waiter: Fiber, _tlv: usize) {
             loop {
                 match self.state.load(Ordering::SeqCst) {
@@ -270,14 +262,6 @@ mod normal {
     impl Waitable for WaiterLatch {
         fn complete(&self, _worker_thread: &WorkerThread) -> bool {
             self.probe()
-        }
-
-        fn can_deadlock(&self) -> bool {
-            true
-        }
-
-        fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
-            panic!();
         }
 
         fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, _tlv: usize) {
@@ -361,14 +345,6 @@ impl Waitable for SingleWaiterCountLatch {
         self.probe()
     }
 
-    fn can_deadlock(&self) -> bool {
-        true
-    }
-
-    fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
-        panic!();
-    }
-
     fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, _tlv: usize) {
         let mut data = self.data.lock();
         if data.0 > 0 {
@@ -431,8 +407,6 @@ impl Drop for Fiber {
 }
 
 pub trait Waitable {
-    fn can_deadlock(&self) -> bool;
-    fn handle_deadlock(&self, worker_thread: &WorkerThread) -> !;
     fn complete(&self, worker_thread: &WorkerThread) -> bool;
     fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, tlv: usize);
 }

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -507,11 +507,11 @@ pub struct WinFiber(winapi::PVOID);
 
 #[cfg(windows)]
 impl WinFiber {
-    #[cfg(debug)]
+    #[cfg(feature = "debug")]
     fn top(&self) -> *const () { 0i32 as _ }
-    #[cfg(debug)]
+    #[cfg(feature = "debug")]
     fn bottom(&self) -> *const () { 0i32 as _ }
-    #[cfg(debug)]
+    #[cfg(feature = "debug")]
     fn poison(&self) { }
 
     fn new(stack_size: usize) -> Option<Self> {

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -27,7 +27,7 @@ use winapi;
 use std::io;
 
 #[cfg(feature = "debug")]
-pub use self::debug::ctrlc;
+pub use self::debug::debug_print_state;
 
 #[cfg(feature = "debug")]
 pub use self::debug::{SingleWaiterLatch, WaiterLatch};
@@ -139,6 +139,7 @@ impl<T> UnsafeOption<T> {
 unsafe impl<T> Send for UnsafeOption<T> {}
 unsafe impl<T> Sync for UnsafeOption<T> {}
 
+#[cfg(not(feature = "debug"))]
 mod normal {
     use super::*;
 
@@ -283,7 +284,6 @@ mod normal {
             }
         }
     }
-
 }
 
 #[derive(Debug)]

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -482,8 +482,11 @@ pub struct WinFiber(winapi::PVOID);
 
 #[cfg(windows)]
 impl WinFiber {
+    #[cfg(debug)]
     fn top(&self) -> *const () { 0i32 as _ }
+    #[cfg(debug)]
     fn bottom(&self) -> *const () { 0i32 as _ }
+    #[cfg(debug)]
     fn poison(&self) { }
 
     fn new(stack_size: usize) -> Option<Self> {

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -201,7 +201,7 @@ mod normal {
         }
 
         fn can_deadlock(&self) -> bool {
-            false
+            true
         }
 
         fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
@@ -273,7 +273,7 @@ mod normal {
         }
 
         fn can_deadlock(&self) -> bool {
-            false
+            true
         }
 
         fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
@@ -362,7 +362,7 @@ impl Waitable for SingleWaiterCountLatch {
     }
 
     fn can_deadlock(&self) -> bool {
-        false
+        true
     }
 
     fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {

--- a/rayon-core/src/fiber/mod.rs
+++ b/rayon-core/src/fiber/mod.rs
@@ -1,0 +1,671 @@
+
+#[cfg(not(windows))]
+use context::{Context, Transfer};
+#[cfg(not(windows))]
+use context::stack::{ProtectedFixedSizeStack};
+use std::mem::{self, ManuallyDrop};
+use std::ptr;
+use std::usize;
+#[cfg(not(windows))]
+use std::intrinsics;
+use std::fmt;
+#[cfg(feature = "debug")]
+use std::fmt::Display;
+use job::JobRef;
+use registry::WorkerThread;
+use latch::{Latch, LatchProbe};
+use registry::Registry;
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use parking_lot::Mutex;
+#[cfg(windows)]
+use kernel32;
+#[cfg(windows)]
+use winapi;
+#[cfg(windows)]
+use std::io;
+
+#[cfg(feature = "debug")]
+pub use self::debug::ctrlc;
+
+#[cfg(feature = "debug")]
+pub use self::debug::{SingleWaiterLatch, WaiterLatch};
+#[cfg(not(feature = "debug"))]
+pub use self::normal::{SingleWaiterLatch, WaiterLatch};
+
+#[cfg(feature = "debug")]
+mod debug;
+
+#[cfg(feature = "debug")]
+pub use self::debug::{FiberStatus, FiberInfo, FiberId, FiberAction, COUNT_LATCHES, LATCHES, FIBERS};
+
+#[cfg(feature = "tlv")]
+pub mod tlv {
+    use std::cell::Cell;
+
+    thread_local!(pub(crate) static TLV: Cell<usize> = Cell::new(0));
+
+    pub fn set<F: FnOnce() -> R, R>(value: usize, f: F) -> R {
+        struct Reset(usize);
+        impl Drop for Reset {
+            fn drop(&mut self) {
+                TLV.with(|tlv| tlv.set(self.0));
+            }
+        }
+        let _reset = Reset(get());
+        TLV.with(|tlv| tlv.set(value));
+        f()
+    }
+
+    pub fn get() -> usize {
+        TLV.with(|tlv| tlv.get())
+    }
+}
+
+#[cfg(windows)]
+extern {
+    fn __rayon_core_get_current_fiber() -> usize;
+}
+
+#[derive(Debug)]
+pub struct UnsafeOption<T> {
+    #[cfg(debug_assertions)]
+    there: bool,
+    val: ManuallyDrop<UnsafeCell<T>>,
+}
+
+impl<T> UnsafeOption<T> {
+    fn none() -> Self {
+        UnsafeOption {
+            #[cfg(debug_assertions)]
+            there: false,
+            val: unsafe {
+                ManuallyDrop::new(UnsafeCell::new(mem::uninitialized()))
+            },
+        }
+    }
+
+    fn take(&self) -> T {
+        unsafe {
+            #[cfg(debug_assertions)]
+            {
+                assert!(self.there);
+                ptr::write(&self.there as *const _ as *mut _, false);
+            }
+
+            ptr::read(self.val.get())
+        }
+    }
+
+    fn give(&self, t: T) {
+        unsafe {
+            #[cfg(debug_assertions)]
+            {
+                assert!(!self.there);
+                ptr::write(&self.there as *const _ as *mut _, true);
+            }
+
+            ptr::write(self.val.get(), t);
+        }
+    }
+}
+
+unsafe impl<T> Send for UnsafeOption<T> {}
+unsafe impl<T> Sync for UnsafeOption<T> {}
+
+mod normal {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct SingleWaiterLatch {
+        // 0 - incomplete
+        // 1 - incomplete with fiber
+        // 2 - complete
+        state: AtomicUsize,
+        waiter: UnsafeOption<(usize, Fiber)>,
+    }
+
+    impl SingleWaiterLatch {
+        pub fn new() -> SingleWaiterLatch {
+            SingleWaiterLatch {
+                state: AtomicUsize::new(0),
+                waiter: UnsafeOption::none(),
+            }
+        }
+
+        pub fn start(&self) {}
+    }
+
+    impl LatchProbe for SingleWaiterLatch {
+        #[inline]
+        fn probe(&self) -> bool {
+            self.state.load(Ordering::SeqCst) == 2
+        }
+    }
+
+    impl Latch for SingleWaiterLatch {
+        fn set(&self) {
+            loop {
+                match self.state.load(Ordering::SeqCst) {
+                    0 => {
+                        let result = self.state.compare_exchange_weak(0,
+                                                                    2,
+                                                                    Ordering::SeqCst,
+                                                                    Ordering::SeqCst);
+                        if result.is_ok() {
+                            break;
+                        }
+                    }
+                    1 => {
+                        self.state.store(2, Ordering::SeqCst);
+                        let (worker_index, fiber) = self.waiter.take();
+                        Registry::current().resume_fiber(worker_index, fiber);
+                        break;
+                    }
+                    _ => panic!(),
+                }
+            }
+            Registry::current().sleep.tickle(usize::MAX);
+        }
+    }
+
+    impl Waitable for SingleWaiterLatch {
+        fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+            self.probe()
+        }
+
+        fn await(&self, worker_thread: &WorkerThread, mut waiter: Fiber) {
+            loop {
+                match self.state.load(Ordering::SeqCst) {
+                    0 => {
+                        self.waiter.give((worker_thread.index(), waiter));
+                        let result = self.state.compare_exchange(0,
+                                                                1,
+                                                                Ordering::SeqCst,
+                                                                Ordering::SeqCst);
+                        if result.is_err() {
+                            waiter = self.waiter.take().1;
+                            break;
+                        }
+
+                        return;
+                    }
+                    2 => break,
+                    _ => panic!(),
+                }
+            }
+            // The latch was already set, so just immediately add the waiter back to the work list
+            worker_thread.registry.resume_fiber(worker_thread.index(), waiter);
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct WaiterLatch {
+        pub data: Mutex<(bool, Vec<(usize, Fiber)>)>,
+    }
+
+    impl WaiterLatch {
+        pub fn new() -> WaiterLatch {
+            WaiterLatch {
+                data: Mutex::new((false, Vec::new())),
+            }
+        }
+        pub fn start(&self) {}
+    }
+
+    impl LatchProbe for WaiterLatch {
+        #[inline]
+        fn probe(&self) -> bool {
+            self.data.lock().0
+        }
+    }
+
+    impl Latch for WaiterLatch {
+        fn set(&self) {
+            let mut data = self.data.lock();
+            debug_assert!(!data.0);
+            data.0 = true;
+            for (worker_index, fiber) in data.1.drain(..) {
+                fiber_log!("resuming fiber {} (worker {}) from latch {:x}", fiber, worker_index, self as *const _ as usize);
+                let registry = Registry::current();
+                registry.resume_fiber(worker_index, fiber);
+            }
+        }
+    }
+
+    impl Waitable for WaiterLatch {
+        fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+            self.probe()
+        }
+
+        fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+            let mut data = self.data.lock();
+            if data.0 {
+                #[cfg(feature = "debug")]
+                {
+                    *waiter.1.status.lock() = FiberStatus::OnQueue(worker_thread.index());
+                }
+                fiber_log!("resuming fiber {} (worker {}) because it tried to await on a complete latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+                worker_thread.registry.resume_fiber(worker_thread.index(), waiter);
+            } else {
+                #[cfg(feature = "debug")]
+                {
+                    *waiter.1.status.lock() = FiberStatus::WaitingOnLatch(Ptr(self as *const _ as _));
+                }
+                fiber_log!("fiber {} (worker {}) is waiting on latch {:x}", waiter, worker_thread.index(), self as *const _ as usize);
+                data.1.push((worker_thread.index(), waiter));
+            }
+        }
+    }
+
+}
+
+#[derive(Debug)]
+pub struct SingleWaiterCountLatch {
+    pub data: Arc<Mutex<(usize, Option<(usize, Fiber)>)>>,
+}
+
+impl SingleWaiterCountLatch {
+    pub fn new() -> SingleWaiterCountLatch {
+        let r = SingleWaiterCountLatch {
+            data: Arc::new(Mutex::new((1, None))),
+        };
+        let _id = &*r.data as *const _ as usize;
+        fiber_log!("starting latch {:x}", _id);
+        #[cfg(feature = "debug")]
+        debug::COUNT_LATCHES.lock().insert(_id, r.data.clone());
+        r
+    }
+
+    pub fn increment(&self) {
+        let mut data = self.data.lock();
+        debug_assert!(data.0 > 0);
+        data.0 += 1;
+    }
+}
+
+impl Drop for SingleWaiterCountLatch {
+    fn drop(&mut self) {
+        let _id = &*self.data as *const _ as usize;
+        fiber_log!("dropping count latch {:x}", _id);
+        #[cfg(feature = "debug")]
+        debug::COUNT_LATCHES.lock().remove(&_id);
+    }
+}
+
+impl LatchProbe for SingleWaiterCountLatch {
+    #[inline]
+    fn probe(&self) -> bool {
+        self.data.lock().0 == 0
+    }
+}
+
+impl Latch for SingleWaiterCountLatch {
+    fn set(&self) {
+        let mut data = self.data.lock();
+        debug_assert!(data.0 > 0);
+        data.0 -= 1;
+        if data.0 == 0 {
+            if let Some((worker_index, fiber)) = data.1.take() {
+                Registry::current().resume_fiber(worker_index, fiber);
+            }
+        }
+        Registry::current().sleep.tickle(usize::MAX);
+    }
+}
+
+impl Waitable for SingleWaiterCountLatch {
+    fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+        self.probe()
+    }
+
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+        let mut data = self.data.lock();
+        if data.0 > 0 {
+            data.1 = Some((worker_thread.index(), waiter));
+        } else {
+            worker_thread.registry.resume_fiber(worker_thread.index(), waiter);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub struct Ptr(pub usize);
+
+impl fmt::Display for Ptr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Debug for Ptr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+#[cfg(feature = "debug")]
+use self::debug::FiberInfoType;
+#[cfg(not(feature = "debug"))]
+type FiberInfoType = ();
+
+#[cfg(not(windows))]
+pub type FiberStack = ProtectedFixedSizeStack;
+#[cfg(not(windows))]
+type FiberContext = Context;
+
+#[cfg(windows)]
+pub type FiberStack = WinFiber;
+#[cfg(windows)]
+type FiberContext = usize;
+
+#[must_use]
+#[derive(Debug)]
+pub struct Fiber(FiberContext, FiberInfoType);
+
+#[cfg(feature = "debug")]
+impl Display for Fiber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use fmt::Debug;
+        self.1.id.fmt(f)
+    }
+}
+
+#[cfg(feature = "debug")]
+static FIBER_ID: AtomicUsize = AtomicUsize::new(1);
+
+impl Drop for Fiber {
+    fn drop(&mut self) {
+        panic!("Dropped a fiber");
+    }
+}
+
+pub trait Waitable {
+    fn complete(&self, worker_thread: &WorkerThread) -> bool;
+    fn await(&self, worker_thread: &WorkerThread, waiter: Fiber);
+}
+
+pub enum ResumeAction {
+    StoreInWaitable(*const Waitable),
+    FreeStack(FiberStack),
+}
+
+impl ResumeAction {
+    fn run(self, worker_thread: &WorkerThread, fiber: Fiber) {
+        match self {
+            ResumeAction::StoreInWaitable(waitable) => {
+                unsafe { (*waitable).await(worker_thread, fiber) }
+            }
+            ResumeAction::FreeStack(stack) => {
+                #[cfg(feature = "debug")]
+                {
+                    stack.poison();
+                    let mut list = worker_thread.poisoned_stacks.borrow_mut();
+                    if list.len() > 0x100 {
+                        fiber_log!("| too many stacks |");
+                        list.pop_front();
+                    }
+                    fiber_log!("done using stack {:x} - {:x}", stack.bottom()as usize, stack.top() as usize);
+                    list.push_back(stack);
+                }
+
+                #[cfg(not(feature = "debug"))]
+                worker_thread.stack_cache.borrow_mut().push(stack);
+
+                mem::forget(fiber);
+            },
+        }
+    }
+}
+
+struct FiberData {
+    stack: FiberStack,
+    job: JobRef,
+    action: ResumeAction,
+    #[cfg(windows)]
+    context: FiberContext,
+}
+
+fn run_fiber(data: FiberData, context: FiberContext, worker: &WorkerThread) -> TransferInfo {
+    unsafe {
+        #[cfg(feature = "debug")]
+        worker.registry.active_fibers.fetch_add(1, Ordering::SeqCst);
+
+        #[cfg(feature = "debug")]
+        let _self_data = worker.current_fiber.borrow().0.clone().unwrap();
+        #[cfg(feature = "debug")]
+        let old_data = worker.current_fiber.borrow().1.clone().unwrap();
+        #[cfg(not(feature = "debug"))]
+        let old_data = ();
+
+        #[cfg(feature = "debug")]
+        #[cfg(windows)] {
+            let mut stack_low = 0;
+            let mut stack_high = 0;
+            ::kernel32::GetCurrentThreadStackLimits(&mut stack_low, &mut stack_high);
+            *_self_data.stack_low.lock() = Ptr(stack_low as usize);
+            *_self_data.stack_high.lock() = Ptr(stack_high as usize);
+        }
+
+        #[cfg(feature = "debug")]
+        FIBERS.lock().insert(_self_data.id, _self_data.clone());
+
+        fiber_log!("fiber starting");
+        data.action.run(worker, Fiber(context, old_data));
+        data.job.execute();
+        let stack = data.stack;
+
+        #[cfg(feature = "debug")]
+        FIBERS.lock().remove(&_self_data.id);
+
+        fiber_log!("fiber complete");
+
+        #[cfg(feature = "debug")]
+        worker.registry.active_fibers.fetch_sub(1, Ordering::SeqCst);
+
+        worker.find_work(ResumeAction::FreeStack(stack))
+    }
+}
+
+#[cfg(not(windows))]
+extern "C" fn context_function(t: Transfer) -> ! {
+    unsafe {
+        let worker = &*WorkerThread::current();
+        run_fiber(ptr::read(t.data as *mut FiberData), t.context, worker);
+        intrinsics::abort();
+    }
+}
+
+#[cfg(windows)]
+pub struct WinFiber(winapi::PVOID);
+
+#[cfg(windows)]
+impl WinFiber {
+    fn top(&self) -> *const () { 0i32 as _ }
+    fn bottom(&self) -> *const () { 0i32 as _ }
+    fn poison(&self) { }
+
+    fn new(stack_size: usize) -> Option<Self> {
+        unsafe {
+            let fiber = kernel32::CreateFiberEx(0x1000,
+                stack_size as _,
+                0,
+                Some(fiber_proc),
+                0i32 as _);
+            if fiber == 0i32 as _ {
+                panic!("unable to allocate fiber {}", io::Error::last_os_error());
+            }
+            Some(WinFiber(fiber))
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WinFiber {
+    fn drop(&mut self) {
+        unsafe {
+            kernel32::DeleteFiber(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn fiber_proc(_: winapi::LPVOID) {
+    // Ensure that we have a guard page. the fiber API doesn't not guarantee this
+    #[cfg(debug_assertions)] {
+        let mut stack_low = 0;
+        let mut stack_high = 0;
+        kernel32::GetCurrentThreadStackLimits(&mut stack_low, &mut stack_high);
+        let mut mbi = mem::zeroed();
+        if kernel32::VirtualQuery(stack_low as _, &mut mbi, 0x1000) != 0 {
+            assert!(mbi.State == winapi::MEM_RESERVE);
+        }
+    }
+
+    let worker = &*WorkerThread::current();
+    loop {
+        let data = NEW_FIBER_DATA.with(|fiber_data| fiber_data.take());
+        let data = ptr::read(data as *mut FiberData);
+        let context = data.context;
+        // No-one will resume us without creating a new fiber, forget the transfer information
+        mem::forget(run_fiber(data, context, worker));
+    }
+}
+
+#[cfg(windows)]
+thread_local! {
+    static RESUME_INFO: UnsafeOption<(*mut ResumeAction, FiberContext)> = UnsafeOption::none();
+    static NEW_FIBER_DATA: UnsafeOption<*mut FiberData> = UnsafeOption::none();
+}
+
+pub struct TransferInfo {
+    #[cfg(not(windows))]
+    old_context: Context,
+    #[cfg(not(windows))]
+    pending_action: usize,
+}
+
+impl TransferInfo {
+    pub fn handle(self, worker: &WorkerThread) {
+        unsafe {
+            #[cfg(not(windows))]
+            let (pending_action, old_context) = (self.pending_action, ptr::read(&self.old_context));
+            #[cfg(windows)]
+            let (pending_action, old_context) = RESUME_INFO.with(|resume_info| resume_info.take());
+
+            #[cfg(feature = "debug")]
+            let data = worker.current_fiber.borrow().1.clone().unwrap();
+            #[cfg(not(feature = "debug"))]
+            let data = ();
+
+            ptr::read(pending_action as *mut ResumeAction).run(worker, Fiber(old_context, data));
+        }
+        mem::forget(self);
+    }
+}
+
+impl Drop for TransferInfo {
+    fn drop(&mut self) {
+        panic!("Dropped TransferInfo");
+    }
+}
+
+impl Fiber {
+    #[cfg(not(windows))]
+    fn to_context(self) -> Context {
+        let r = unsafe { ptr::read(&self.0) };
+        mem::forget(self);
+        r
+    }
+
+    pub fn resume(self, _worker: &WorkerThread, mut action: ResumeAction) -> TransferInfo {
+        #[cfg(feature = "tlv")]
+        let saved_tlv = tlv::get();
+        #[cfg(feature = "debug")]
+        {
+            *self.1.status.lock() = FiberStatus::Resumed;
+            fiber_log!("resuming fiber {} and suspending {:?}", self, _worker.current_fiber.borrow().0.as_ref().unwrap().id);
+            let new = (Some(self.1.clone()), _worker.current_fiber.borrow().0.clone());
+            *_worker.current_fiber.borrow_mut() = new;
+        }
+        let result = {
+            #[cfg(windows)]
+            unsafe {
+                RESUME_INFO.with(|resume_info| {
+                    resume_info.give((&mut action, __rayon_core_get_current_fiber()));
+                });
+                kernel32::SwitchToFiber(self.0 as _);
+                mem::forget(self);
+                TransferInfo {}
+            }
+            #[cfg(not(windows))]
+            unsafe {
+                let t = self.to_context().resume(&mut action as *mut _ as usize);
+                TransferInfo {
+                    pending_action: t.data,
+                    old_context: t.context
+                }
+            }
+        };
+        mem::forget(action);
+        #[cfg(feature = "tlv")]
+        tlv::TLV.with(|tlv| tlv.set(saved_tlv));
+        result
+    }
+
+    pub fn spawn(worker_thread: &WorkerThread, job: JobRef, action: ResumeAction) -> TransferInfo {
+        let stack = {
+            let mut cache = worker_thread.stack_cache.borrow_mut();
+            if let Some(stack) = cache.pop() {
+                stack
+            } else {
+                let stack_size = worker_thread.registry.stack_size;
+                for _i in 0..20 {
+                    cache.push(FiberStack::new(stack_size).unwrap());
+                }
+                FiberStack::new(stack_size).unwrap()
+            }
+        };
+
+        let mut data = FiberData {
+            stack,
+            job,
+            action,
+            #[cfg(windows)]
+            context: unsafe { __rayon_core_get_current_fiber() },
+        };
+
+        #[cfg(feature = "debug")]
+        {
+            fiber_log!("using stack {:x} - {:x}", data.stack.bottom() as usize, data.stack.top() as usize);
+            let new_id = FIBER_ID.fetch_add(1, Ordering::SeqCst);
+            let fiber_data = Arc::new(FiberInfo::new(FiberId::Job(new_id), data.stack.bottom() as usize, data.stack.top() as usize));
+            let new = (Some(fiber_data), worker_thread.current_fiber.borrow().0.clone());
+            *worker_thread.current_fiber.borrow_mut() = new;
+        }
+
+        let result = unsafe {
+            #[cfg(windows)]
+            {
+                NEW_FIBER_DATA.with(|new_fiber_data| {
+                    new_fiber_data.give(&mut data as *mut _);
+                });
+                kernel32::SwitchToFiber(data.stack.0);
+                TransferInfo {}
+            }
+
+            #[cfg(not(windows))]
+            {
+                let context = Context::new(&data.stack, context_function);
+                let t = context.resume(&mut data as *mut _ as usize);
+                TransferInfo {
+                    pending_action: t.data,
+                    old_context: t.context
+                }
+            }
+        };
+        mem::forget(data);
+        result
+    }
+}

--- a/rayon-core/src/fiber/windows.c
+++ b/rayon-core/src/fiber/windows.c
@@ -1,0 +1,5 @@
+#include <windows.h>
+
+PVOID __rayon_core_get_current_fiber() {
+    return GetCurrentFiber();
+}

--- a/rayon-core/src/fork/mod.rs
+++ b/rayon-core/src/fork/mod.rs
@@ -1,0 +1,281 @@
+use registry::{self, WorkerThread};
+#[cfg(feature = "tlv")]
+use fiber::tlv;
+use fiber::SingleWaiterLatch;
+use job::{Job, JobRef};
+use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
+use std::iter;
+use latch::Latch;
+
+#[repr(align(64))]
+#[derive(Debug)]
+struct CacheAligned<T>(T);
+/*
+#[derive(Debug)]
+struct Slice {
+    start: usize,
+    len: AtomicIsize, // Limit this to 31 bits to allow underflow when stealing
+}
+
+impl Slice {
+    fn new(start: usize, len: usize) -> Self {
+        Slice {
+            start,
+            len: AtomicIsize::new(len as isize),
+        }
+    }
+
+    fn take(&self) -> Option<usize> {
+        loop {
+            let old_len = self.len.fetch_sub(1, Ordering::SeqCst);
+            if old_len <= 0 {
+                self.len.fetch_add(1, Ordering::SeqCst);
+                return None;
+            }
+            return Some(self.start + (old_len as usize) - 1);
+        }
+    }
+
+    fn take2(&self) -> Option<usize> {
+        loop {
+            let current = self.len.load(Ordering::SeqCst);
+            if current == 0 {
+                return None;
+            }
+            let result = self.len.compare_exchange_weak(current,
+                                                        current - 1,
+                                                        Ordering::SeqCst,
+                                                        Ordering::SeqCst);
+            if result.is_ok() {
+                return Some(self.start + (current as usize) - 1);
+            }
+        }
+    }
+
+    fn steal(&self) -> Option<usize> {
+        loop {
+            let current = self.len.load(Ordering::SeqCst);
+            if current == 0 {
+                return None;
+            }
+            let result = self.len.compare_exchange_weak(current,
+                                                        current - 1,
+                                                        Ordering::SeqCst,
+                                                        Ordering::SeqCst);
+            if result.is_ok() {
+                return Some(self.start + (current as usize) - 1);
+            }
+        }
+    }
+}*/
+
+#[derive(Debug)]
+struct Slice {
+    data: AtomicUsize,
+}
+
+impl Slice {
+    #[inline(always)]
+    fn new(start: usize, len: usize) -> Self {
+        Slice {
+            data: AtomicUsize::new(Slice::encode(start, len)),
+        }
+    }
+
+    #[inline(always)]
+    fn encode(start: usize, len: usize) -> usize {
+        (len as u32 as usize) | ((start as u32 as usize) << 32)
+    }
+
+    #[inline(always)]
+    fn decode(data: usize) -> (usize, usize) {
+        (data >> 32, data as u32 as usize)
+    }
+
+    #[inline]
+    fn take_one(self) -> (usize, Slice) {
+        let (start, len) = Slice::decode(self.data.into_inner());
+        (start + len - 1, Slice { data: AtomicUsize::new(Slice::encode(start, len - 1)) })
+    }
+
+    #[inline]
+    fn take(&self) -> Option<usize> {
+        loop {
+            let data = self.data.load(Ordering::SeqCst);
+            let (old_start, old_len) = Slice::decode(data);
+            if old_len == 0 {
+                return None;
+            }
+            let result = self.data.compare_exchange_weak(data,
+                                                         Slice::encode(old_start, old_len - 1),
+                                                         Ordering::SeqCst,
+                                                         Ordering::SeqCst);
+            if result.is_ok() {
+                return Some(old_start + old_len - 1);
+            }
+        }
+    }
+
+    #[inline]
+    fn steal_half(&self) -> Option<Slice> {
+        loop {
+            let data = self.data.load(Ordering::SeqCst);
+            let (start, mut len) = Slice::decode(data);
+            len = match len {
+                0 => return None,
+                1 => 1,
+                _ => len / 2,
+            };
+            let result = self.data.compare_exchange_weak(data,
+                                                         Slice::encode(start, len),
+                                                         Ordering::SeqCst,
+                                                         Ordering::SeqCst);
+            if result.is_ok() {
+                return Some(Slice { data: AtomicUsize::new(data) });
+            }
+        }
+    }
+
+    #[inline]
+    fn replace(&self, new: Slice) {
+        let new_data = new.data.into_inner();
+        loop {
+            let data = self.data.load(Ordering::SeqCst);
+            assert!(Slice::decode(data).1 == 0);
+            let result = self.data.compare_exchange_weak(data,
+                                                         new_data,
+                                                         Ordering::SeqCst,
+                                                         Ordering::SeqCst);
+            if result.is_ok() {
+                return;
+            }
+        }
+    }
+}
+
+struct ForkData<F: Fn(usize) + Send> {
+    ref_count: CacheAligned<AtomicUsize>,
+    active: CacheAligned<AtomicUsize>,
+    slices: Vec<CacheAligned<Slice>>,
+    f: F,
+    complete: SingleWaiterLatch,
+    #[cfg(feature = "tlv")]
+    tlv: usize,
+}
+
+impl<F: Fn(usize) + Send> ForkData<F> {
+    pub unsafe fn as_job_ref(this: *const Self) -> JobRef {
+        JobRef::new(this)
+    }
+
+    unsafe fn decr(&self) {
+        if self.ref_count.0.fetch_sub(1, Ordering::SeqCst) == 0 {
+            // Destroy the data if we are the last reference
+            Box::from_raw(self as *const Self as *mut Self);
+        }
+    }
+
+    fn steal(&self, worker: &WorkerThread) -> Option<usize> {
+        let worker_idx = worker.index();
+        if let Some(v) = self.slices[worker_idx].0.take() {
+            return Some(v);
+        }
+
+        for (i, slice) in self.slices.iter().enumerate() {
+            if i == worker_idx {
+                continue;
+            }
+
+            if let Some(s) = slice.0.take() {
+                /*let (r, s) = s.take_one();
+                self.slices[worker_idx].0.replace(s);*/
+                return Some(s);
+            }
+        }
+
+        None
+    }
+
+    fn iter(&self, i: usize) {
+        //println!("process {}", i);
+        (self.f)(i);
+    }
+
+    fn process(&self, worker: &WorkerThread, first: usize) {
+        let _s = self.active.0.fetch_add(1, Ordering::SeqCst);
+        //println!("worker start {}", _s);
+
+        self.iter(first);
+
+        while let Some(i) = self.steal(worker) {
+            self.iter(i);
+        }
+        let r = self.active.0.fetch_sub(1, Ordering::SeqCst);
+        //println!("worker done {}", r);
+        if r == 1 {
+            // There was no more work to steal and we are the last active worker
+            //println!("set!");
+            self.complete.set();
+        }
+    }
+}
+
+impl<F: Fn(usize) + Send> Job for ForkData<F> {
+    unsafe fn execute(this: *const Self) {
+        let this = &*this;
+        #[cfg(feature = "tlv")]
+        tlv::TLV.with(|tlv| tlv.set(this.tlv));
+
+        let worker = &*WorkerThread::current();
+    
+        if let Some(first) = this.steal(worker) {
+            //println!("started worker");
+            worker.push(ForkData::as_job_ref(this));
+
+            this.process(worker, first);
+        } else {
+            //println!("dummy");
+            this.decr();
+        }
+    }
+}
+
+pub fn fork<F: Fn(usize) + Send>(n: usize, f: F)
+{
+    registry::in_worker(|worker_thread, injected| unsafe {
+        // FIXME: Fallback to regular Rayon iterators when `n` is too large
+        let threads = worker_thread.registry.num_threads();
+
+        let i_per_thread = n / threads;
+        let last_thread = i_per_thread + n % threads;
+
+        let data = Box::into_raw(Box::new(ForkData {
+            ref_count: CacheAligned(AtomicUsize::new(threads + 1)),
+            active: CacheAligned(AtomicUsize::new(0)),
+            slices: iter::once(CacheAligned(Slice::new(0, last_thread)))
+              .chain((0..(threads - 1)).map(|i| {
+                CacheAligned(Slice::new(last_thread + i * i_per_thread, i_per_thread))
+            })).collect(),
+            complete: SingleWaiterLatch::new(),
+            f,
+            #[cfg(feature = "tlv")]
+            tlv: tlv::get(),
+        }));
+
+        //println!("slices: {:?}", (*data).slices);
+
+        for _ in 0..threads {
+            worker_thread.worker.push(ForkData::as_job_ref(data));
+        }
+        worker_thread.registry.signal();
+
+        //(*data).process();
+
+        // Wait for things to complete
+        worker_thread.wait_until(&(*data).complete);
+
+        //println!("fork end");
+
+        (*data).decr();
+    })
+}

--- a/rayon-core/src/internal/worker.rs
+++ b/rayon-core/src/internal/worker.rs
@@ -7,33 +7,6 @@ pub struct WorkerThread<'w> {
     thread: &'w registry::WorkerThread
 }
 
-impl<'w> WorkerThread<'w> {
-    /// Causes the worker thread to wait until `f()` returns true.
-    /// While the thread is waiting, it will attempt to steal work
-    /// from other threads, and may go to sleep if there is no work to
-    /// steal.
-    ///
-    /// **Dead-lock warning: This is a low-level interface and cannot
-    /// be used to wait on arbitrary conditions.** In particular, if
-    /// the Rayon thread goes to sleep, it will only be awoken when
-    /// new rayon events occur (e.g., `spawn()` or `join()` is
-    /// invoked, or one of the methods on a `ScopeHandle`). Therefore,
-    /// you must ensure that, once the condition `f()` becomes true,
-    /// some "rayon event" will also occur to ensure that waiting
-    /// threads are awoken.
-    pub unsafe fn wait_until_true<F>(&self, f: F) where F: Fn() -> bool {
-        struct DummyLatch<'a, F: 'a> { f: &'a F }
-
-        impl<'a, F: Fn() -> bool> LatchProbe for DummyLatch<'a, F> {
-            fn probe(&self) -> bool {
-                (self.f)()
-            }
-        }
-
-        self.thread.wait_until(&DummyLatch { f: &f });
-    }
-}
-
 impl<'w> fmt::Debug for WorkerThread<'w> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("WorkerThread")

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -126,14 +126,6 @@ pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
                             panic!()
                         }
 
-                        fn can_deadlock(&self) -> bool {
-                            true
-                        }
-
-                        fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {
-                            panic!();
-                        }
-
                         fn await(&self, worker_thread: &WorkerThread, waiter: Fiber, _tlv: usize) {
                             let worker_index = worker_thread.index();
                             worker_thread.registry.resume_fiber(worker_index, waiter);

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -127,7 +127,7 @@ pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
                         }
 
                         fn can_deadlock(&self) -> bool {
-                            false
+                            true
                         }
 
                         fn handle_deadlock(&self, _worker_thread: &WorkerThread) -> ! {

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -1,11 +1,13 @@
-use latch::{LatchProbe, SpinLatch};
+use latch::{LatchProbe};
 use log::Event::*;
 use job::StackJob;
 use registry::{self, WorkerThread};
-use std::any::Any;
 use unwind;
+use fiber::{Waitable, Fiber, ResumeAction};
 
 use FnContext;
+use fiber::SingleWaiterLatch;
+use PoisonedJob;
 
 #[cfg(test)]
 mod test;
@@ -77,15 +79,27 @@ pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
         // done here so that the stack frame can keep it all live
         // long enough.
         let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)),
-                                  SpinLatch::new());
+                                  SingleWaiterLatch::new());
         let job_b_ref = job_b.as_job_ref();
+        job_b.latch.start();
         worker_thread.push(job_b_ref);
 
         // Execute task a; hopefully b gets stolen in the meantime.
         let status_a = unwind::halt_unwinding(move || oper_a(FnContext::new(injected)));
         let result_a = match status_a {
             Ok(v) => v,
-            Err(err) => join_recover_from_panic(worker_thread, &job_b.latch, err),
+            Err(err) => {
+                // If job A panics, we still cannot return until we are sure that job
+                // B is complete. This is because it may contain references into the
+                // enclosing stack frame(s).
+                worker_thread.wait_until(&job_b.latch);
+                debug_assert!(job_b.latch.probe());
+                if err.is::<PoisonedJob>() {
+                    // Job A was poisoned, so unwind the panic of Job B if it exists
+                    job_b.into_result();
+                }
+                unwind::resume_unwinding(err)
+            },
         };
 
         // Now that task A has finished, try to pop job B from the
@@ -104,9 +118,24 @@ pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
                     return (result_a, result_b);
                 } else {
                     log!(PoppedJob { worker: worker_thread.index() });
-                    worker_thread.execute(job);
+
+                    struct ResumeAgain;
+
+                    impl Waitable for ResumeAgain {
+                        fn complete(&self, _worker_thread: &WorkerThread) -> bool {
+                            panic!()
+                        }
+
+                        fn await(&self, worker_thread: &WorkerThread, waiter: Fiber) {
+                            let worker_index = worker_thread.index();
+                            worker_thread.registry.resume_fiber(worker_index, waiter);
+                        }
+                    }
+
+                    worker_thread.execute(job, ResumeAction::StoreInWaitable(&ResumeAgain));
                 }
             } else {
+                // CHECK: This can steal our job back to this thread
                 // Local deque is empty. Time to steal from other
                 // threads.
                 log!(LostJob { worker: worker_thread.index() });
@@ -118,17 +147,4 @@ pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
 
         return (result_a, job_b.into_result());
     })
-}
-
-/// If job A panics, we still cannot return until we are sure that job
-/// B is complete. This is because it may contain references into the
-/// enclosing stack frame(s).
-#[cold] // cold path
-unsafe fn join_recover_from_panic(worker_thread: &WorkerThread,
-                                  job_b_latch: &SpinLatch,
-                                  err: Box<Any + Send>)
-                                  -> !
-{
-    worker_thread.wait_until(job_b_latch);
-    unwind::resume_unwinding(err)
 }

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -132,6 +132,12 @@ impl CountLatch {
         debug_assert!(!self.probe());
         self.counter.fetch_add(1, Ordering::Relaxed);
     }
+
+    #[inline]
+    pub fn decrement(&self) -> bool {
+        debug_assert!(!self.probe());
+        self.counter.fetch_sub(1, Ordering::SeqCst) - 1 == 0
+    }
 }
 
 impl LatchProbe for CountLatch {

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -70,7 +70,7 @@ impl Latch for SpinLatch {
 
 /// A Latch starts as false and eventually becomes true. You can block
 /// until it becomes true.
-pub struct LockLatch {
+pub struct LockLatch { // FIXME: Use parking_lot
     m: Mutex<bool>,
     v: Condvar,
 }

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, Condvar};
-use std::usize;
+//use std::usize;
 
-use sleep::Sleep;
+//use sleep::Sleep;
 
 /// We define various kinds of latches, which are all a primitive signaling
 /// mechanism. A latch starts as false. Eventually someone calls `set()` and
@@ -156,7 +156,7 @@ impl Latch for CountLatch {
     }
 }
 
-
+/*
 /// A tickling latch wraps another latch type, and will also awaken a thread
 /// pool when it is set.  This is useful for jobs injected between thread pools,
 /// so the source pool can continue processing its own work while waiting.
@@ -186,6 +186,7 @@ impl<'a, L: Latch> Latch for TickleLatch<'a, L> {
     #[inline]
     fn set(&self) {
         self.inner.set();
-        self.sleep.tickle(usize::MAX);
+        self.signal();
     }
 }
+*/

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -45,7 +45,9 @@ extern crate parking_lot;
 extern crate libc;
 extern crate num_cpus;
 extern crate rand;
+#[cfg(feature = "debug")]
 extern crate ctrlc;
+#[cfg(test)]
 extern crate test as bench;
 #[cfg(windows)]
 extern crate kernel32;

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -28,6 +28,9 @@
 #![feature(core_intrinsics)]
 #![feature(test)]
 #![feature(never_type)]
+#![feature(repr_align)] 
+#![feature(attr_literals)]
+#![feature(arbitrary_self_types)]
 
 use std::any::Any;
 use std::env;
@@ -61,6 +64,7 @@ mod log;
 
 pub mod latch;
 mod join;
+mod fork;
 mod job;
 pub mod registry;
 mod scope;
@@ -78,6 +82,7 @@ pub use thread_pool::ThreadPool;
 pub use thread_pool::current_thread_index;
 pub use thread_pool::current_thread_has_pending_tasks;
 pub use join::{join, join_context};
+pub use fork::{fork};
 pub use scope::{scope, Scope};
 pub use spawn::spawn;
 

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -151,7 +151,7 @@ type PanicHandler = Fn(Box<Any + Send>) + Send + Sync;
 /// Note that this same closure may be invoked multiple times in parallel.
 type MainHandler = Fn(usize, &mut FnMut()) + Send + Sync;
 
-type DeadlockHandler = Fn() -> ! + Send + Sync;
+type DeadlockHandler = Fn() + Send + Sync;
 
 /// The type for a closure that gets invoked when a thread starts. The
 /// closure is passed the index of the thread on which it is invoked.
@@ -311,7 +311,7 @@ impl Configuration {
 
     /// Set a callback to be invoked on current deadlock.
     pub fn deadlock_handler<H>(mut self, deadlock_handler: H) -> Configuration
-        where H: Fn() -> ! + Send + Sync + 'static
+        where H: Fn() + Send + Sync + 'static
     {
         self.deadlock_handler = Some(Box::new(deadlock_handler));
         self

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -51,6 +51,7 @@ extern crate test as bench;
 extern crate kernel32;
 #[cfg(windows)]
 extern crate winapi;
+extern crate crossbeam_channel;
 
 #[macro_use]
 mod log;

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -72,12 +72,14 @@ mod sleep;
 mod spawn;
 mod test;
 mod thread_pool;
+mod worker_local;
 mod unwind;
 mod util;
 pub mod fiber;
 
 #[cfg(rayon_unstable)]
 pub mod internal;
+pub use worker_local::WorkerLocal;
 pub use thread_pool::ThreadPool;
 pub use thread_pool::current_thread_index;
 pub use thread_pool::current_thread_has_pending_tasks;

--- a/rayon-core/src/log.rs
+++ b/rayon-core/src/log.rs
@@ -29,11 +29,11 @@ pub enum Event {
     PoppedJob { worker: usize },
     PoppedRhs { worker: usize },
     LostJob { worker: usize },
-    JobCompletedOk { owner_thread: usize },
-    JobPanickedErrorStored { owner_thread: usize },
-    JobPanickedErrorNotStored { owner_thread: usize },
-    ScopeCompletePanicked { owner_thread: usize },
-    ScopeCompleteNoPanic { owner_thread: usize },
+    JobCompletedOk,
+    JobPanickedErrorStored,
+    JobPanickedErrorNotStored,
+    ScopeCompletePanicked,
+    ScopeCompleteNoPanic,
 }
 
 pub const DUMP_LOGS: bool = cfg!(debug_assertions);

--- a/rayon-core/src/log.rs
+++ b/rayon-core/src/log.rs
@@ -42,8 +42,44 @@ lazy_static! {
     pub static ref LOG_ENV: bool = env::var("RAYON_LOG").is_ok() || env::var("RAYON_RS_LOG").is_ok();
 }
 
+#[cfg(feature = "debug")]
+lazy_static! {
+    pub static ref FIBER_LOG_ENV: bool = env::var("RAYON_FIBER_LOG").is_ok();
+}
+
 macro_rules! log {
     ($event:expr) => {
-        if ::log::DUMP_LOGS { if *::log::LOG_ENV { println!("{:?}", $event); } }
+        if ::log::DUMP_LOGS { if *::log::LOG_ENV { debug_log!("{:?}", $event); } }
     }
+}
+
+macro_rules! debug_log {
+    ($($args:tt)*) => {{
+        let str = &format!($($args)*);
+        println!("{}", str);
+        #[cfg(windows)]
+        #[allow(unused_unsafe)]
+        {
+            let str = &format!("{}\n\x00", str)[..];
+            unsafe {
+                ::kernel32::OutputDebugStringA(str as *const str as _);
+            }
+        }
+    }}
+}
+
+macro_rules! fiber_log {
+    ($($args:tt)*) => {{
+        #[cfg(feature = "debug")]
+        #[allow(unused_unsafe)]
+        {if *::log::FIBER_LOG_ENV {
+            use registry::WorkerThread;;
+            if WorkerThread::current() == 0i32 as _ {
+                debug_log!("outside pool :: {}", &format!($($args)*));
+            } else {
+                let worker = unsafe { &*WorkerThread::current() };
+                debug_log!("fiber {:?} - worker {} :: {}", worker.fiber_info().id, worker.index(), &format!($($args)*));
+            }
+        }}
+    }}
 }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -590,7 +590,7 @@ impl ThreadInfo {
 
 pub struct WorkerThread {
     /// the "worker" half of our local deque
-    worker: Worker<JobRef>,
+    pub worker: Worker<JobRef>,
 
     rx_resumed_tasks: crossbeam_channel::Receiver<Fiber>,
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -594,7 +594,7 @@ pub struct WorkerThread {
 
     rx_resumed_tasks: crossbeam_channel::Receiver<Fiber>,
 
-    index: usize,
+    pub(crate) index: usize,
 
     #[cfg(feature = "debug")]
     stack_low: Ptr,

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -800,8 +800,8 @@ impl WorkerThread {
                 yields = new_yields;
                 if deadlock {
                     self.registry.sleep.work_found(self.index, yields);
-                    mem::forget(abort_guard);
                     (self.registry.deadlock_handler.as_ref().expect("no deadlock handler"))();
+                    yields = 0;
                 }
             }
         }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -140,7 +140,7 @@ static THE_REGISTRY_SET: Once = ONCE_INIT;
 /// initialization has not already occurred, use the default
 /// configuration.
 fn global_registry() -> &'static Arc<Registry> {
-    THE_REGISTRY_SET.call_once(|| unsafe { init_registry(Configuration::new()).unwrap() });
+    THE_REGISTRY_SET.call_once(|| unsafe { init_registry(Configuration::new().num_threads(4)).unwrap() });
     unsafe { THE_REGISTRY.expect("The global thread pool has not been initialized.") }
 }
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -916,7 +916,9 @@ pub fn debug_print_state() {
 
         debug_log!("------ registry {:x} ------", &*registry as *const _ as usize);
         debug_log!("  terminate_latch: {:?}", registry.terminate_latch.probe());
-
+        debug_log!("  active_fibers: {:?}", registry.active_fibers.load(Ordering::SeqCst));
+        debug_log!("  external_waiters: {:?}", registry.external_waiters.load(Ordering::SeqCst));
+        
         for wt in &*registry.workers.lock() {
             print_worker(*wt);
         }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -196,8 +196,7 @@ impl Registry {
         #[cfg(feature = "debug")]
         ctrlc::set_handler(move || {
             use std;
-            ctrlc();
-            fiber::ctrlc();
+            debug_print_state();
             println!("saw ctrl-c");
             std::process::abort();
         }).ok();
@@ -896,8 +895,7 @@ pub fn deadlock_check(registry: &Registry) {
     if is_deadlocked(registry) {
         debug_log!("\n\n ------ RAYON DEADLOCK FOUND ------");
         loop {
-            ctrlc();
-            fiber::ctrlc();
+            debug_print_state();
             #[cfg(windows)]
             unsafe { ::kernel32::DebugBreak() };
             #[cfg(not(windows))]
@@ -907,7 +905,7 @@ pub fn deadlock_check(registry: &Registry) {
 }
 
 #[cfg(feature = "debug")]
-pub fn ctrlc() {
+pub fn debug_print_state() {
     debug_log!("------ registries ------");
     for r in &*(REGISTRIES.lock()) {
         let registry = if let Some(r) = r.upgrade() {
@@ -926,6 +924,7 @@ pub fn ctrlc() {
         debug_log!("------ end registry {:x} ------", &*registry as *const _ as usize);
     }
     debug_log!("------ end registries ------");
+    fiber::debug_print_state();
 }
 
 #[cfg(feature = "debug")]

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -7,8 +7,6 @@ use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::usize;
 use registry::WorkerThread;
-#[cfg(feature = "debug")]
-use registry::deadlock_check;
 
 pub struct Sleep {
     state: AtomicUsize,

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -276,7 +276,8 @@ impl Sleep {
                         } else {
                             #[cfg(feature = "debug")]
                             deadlock_check(&*_worker.registry);
-                            panic!("deadlock in rayon");
+                            /*eprintln!("\ndeadlock in rayon");
+                            panic!("deadlock in rayon");*/
                         }
                     }
                     *worker_count = new_worker_count;

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -49,16 +49,16 @@ impl Sleep {
     }
 
     #[inline]
-    pub fn work_found(&self, worker_index: usize, yields: usize) -> usize {
+    pub fn work_found(&self, worker: &WorkerThread, yields: usize) -> usize {
         log!(FoundWork {
-            worker: worker_index,
+            worker: worker.index(),
             yields: yields,
         });
         if yields > ROUNDS_UNTIL_SLEEPY {
             // FIXME tickling here is a bit extreme; mostly we want to "release the lock"
             // from us being sleepy, we don't necessarily need to wake others
             // who are sleeping
-            self.tickle(worker_index);
+            worker.registry.signal();
         }
         0
     }
@@ -66,10 +66,9 @@ impl Sleep {
     #[inline]
     pub fn no_work_found(&self,
                          worker: &WorkerThread,
-                         worker_index: usize,
                          yields: usize) -> (usize, bool) {
         log!(DidNotFindWork {
-            worker: worker_index,
+            worker: worker.index(),
             yields: yields,
         });
         let r = if yields < ROUNDS_UNTIL_SLEEPY {
@@ -77,27 +76,27 @@ impl Sleep {
             yields + 1
         } else if yields == ROUNDS_UNTIL_SLEEPY {
             thread::yield_now();
-            if self.get_sleepy(worker_index) {
+            if self.get_sleepy(worker.index()) {
                 yields + 1
             } else {
                 yields
             }
         } else if yields < ROUNDS_UNTIL_ASLEEP {
             thread::yield_now();
-            if self.still_sleepy(worker_index) {
+            if self.still_sleepy(worker.index()) {
                 yields + 1
             } else {
-                log!(GotInterrupted { worker: worker_index });
+                log!(GotInterrupted { worker: worker.index() });
                 0
             }
         } else {
             debug_assert_eq!(yields, ROUNDS_UNTIL_ASLEEP);
-            return (0, self.sleep(worker, worker_index))
+            return (0, self.sleep(worker))
         };
         (r, false)
     }
 
-    pub fn tickle(&self, worker_index: usize) {
+    pub fn tickle(&self, worker_index: usize, worker_count: usize) {
         // As described in README.md, this load must be SeqCst so as to ensure that:
         // - if anyone is sleepy or asleep, we *definitely* see that now (and not eventually);
         // - if anyone after us becomes sleepy or asleep, they see memory events that
@@ -105,14 +104,14 @@ impl Sleep {
         let old_state = self.state.load(Ordering::SeqCst);
         if old_state != AWAKE {
             fiber_log!("real tickle");
-            self.tickle_cold(worker_index);
+            self.tickle_cold(worker_index, worker_count);
         } else {
             fiber_log!("dummy tickle");
         }
     }
 
     #[cold]
-    fn tickle_cold(&self, worker_index: usize) {
+    fn tickle_cold(&self, worker_index: usize, worker_count: usize) {
         // The `Release` ordering here suffices. The reasoning is that
         // the atomic's own natural ordering ensure that any attempt
         // to become sleepy/asleep either will come before/after this
@@ -129,7 +128,9 @@ impl Sleep {
             old_state: old_state,
         });
         if self.anyone_sleeping(old_state) {
-            let _data = self.data.lock().unwrap();
+            let mut worker_count_guard = self.data.lock().unwrap();
+            *worker_count_guard = worker_count;
+            //eprintln!("[{}] tickling all", worker_index);
             self.tickle.notify_all();
         }
     }
@@ -191,7 +192,7 @@ impl Sleep {
         self.worker_is_sleepy(state, worker_index)
     }
 
-    fn sleep(&self, worker: &WorkerThread, worker_index: usize) -> bool {
+    fn sleep(&self, worker: &WorkerThread) -> bool {
         loop {
             // Acquire here suffices. If we observe that the current worker is still
             // sleepy, then in fact we know that no writes have occurred, and anyhow
@@ -201,7 +202,7 @@ impl Sleep {
             // due to a tickle, and then the Acquire means we also see
             // any events that occured before that.
             let state = self.state.load(Ordering::Acquire);
-            if self.worker_is_sleepy(state, worker_index) {
+            if self.worker_is_sleepy(state, worker.index()) {
                 // It is important that we hold the lock when we do
                 // the CAS. Otherwise, if we were to CAS first, then
                 // the following sequence of events could occur:
@@ -262,31 +263,37 @@ impl Sleep {
                     // to sleep. Note that if we get a false wakeup it's not a
                     // problem for us, we'll just loop around and maybe get
                     // sleepy again.
-                    log!(FellAsleep { worker: worker_index });
+                    log!(FellAsleep { worker: worker.index() });
 
-                    fiber_log!("worker {} fell asleep", worker_index);
+                    fiber_log!("worker {} fell asleep", worker.index());
                     #[cfg(feature = "debug")]
                     worker.asleep.store(true, Ordering::SeqCst);
 
+                    //eprintln!("[{}] sleeping thread", worker.index());
+
                     let new_worker_count = *worker_count - 1;
                     if new_worker_count == 0 { // Possible deadlock
-                        if worker.registry.external_waiters.load(Ordering::SeqCst) > 0 {
+                        let w = worker.registry.external_waiters.load(Ordering::SeqCst);
+
+                        //eprintln!("[{}] last awake thread, {} external waiters", worker.index(), w);
+                        if w > 0 {
                             return true;
                         }
                     }
                     *worker_count = new_worker_count;
-                    let mut worker_count = self.tickle.wait(worker_count).unwrap();
-                    *worker_count = *worker_count + 1;
+                    let _worker_count = self.tickle.wait(worker_count).unwrap();
 
-                    fiber_log!("worker {} woke up", worker_index);
+                    //eprintln!("[{}] waking up thread", worker.index());
+
+                    fiber_log!("worker {} woke up", worker.index());
                     #[cfg(feature = "debug")]
                     worker.asleep.store(false, Ordering::SeqCst);
 
-                    log!(GotAwoken { worker: worker_index });
+                    log!(GotAwoken { worker: worker.index() });
                     return false;
                 }
             } else {
-                log!(GotInterrupted { worker: worker_index });
+                log!(GotInterrupted { worker: worker.index() });
                 return false;
             }
         }

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -26,7 +26,7 @@ fn workers_stop() {
         let thread_pool = ThreadPool::new(Configuration::new().num_threads(22)).unwrap();
         registry = thread_pool.install(|| {
                                            // do some work on these threads
-                                           join_a_lot(22);
+                                           join_a_lot(1);
 
                                            thread_pool.registry.clone()
                                        });

--- a/rayon-core/src/worker_local.rs
+++ b/rayon-core/src/worker_local.rs
@@ -1,0 +1,74 @@
+use registry::{Registry, WorkerThread};
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+
+#[repr(align(64))]
+#[derive(Debug)]
+struct CacheAligned<T>(T);
+
+/// Holds worker-locals values for each thread in a thread pool.
+/// You can only access the worker local value through the Deref impl
+/// on the thread pool it was constructed on. It will panic otherwise
+pub struct WorkerLocal<T> {
+    locals: Vec<CacheAligned<T>>,
+    registry: Arc<Registry>,
+}
+
+unsafe impl<T> Send for WorkerLocal<T> {}
+unsafe impl<T> Sync for WorkerLocal<T> {}
+
+impl<T> WorkerLocal<T> {
+    /// Creates a new worker local where the `initial` closure computes the
+    /// value this worker local should take for each thread in the thread pool.
+    #[inline]
+    pub fn new<F: FnMut(usize) -> T>(mut initial: F) -> WorkerLocal<T> {
+        let registry = Registry::current();
+        WorkerLocal {
+            locals: (0..registry.num_threads())
+                .map(|i| CacheAligned(initial(i)))
+                .collect(),
+            registry,
+        }
+    }
+
+    /// Returns the worker-local value for each thread
+    #[inline]
+    pub fn into_inner(self) -> Vec<T> {
+        self.locals.into_iter().map(|c| c.0).collect()
+    }
+
+    fn current(&self) -> &T {
+        unsafe {
+            let worker_thread = WorkerThread::current();
+            if worker_thread.is_null()
+                || &*(*worker_thread).registry as *const _ != &*self.registry as *const _
+            {
+                panic!("WorkerLocal can only be used on the thread pool it was created on")
+            }
+            &self.locals[(*worker_thread).index].0
+        }
+    }
+}
+
+impl<T> WorkerLocal<Vec<T>> {
+    /// Joins the elements of all the worker locals into one Vec
+    pub fn join(self) -> Vec<T> {
+        self.into_inner().into_iter().flat_map(|v| v).collect()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for WorkerLocal<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.locals, f)
+    }
+}
+
+impl<T> Deref for WorkerLocal<T> {
+    type Target = T;
+
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        self.current()
+    }
+}

--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 rayon = { path = "../" }
+rayon-core = { path = "../rayon-core" }
 cgmath = "0.15"
 docopt = "0.8"
 fixedbitset = "0.1.5"

--- a/rayon-demo/src/core_microbench.rs
+++ b/rayon-demo/src/core_microbench.rs
@@ -1,0 +1,33 @@
+//! Some microbenchmarks that stress test a pure `join` path.
+
+use rayon;
+use rayon_core;
+use rayon::prelude::*;
+use test::Bencher;
+use std::usize;
+
+#[bench]
+fn join_overhead(b: &mut Bencher) {
+    b.iter(|| {
+        rayon_core::registry::in_worker(|_, _| {
+            for i in 0..70000 {
+                rayon::join(|| {
+                    unsafe { asm!(""::::"volatile") };
+                }, || {
+                    unsafe { asm!(""::::"volatile") };
+                });
+            }
+        });
+    });
+}
+
+#[bench]
+fn install_overhead(b: &mut Bencher) {
+    b.iter(|| {
+        for i in 0..7000 {
+            rayon_core::registry::in_worker(|_, _| {
+                unsafe { asm!(""::::"volatile") };
+            });
+        }
+    });
+}

--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(test, feature(test))]
 #![feature(conservative_impl_trait)]
+#![feature(asm)]
 
 use std::env;
 use std::io;
@@ -23,9 +24,11 @@ mod life;
 #[cfg(test)] mod fibonacci;
 #[cfg(test)] mod find;
 #[cfg(test)] mod join_microbench;
+#[cfg(test)] mod core_microbench;
 #[cfg(test)] mod str_split;
 #[cfg(test)] mod sort;
 
+extern crate rayon_core; // core_microbench
 extern crate rayon; // all
 extern crate docopt; // all
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,4 +130,5 @@ pub use rayon_core::ThreadPool;
 pub use rayon_core::{join, join_context};
 pub use rayon_core::FnContext;
 pub use rayon_core::{scope, Scope};
+pub use rayon_core::fork;
 pub use rayon_core::spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //!
 //! [`std`]: https://doc.rust-lang.org/std/
 
-extern crate rayon_core;
+extern crate rustc_rayon_core as rayon_core;
 extern crate either;
 
 #[cfg(test)]


### PR DESCRIPTION
This has quite a few changes to rayon_core in order to make it suitable for parallelizing rustc. The primary new feature is that jobs are run inside fibers. This enables rayon to schedule jobs whose dependencies form a DAG. I'm just creating this PR for feedback from humans and bots alike.