### PR TITLE
Add chunks method to IndexedParallelIterator

### DIFF
--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -4,6 +4,12 @@ use ::math::div_round_up;
 use super::plumbing::*;
 use super::*;
 
+/// `Chunks` is an iterator that groups elements of an underlying iterator.
+///
+/// This struct is created by the [`chunks()`] method on [`IndexedParallelIterator`]
+///
+/// [`chunks()`]: trait.IndexedParallelIterator.html#method.chunks
+/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Chunks<I>

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -1,0 +1,185 @@
+use super::plumbing::*;
+use super::*;
+
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone)]
+pub struct Chunks<I>
+    where I: IndexedParallelIterator
+{
+    size: usize,
+    i: I,
+}
+
+/// Create a new `Chunks` iterator
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I>(i: I, size: usize) -> Chunks<I>
+    where I: IndexedParallelIterator
+{
+    Chunks { i: i, size: size }
+}
+
+impl<I> ParallelIterator for Chunks<I>
+    where I: IndexedParallelIterator
+{
+    type Item = Vec<I::Item>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Vec<I::Item>>
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl<I> IndexedParallelIterator for Chunks<I>
+    where I: IndexedParallelIterator
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        calc_length(self.i.len(), self.size)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        return self.i.with_producer(Callback {
+            size: self.size,
+            callback: callback,
+        });
+
+        struct Callback<CB> {
+            size: usize,
+            callback: CB,
+        }
+
+        impl<T, CB> ProducerCallback<T> for Callback<CB>
+            where CB: ProducerCallback<Vec<T>>
+        {
+            type Output = CB::Output;
+
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item = T>
+            {
+                self.callback.callback(ChunkProducer {
+                    chunk_size: self.size,
+                    base: base,
+                })
+            }
+        }
+    }
+}
+
+struct ChunkProducer<P>
+    where P: Producer
+{
+    chunk_size: usize,
+    base: P,
+}
+
+impl<P> Producer for ChunkProducer<P>
+    where P: Producer
+{
+    type Item = Vec<P::Item>;
+    type IntoIter = ChunkSeq<P::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ChunkSeq {
+            chunk_size: self.chunk_size,
+            inner: self.base.into_iter()
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let elem_index = index * self.chunk_size;
+        let (left, right) = self.base.split_at(elem_index);
+        (ChunkProducer {
+            chunk_size: self.chunk_size,
+            base: left,
+        },
+        ChunkProducer {
+            chunk_size: self.chunk_size,
+            base: right,
+        })
+    }
+
+    // FIXME: should these be adjusted for the chunk_size?
+
+    fn min_len(&self) -> usize {
+        self.base.min_len()
+    }
+
+    fn max_len(&self) -> usize {
+        self.base.max_len()
+    }
+}
+
+struct ChunkSeq<I> {
+    chunk_size: usize,
+    inner: I,
+}
+
+impl<I> Iterator for ChunkSeq<I>
+    where I: Iterator + ExactSizeIterator
+{
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.inner.len() > 0 {
+            Some(self.inner.by_ref().take(self.chunk_size).collect())
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<I> ExactSizeIterator for ChunkSeq<I>
+    where I: Iterator + ExactSizeIterator
+{
+    #[inline]
+    fn len(&self) -> usize {
+        calc_length(self.inner.len(), self.chunk_size)
+    }
+}
+
+impl<I> DoubleEndedIterator for ChunkSeq<I>
+    where I: Iterator + ExactSizeIterator + DoubleEndedIterator
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.inner.len() == 0 {
+            return None
+        }
+        let mut last_size = self.inner.len() % self.chunk_size;
+        if last_size == 0 {
+            last_size = self.chunk_size;
+        }
+        let mut chunk: Vec<_> = self.inner.by_ref().rev().take(last_size).collect();
+        // the elements themselves shouldn't be reversed.
+        chunk.reverse();
+        Some(chunk)
+    }
+}
+
+fn calc_length(num_items: usize, chunk_size: usize) -> usize {
+    if num_items == 0 {
+        0
+    } else {
+        (num_items - 1) / chunk_size + 1
+    }
+}
+
+
+// TODO: unit tests for calc_length

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -33,7 +33,7 @@ impl<I> ParallelIterator for Chunks<I>
         bridge(self, consumer)
     }
 
