### PR TITLE
Adapt for wasm32 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,16 @@ matrix:
       env: RUSTFLAGS='--cfg rayon_unstable'
       if: NOT type = pull_request
 
+    # wasm won't actually work without threading, but it builds
+    - rust: nightly
+      os: linux
+      env: TARGET=wasm32-unknown-unknown
+      script:
+        - rustup target add $TARGET
+        - cargo build --target $TARGET
+      if: NOT type = pull_request
+
+
 script:
   - cargo build
   - |


### PR DESCRIPTION
Changed from libc::abort() to std::process::abort() in unwind.rs (rayon-core) so it can be compiled for wasm32-unknown-unknown. As a consequence, both an unsafe block and the libc crate dependency for rayon-core can be removed.

Version bump in rand to 0.4, as 0.3.19 doesn't compile for wasm. It seems I'm late for the version bump (#502), so I'm not sure if I should remove it from the commit.   