### PR TITLE
document spawn return value, modules

### DIFF
--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -10,8 +10,8 @@ use FnContext;
 #[cfg(test)]
 mod test;
 
-/// The `join` function takes two closures and *potentially* runs them
-/// in parallel. It returns a pair of the results from those closures.
+/// Takes two closures and *potentially* runs them in parallel. It
+/// returns a pair of the results from those closures.
 ///
 /// Conceptually, calling `join()` is similar to spawning two threads,
 /// one executing each of the two closures. However, the
@@ -58,12 +58,13 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     join_context(|_| oper_a(), |_| oper_b())
 }
 
-/// The `join_context` function is identical to `join`, except the closures
-/// have a parameter that provides context for the way the closure has been
-/// called, especially indicating whether they're executing on a different
-/// thread than where `join_context` was called.  This will occur if the second
-/// job is stolen by a different thread, or if `join_context` was called from
-/// outside the thread pool to begin with.
+/// Indentical to `join`, except that the closures have a parameter
+/// that provides context for the way the closure has been called,
+/// especially indicating whether they're executing on a different
+/// thread than where `join_context` was called.  This will occur if
+/// the second job is stolen by a different thread, or if
+/// `join_context` was called from outside the thread pool to begin
+/// with.
 pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where A: FnOnce(FnContext) -> RA + Send,
           B: FnOnce(FnContext) -> RB + Send,

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -1,3 +1,9 @@
+//! Methods for custom fork-join scopes, created by the [`scope()`]
+//! function. These are a more flexible alternative to [`join()`].
+//!
+//! [`scope()`]: fn.scope.html
+//! [`join()`]: ../join/join.fn.html
+
 use latch::{Latch, CountLatch};
 use log::Event::*;
 use job::HeapJob;

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -15,13 +15,13 @@ use registry::{Registry, WorkerThread};
 mod internal;
 mod test;
 
-/// # ThreadPool
-///
-/// The [`ThreadPool`] struct represents a user created [thread-pool]. [`ThreadPool::new()`]
-/// takes a [`Configuration`] struct that you can use to specify the number and/or
-/// names of threads in the pool. You can then execute functions explicitly within
-/// this [`ThreadPool`] using [`ThreadPool::install()`]. By contrast, top level
-/// rayon functions (like `join()`)  will execute implicitly within the current thread-pool.
+/// Represents a user created [thread-pool]. [`ThreadPool::new()`]
+/// takes a [`Configuration`] struct that you can use to specify the
+/// number and/or names of threads in the pool. You can then execute
+/// functions explicitly within this [`ThreadPool`] using
+/// [`ThreadPool::install()`]. By contrast, top level rayon functions
+/// (like `join()`) will execute implicitly within the current
+/// thread-pool.
 ///
 ///
 /// ## Creating a ThreadPool

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -1,3 +1,8 @@
+//! Contains support for user-managed thread pools, represented by the
+//! the [`ThreadPool`] type (see that struct for details).
+//!
+//! [`ThreadPool`]: struct.ThreadPool.html
+
 use Configuration;
 use join;
 use {scope, Scope};
@@ -9,6 +14,7 @@ use registry::{Registry, WorkerThread};
 
 mod internal;
 mod test;
+
 /// # ThreadPool
 ///
 /// The [`ThreadPool`] struct represents a user created [thread-pool]. [`ThreadPool::new()`]


### PR DESCRIPTION
Document the spawn return vaule and add doc-comments to some of the modules. Also cleanup the style of doc-comments to be a bit more consistent -- e.g., don't name the function being documented in the first sentence, which reads a bit oddly in rustdoc.

Fixes #431 
Fixes https://github.com/rayon-rs/rayon/issues/421