-    fn opt_len(&mut self) -> Option<usize> {
+    fn opt_len(&self) -> Option<usize> {
         Some(self.len())
     }
 }
@@ -47,11 +47,11 @@ impl<I> IndexedParallelIterator for Chunks<I>
         bridge(self, consumer)
     }
 
-    fn len(&mut self) -> usize {
+    fn len(&self) -> usize {
         div_round_up(self.i.len(), self.size)
     }
 
-    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
         let len = self.i.len();

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -1,3 +1,4 @@
+use ::math::div_round_up;
 use super::plumbing::*;
 use super::*;
 
@@ -45,7 +46,7 @@ impl<I> IndexedParallelIterator for Chunks<I>
     }
 
     fn len(&mut self) -> usize {
-        calc_length(self.i.len(), self.size)
+        div_round_up(self.i.len(), self.size)
     }
 
     fn with_producer<CB>(self, callback: CB) -> CB::Output
@@ -111,14 +112,12 @@ impl<P> Producer for ChunkProducer<P>
         })
     }
 
-    // FIXME: should these be adjusted for the chunk_size?
-
     fn min_len(&self) -> usize {
-        self.base.min_len()
+        div_round_up(self.base.min_len(), self.chunk_size)
     }
 
     fn max_len(&self) -> usize {
-        self.base.max_len()
+        self.base.max_len() / self.chunk_size
     }
 }
 
@@ -151,7 +150,7 @@ impl<I> ExactSizeIterator for ChunkSeq<I>
 {
     #[inline]
     fn len(&self) -> usize {
-        calc_length(self.inner.len(), self.chunk_size)
+        div_round_up(self.inner.len(), self.chunk_size)
     }
 }
 
@@ -172,14 +171,3 @@ impl<I> DoubleEndedIterator for ChunkSeq<I>
         Some(chunk)
     }
 }
-
-fn calc_length(num_items: usize, chunk_size: usize) -> usize {
-    if num_items == 0 {
-        0
-    } else {
-        (num_items - 1) / chunk_size + 1
-    }
-}
-
-
-// TODO: unit tests for calc_length

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -30,6 +30,8 @@ mod find;
 mod find_first_last;
 mod chain;
 pub use self::chain::Chain;
+mod chunks;
+pub use self::chunks::Chunks;
 mod collect;
 mod enumerate;
 pub use self::enumerate::Enumerate;
