### PR TITLE
Specialize some Folder::consume_iter methods

### DIFF
--- a/src/iter/for_each.rs
+++ b/src/iter/for_each.rs
@@ -45,6 +45,11 @@ impl<'f, F, T> Folder<T> for ForEachConsumer<'f, F>
         self
     }
 
+    fn consume_iter<I>(self, iter: I) -> Self where I: IntoIterator<Item=T> {
+        iter.into_iter().fold((), |_, item| (self.op)(item));
+        self
+    }
+
     fn complete(self) {}
 
     fn full(&self) -> bool {

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -33,6 +33,11 @@ impl<T> Folder<T> for NoopConsumer {
         self
     }
 
+   fn consume_iter<I>(self, iter: I) -> Self where I: IntoIterator<Item=T> {
+        iter.into_iter().fold((), |_, _| ());
+        self
+   }
+
     fn complete(self) {}
 
     fn full(&self) -> bool {


### PR DESCRIPTION
Fixes the second item of #465.