@@ -1350,6 +1352,25 @@ pub trait IndexedParallelIterator: ParallelIterator {
               I::Iter: IndexedParallelIterator<Item = Self::Item>
     {
         interleave_shortest::new(self, other.into_par_iter())
+    }
+
+    /// Split an iterator up into fixed-size chunks.
+    ///
+    /// Returns an iterator that returns `Vec`s of the given number of elements.
+    /// If the number of elements in the iterator is not divisible by `chunk_size`,
+    /// the last chunk may be shorter than `chunk_size`.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let a = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    /// let r: Vec<Vec<i32>> = a.into_par_iter().chunks(3).collect();
+    /// assert_eq!(r, vec![vec![1,2,3], vec![4,5,6], vec![7,8,9], vec![10]]);
+    /// ```
+    fn chunks(self, chunk_size: usize) -> Chunks<Self> {
+        assert_ne!(chunk_size, 0, "chunk_size must not be zero");
+        chunks::new(self, chunk_size)
     }
 
     /// Lexicographically compares the elements of this `ParallelIterator` with those of

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1360,7 +1360,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// If the number of elements in the iterator is not divisible by `chunk_size`,
     /// the last chunk may be shorter than `chunk_size`.
     ///
-    /// Example:
+    /// # Examples
     ///
     /// ```
     /// use rayon::prelude::*;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1369,7 +1369,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// assert_eq!(r, vec![vec![1,2,3], vec![4,5,6], vec![7,8,9], vec![10]]);
     /// ```
     fn chunks(self, chunk_size: usize) -> Chunks<Self> {
-        assert_ne!(chunk_size, 0, "chunk_size must not be zero");
+        assert!(chunk_size != 0, "chunk_size must not be zero");
         chunks::new(self, chunk_size)
     }
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1360,6 +1360,12 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// If the number of elements in the iterator is not divisible by `chunk_size`,
     /// the last chunk may be shorter than `chunk_size`.
     ///
+    /// See also [`par_chunks()`] and [`par_chunks_mut()`] for similar behavior on
+    /// slices, without having to allocate intermediate `Vec`s for the chunks.
+    ///
+    /// [`par_chunks()`]: ../slice/trait.ParallelSlice.html#method.par_chunks
+    /// [`par_chunks_mut()`]: ../slice/trait.ParallelSliceMut.html#method.par_chunks_mut
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1871,11 +1871,11 @@ fn check_chunks_uneven() {
 
     for (i, (v, n, expected)) in cases.into_iter().enumerate() {
         let mut res: Vec<Vec<u32>> = vec![];
-        v.par_iter().chunks(n).map(|v| v.into_iter().cloned().collect()).collect_into(&mut res);
+        v.par_iter().chunks(n).map(|v| v.into_iter().cloned().collect()).collect_into_vec(&mut res);
         assert_eq!(expected, res, "Case {} failed", i);
 
         res.truncate(0);
-        v.into_par_iter().chunks(n).rev().collect_into(&mut res);
+        v.into_par_iter().chunks(n).rev().collect_into_vec(&mut res);
         assert_eq!(expected.into_iter().rev().collect::<Vec<Vec<u32>>>(), res, "Case {} reversed failed", i);
     }
 }

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1835,6 +1835,52 @@ fn check_interleave_shortest() {
 }
 
 #[test]
+#[should_panic(expected = "chunk_size must not be zero")]
+fn check_chunks_zero_size() {
+    let _: Vec<Vec<i32>> = vec![1,2,3].into_par_iter().chunks(0).collect();
+}
+
+#[test]
+fn check_chunks_even_size() {
+    assert_eq!(vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]], (1..10).into_par_iter().chunks(3).collect::<Vec<Vec<i32>>>());
+}
+
+#[test]
+fn check_chunks_empty() {
+    let v: Vec<i32> = vec![];
+    let expected: Vec<Vec<i32>> = vec![];
+    assert_eq!(expected, v.into_par_iter().chunks(2).collect::<Vec<Vec<i32>>>());
+}
+
+#[test]
+fn check_chunks_len() {
+    assert_eq!(4, (0..8).into_par_iter().chunks(2).len());
+    assert_eq!(3, (0..9).into_par_iter().chunks(3).len());
+    assert_eq!(3, (0..8).into_par_iter().chunks(3).len());
+    assert_eq!(1, (&[1]).par_iter().chunks(3).len());
+    assert_eq!(0, (0..0).into_par_iter().chunks(3).len());
+}
+
+#[test]
+fn check_chunks_uneven() {
+    let cases: Vec<(Vec<u32>, usize, Vec<Vec<u32>>)> = vec![
+        ((0..5).collect(), 3, vec![vec![0,1, 2], vec![3, 4]]),
+        (vec![1], 5, vec![vec![1]]),
+        ((0..4).collect(), 3, vec![vec![0,1, 2], vec![3]]),
+    ];
+
+    for (i, (v, n, expected)) in cases.into_iter().enumerate() {
+        let mut res: Vec<Vec<u32>> = vec![];
+        v.par_iter().chunks(n).map(|v| v.into_iter().cloned().collect()).collect_into(&mut res);
+        assert_eq!(expected, res, "Case {} failed", i);
+
+        res.truncate(0);
+        v.into_par_iter().chunks(n).rev().collect_into(&mut res);
+        assert_eq!(expected.into_iter().rev().collect::<Vec<Vec<u32>>>(), res, "Case {} reversed failed", i);
+    }
+}
+
+#[test]
 #[ignore] // it's quick enough on optimized 32-bit platforms, but otherwise... ... ...
 #[should_panic(expected = "overflow")]
 #[cfg(debug_assertions)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub mod str;
 pub mod vec;
 
 mod par_either;
+mod math;
 mod test;
 
 pub use rayon_core::current_num_threads;

--- a/src/math.rs
+++ b/src/math.rs
@@ -2,6 +2,7 @@
 /// if not evenly divisable.
 #[inline]
 pub fn div_round_up(n: usize, divisor: usize) -> usize {
+    debug_assert!(divisor != 0, "Division by zero!");
     if n == 0 {
         0
     } else {

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,24 @@
+/// Divide `n` by `divisor`, and round up to the nearest integer
+/// if not evenly divisable.
+#[inline]
+pub fn div_round_up(n: usize, divisor: usize) -> usize {
+    if n == 0 {
+        0
+    } else {
+        (n - 1) / divisor + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_div_round_up() {
+        assert_eq!(0, div_round_up(0, 5));
+        assert_eq!(1, div_round_up(5, 5));
+        assert_eq!(1, div_round_up(1, 5));
+        assert_eq!(2, div_round_up(3, 2));
+        assert_eq!(usize::max_value() / 2 + 1, div_round_up(usize::max_value(), 2));
+    }
+}

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -477,7 +477,7 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
         bridge(self, consumer)
     }
 
-    fn len(self) -> usize {
+    fn len(&self) -> usize {
         div_round_up(self.slice.len(), self.chunk_size)
     }
 
@@ -682,13 +682,8 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
         bridge(self, consumer)
     }
 
-<<<<<<< HEAD
-    fn len(&mut self) -> usize {
-        div_round_up(self.slice.len(), self.chunk_size)
-=======
     fn len(&self) -> usize {
-        (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
->>>>>>> rayon/master
+        div_round_up(self.slice.len(), self.chunk_size)
     }
 
     fn with_producer<CB>(self, callback: CB) -> CB::Output

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -121,6 +121,7 @@ fn clone_adaptors() {
     check(v.par_iter().interleave(&v));
     check(v.par_iter().interleave_shortest(&v));
     check(v.par_iter().intersperse(&None));
+    check(v.par_iter().chunks(3));
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
     check(v.par_iter().rev());

--- a/tests/compile-fail/must_use.rs
+++ b/tests/compile-fail/must_use.rs
@@ -23,6 +23,7 @@ fn main() {
     v.par_iter().interleave(&v);            //~ ERROR must be used
     v.par_iter().interleave_shortest(&v);   //~ ERROR must be used
     v.par_iter().intersperse(&None);        //~ ERROR must be used
+    v.par_iter().chunks(2);                 //~ ERROR must be used
     v.par_iter().map(|x| x);                //~ ERROR must be used
     v.par_iter().map_with(0, |_, x| x);     //~ ERROR must be used
     v.par_iter().rev();                     //~ ERROR must be used

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -130,6 +130,7 @@ fn debug_adaptors() {
     check(v.par_iter().interleave(&v));
     check(v.par_iter().interleave_shortest(&v));
     check(v.par_iter().intersperse(&-1));
+    check(v.par_iter().chunks(3));
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
     check(v.par_iter().rev());

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -227,6 +227,13 @@ fn intersperse() {
 }
 
 #[test]
+fn chunks() {
+    let s: Vec<_> = (0..10).collect();
+    let v: Vec<_> = s.chunks(2).map(|c| c.to_vec()).collect();
+    check(&v, || s.par_iter().cloned().chunks(2));
+}
+
+#[test]
 fn map() {
     let v: Vec<_> = (0..10).collect();
     check(&v, || v.par_iter().map(Clone::clone));


### PR DESCRIPTION
Fixes #501 

Note: I am only using a Vec<T> for each chunk because if I defined a Chunk iterator like itertools does, it would have to reference the type of `Producer::IntoIter` for the producer given to the ProducerCallback, which isn't accessible from the IndexedParallelIterator type. And the Chunk type needs to be the Item of the Chunks iterator.  An alternative implementation could possibly use a Box<Iterator> instead of using generics.