### PR TITLE
Introduce concrete error type

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ equals to the number of logical cores and not the physical ones.
 
 If you want to alter the number of threads spawned, you can set the
 environmental variable `RAYON_NUM_THREADS` to the desired number of threads
-or use the [`initialize` function](https://docs.rs/rayon/*/rayon/fn.initialize.html) method
+or use the [`ThreadPoolBuilder::build_global` function](https://docs.rs/rayon/*/rayon/struct.ThreadPoolBuilder.html#method.build_global) method
 
 ### Parallel Iterators
 

--- a/rayon-core/src/join/test.rs
+++ b/rayon-core/src/join/test.rs
@@ -1,9 +1,8 @@
 //! Tests for the join code.
 
-use Configuration;
+use ThreadPoolBuilder;
 use join::*;
 use rand::{Rng, SeedableRng, XorShiftRng};
-use thread_pool::*;
 use unwind;
 
 fn quick_sort<T: PartialOrd + Send>(v: &mut [T]) {
@@ -44,7 +43,7 @@ fn sort_in_pool() {
     let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
     let mut data: Vec<_> = (0..12 * 1024).map(|_| rng.next_u32()).collect();
 
-    let pool = ThreadPool::new(Configuration::new()).unwrap();
+    let pool = ThreadPoolBuilder::new().build().unwrap();
     let mut sorted_data = data.clone();
     sorted_data.sort();
     pool.install(|| quick_sort(&mut data));
@@ -89,7 +88,7 @@ fn join_context_both() {
 #[test]
 fn join_context_neither() {
     // If we're already in a 1-thread pool, neither job should be stolen.
-    let pool = ThreadPool::new(Configuration::new().num_threads(1)).unwrap();
+    let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
     let (a_migrated, b_migrated) = pool.install(|| {
         join_context(|a| a.migrated(), |b| b.migrated())
     });
@@ -103,7 +102,7 @@ fn join_context_second() {
 
     // If we're already in a 2-thread pool, the second job should be stolen.
     let barrier = Barrier::new(2);
-    let pool = ThreadPool::new(Configuration::new().num_threads(2)).unwrap();
+    let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
     let (a_migrated, b_migrated) = pool.install(|| {
         join_context(|a| { barrier.wait(); a.migrated() },
                      |b| { barrier.wait(); b.migrated() })

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -26,6 +26,7 @@
 
 use std::any::Any;
 use std::env;
+use std::io;
 use std::error::Error;
 use std::marker::PhantomData;
 use std::str::FromStr;
@@ -75,18 +76,47 @@ pub use spawn::spawn;
 /// ### Future compatibility note
 ///
 /// Note that unless this thread-pool was created with a
-/// configuration that specifies the number of threads, then this
+/// builder that specifies the number of threads, then this
 /// number may vary over time in future versions (see [the
 /// `num_threads()` method for details][snt]).
 ///
-/// [snt]: struct.Configuration.html#method.num_threads
+/// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
 pub fn current_num_threads() -> usize {
     ::registry::Registry::current_num_threads()
 }
 
-/// Contains the rayon thread pool configuration.
+/// Error when initializing a thread pool.
+#[derive(Debug)]
+pub struct ThreadPoolInitError {
+    kind: ErrorKind,
+}
+
+#[derive(Debug)]
+enum ErrorKind {
+    GlobalPoolAlreadyInitialized,
+    IOError(io::Error),
+}
+
+/// Used to create a new [`ThreadPool`] or to configure the global rayon thread pool.
+/// ## Creating a ThreadPool
+/// The following creates a thread pool with 22 threads.
+///
+/// ```rust
+/// # use rayon_core as rayon;
+/// let pool = rayon::ThreadPoolBuilder::new().num_threads(22).build().unwrap();
+/// ```
+///
+/// To instead configure the global thread pool, use [`build_global()`]:
+///
+/// ```rust
+/// # use rayon_core as rayon;
+/// rayon::ThreadPoolBuilder::new().num_threads(22).build_global().unwrap();
+/// ```
+///
+/// [`ThreadPool`]: struct.ThreadPool.html
+/// [`build_global()`]: struct.ThreadPoolBuilder.html#method.build_global
 #[derive(Default)]
-pub struct Configuration {
+pub struct ThreadPoolBuilder {
     /// The number of threads in the rayon thread pool.
     /// If zero will use the RAYON_NUM_THREADS environment variable.
     /// If RAYON_NUM_THREADS is invalid or zero will use the default.
@@ -114,6 +144,15 @@ pub struct Configuration {
     breadth_first: bool,
 }
 
+/// Contains the rayon thread pool configuration. Use [`ThreadPoolBuilder`] instead.
+///
+/// [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
+#[deprecated(note = "Use `ThreadPoolBuilder`")]
+#[derive(Default)]
+pub struct Configuration {
+    builder: ThreadPoolBuilder,
+}
+
 /// The type for a panic handling closure. Note that this same closure
 /// may be invoked multiple times in parallel.
 type PanicHandler = Fn(Box<Any + Send>) + Send + Sync;
@@ -128,15 +167,38 @@ type StartHandler = Fn(usize) + Send + Sync;
 /// Note that this same closure may be invoked multiple times in parallel.
 type ExitHandler = Fn(usize) + Send + Sync;
 
-impl Configuration {
-    /// Creates and return a valid rayon thread pool configuration, but does not initialize it.
-    pub fn new() -> Configuration {
-        Configuration::default()
+impl ThreadPoolBuilder {
+    /// Creates and returns a valid rayon thread pool builder, but does not initialize it.
+    pub fn new() -> ThreadPoolBuilder {
+        ThreadPoolBuilder::default()
     }
 
     /// Create a new `ThreadPool` initialized using this configuration.
-    pub fn build(self) -> Result<ThreadPool, Box<Error + 'static>> {
-        ThreadPool::new(self)
+    pub fn build(self) -> Result<ThreadPool, ThreadPoolInitError> {
+        thread_pool::build(self)
+    }
+
+    /// Initializes the global thread pool. This initialization is
+    /// **optional**.  If you do not call this function, the thread pool
+    /// will be automatically initialized with the default
+    /// configuration. Calling `build_global` is not recommended, except
+    /// in two scenarios:
+    ///
+    /// - You wish to change the default configuration.
+    /// - You are running a benchmark, in which case initializing may
+    ///   yield slightly more consistent results, since the worker threads
+    ///   will already be ready to go even in the first iteration.  But
+    ///   this cost is minimal.
+    ///
+    /// Initialization of the global thread pool happens exactly
+    /// once. Once started, the configuration cannot be
+    /// changed. Therefore, if you call `build_global` a second time, it
+    /// will return an error. An `Ok` result indicates that this
+    /// is the first initialization of the thread pool.
+    pub fn build_global(self) -> Result<(), ThreadPoolInitError> {
+        let registry = try!(registry::init_global_registry(self));
+        registry.wait_until_primed();
+        Ok(())
     }
 
     /// Get the number of threads that will be used for the thread
@@ -198,7 +260,7 @@ impl Configuration {
     /// replacement of the now deprecated `RAYON_RS_NUM_CPUS` environment
     /// variable. If both variables are specified, `RAYON_NUM_THREADS` will
     /// be prefered.
-    pub fn num_threads(mut self, num_threads: usize) -> Configuration {
+    pub fn num_threads(mut self, num_threads: usize) -> ThreadPoolBuilder {
         self.num_threads = num_threads;
         self
     }
@@ -222,7 +284,7 @@ impl Configuration {
     /// If the panic handler itself panics, this will abort the
     /// process. To prevent this, wrap the body of your panic handler
     /// in a call to `std::panic::catch_unwind()`.
-    pub fn panic_handler<H>(mut self, panic_handler: H) -> Configuration
+    pub fn panic_handler<H>(mut self, panic_handler: H) -> ThreadPoolBuilder
         where H: Fn(Box<Any + Send>) + Send + Sync + 'static
     {
         self.panic_handler = Some(Box::new(panic_handler));
@@ -280,7 +342,7 @@ impl Configuration {
     /// Note that this same closure may be invoked multiple times in parallel.
     /// If this closure panics, the panic will be passed to the panic handler.
     /// If that handler returns, then startup will continue normally.
-    pub fn start_handler<H>(mut self, start_handler: H) -> Configuration
+    pub fn start_handler<H>(mut self, start_handler: H) -> ThreadPoolBuilder
         where H: Fn(usize) + Send + Sync + 'static
     {
         self.start_handler = Some(Box::new(start_handler));
@@ -298,7 +360,7 @@ impl Configuration {
     /// Note that this same closure may be invoked multiple times in parallel.
     /// If this closure panics, the panic will be passed to the panic handler.
     /// If that handler returns, then the thread will exit normally.
-    pub fn exit_handler<H>(mut self, exit_handler: H) -> Configuration
+    pub fn exit_handler<H>(mut self, exit_handler: H) -> ThreadPoolBuilder
         where H: Fn(usize) + Send + Sync + 'static
     {
         self.exit_handler = Some(Box::new(exit_handler));
@@ -306,35 +368,110 @@ impl Configuration {
     }
 }
 
-/// Initializes the global thread pool. This initialization is
-/// **optional**.  If you do not call this function, the thread pool
-/// will be automatically initialized with the default
-/// configuration. In fact, calling `initialize` is not recommended,
-/// except for in two scenarios:
-///
-/// - You wish to change the default configuration.
-/// - You are running a benchmark, in which case initializing may
-///   yield slightly more consistent results, since the worker threads
-///   will already be ready to go even in the first iteration.  But
-///   this cost is minimal.
-///
-/// Initialization of the global thread pool happens exactly
-/// once. Once started, the configuration cannot be
-/// changed. Therefore, if you call `initialize` a second time, it
-/// will return an error. An `Ok` result indicates that this
-/// is the first initialization of the thread pool.
-pub fn initialize(config: Configuration) -> Result<(), Box<Error>> {
-    let registry = try!(registry::init_global_registry(config));
-    registry.wait_until_primed();
-    Ok(())
+#[allow(deprecated)]
+impl Configuration {
+    /// Creates and return a valid rayon thread pool configuration, but does not initialize it.
+    pub fn new() -> Configuration {
+        Configuration { builder: ThreadPoolBuilder::new() }
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::build`.
+    pub fn build(self) -> Result<ThreadPool, Box<Error + 'static>> {
+        self.builder.build().map_err(|e| e.into())
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::thread_name`.
+    pub fn thread_name<F>(mut self, closure: F) -> Self
+    where F: FnMut(usize) -> String + 'static {
+        self.builder = self.builder.thread_name(closure);
+        self 
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::num_threads`.
+    pub fn num_threads(mut self, num_threads: usize) -> Configuration {
+        self.builder = self.builder.num_threads(num_threads);
+        self
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::panic_handler`.
+    pub fn panic_handler<H>(mut self, panic_handler: H) -> Configuration
+        where H: Fn(Box<Any + Send>) + Send + Sync + 'static
+    {
+        self.builder = self.builder.panic_handler(panic_handler);
+        self
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::stack_size`.
+    pub fn stack_size(mut self, stack_size: usize) -> Self {
+        self.builder = self.builder.stack_size(stack_size);
+        self
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::breadth_first`.
+    pub fn breadth_first(mut self) -> Self {
+        self.builder = self.builder.breadth_first();
+        self
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::start_handler`.
+    pub fn start_handler<H>(mut self, start_handler: H) -> Configuration
+        where H: Fn(usize) + Send + Sync + 'static
+    {
+        self.builder = self.builder.start_handler(start_handler);
+        self
+    }
+
+    /// Deprecated in favor of `ThreadPoolBuilder::exit_handler`.
+    pub fn exit_handler<H>(mut self, exit_handler: H) -> Configuration
+        where H: Fn(usize) + Send + Sync + 'static
+    {
+        self.builder = self.builder.exit_handler(exit_handler);
+        self
+    }
+
+    /// Returns a ThreadPoolBuilder with identical parameters.
+    fn into_builder(self) -> ThreadPoolBuilder {
+        self.builder
+    }
 }
 
-impl fmt::Debug for Configuration {
+impl ThreadPoolInitError {
+    fn new(kind: ErrorKind) -> ThreadPoolInitError {
+        ThreadPoolInitError { kind: kind }
+    }
+}
+
+impl Error for ThreadPoolInitError {
+    fn description(&self) -> &str {
+        match self.kind {
+            ErrorKind::GlobalPoolAlreadyInitialized => "The global thread pool has already been initialized.",
+            ErrorKind::IOError(ref e) => e.description(),
+        }
+    }
+}
+
+impl fmt::Display for ThreadPoolInitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Configuration { ref num_threads, ref get_thread_name,
-                            ref panic_handler, ref stack_size,
-                            ref start_handler, ref exit_handler,
-                            ref breadth_first } = *self;
+        match self.kind {
+            ErrorKind::IOError(ref e) => e.fmt(f),
+            _ => self.description().fmt(f),
+        }
+    }
+}
+
+/// Deprecated in favor of `ThreadPoolBuilder::build_global`.
+#[deprecated(note = "use `ThreadPoolBuilder::build_global`")]
+#[allow(deprecated)]
+pub fn initialize(config: Configuration) -> Result<(), Box<Error>> {
+    config.into_builder().build_global().map_err(|e| e.into())
+}
+
+impl fmt::Debug for ThreadPoolBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ThreadPoolBuilder { ref num_threads, ref get_thread_name,
+                                ref panic_handler, ref stack_size,
+                                ref start_handler, ref exit_handler,
+                                ref breadth_first } = *self;
 
         // Just print `Some(<closure>)` or `None` to the debug
         // output.
@@ -349,7 +486,7 @@ impl fmt::Debug for Configuration {
         let start_handler = start_handler.as_ref().map(|_| ClosurePlaceholder);
         let exit_handler = exit_handler.as_ref().map(|_| ClosurePlaceholder);
 
-        f.debug_struct("Configuration")
+        f.debug_struct("ThreadPoolBuilder")
          .field("num_threads", num_threads)
          .field("get_thread_name", &get_thread_name)
          .field("panic_handler", &panic_handler)
@@ -358,6 +495,13 @@ impl fmt::Debug for Configuration {
          .field("exit_handler", &exit_handler)
          .field("breadth_first", &breadth_first)
          .finish()
+    }
+}
+
+#[allow(deprecated)]
+impl fmt::Debug for Configuration {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.builder.fmt(f)
     }
 }
 

--- a/rayon-core/src/scope/test.rs
+++ b/rayon-core/src/scope/test.rs
@@ -1,6 +1,5 @@
-use Configuration;
+use ThreadPoolBuilder;
 use {scope, Scope};
-use ThreadPool;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::cmp;
 use std::iter::once;
@@ -142,8 +141,8 @@ fn update_tree() {
 /// permitting an approx 10% change with a 10x input change.
 #[test]
 fn linear_stack_growth() {
-    let config = Configuration::new().num_threads(1);
-    let pool = ThreadPool::new(config).unwrap();
+    let builder = ThreadPoolBuilder::new().num_threads(1);
+    let pool = builder.build().unwrap();
     pool.install(|| {
         let mut max_diff = Mutex::new(0);
         let bottom_of_stack = 0;

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -27,11 +27,11 @@ use unwind;
 /// # Panic handling
 ///
 /// If this closure should panic, the resulting panic will be
-/// propagated to the panic handler registered in the `Configuration`,
-/// if any.  See [`Configuration::panic_handler()`][ph] for more
+/// propagated to the panic handler registered in the `ThreadPoolBuilder`,
+/// if any.  See [`ThreadPoolBuilder::panic_handler()`][ph] for more
 /// details.
 ///
-/// [ph]: struct.Configuration.html#method.panic_handler
+/// [ph]: struct.ThreadPoolBuilder.html#method.panic_handler
 ///
 /// # Examples
 ///

--- a/rayon-core/src/spawn/test.rs
+++ b/rayon-core/src/spawn/test.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::sync::Mutex;
 use std::sync::mpsc::channel;
 
-use {Configuration, ThreadPool};
+use ThreadPoolBuilder;
 use super::spawn;
 
 #[test]
@@ -40,9 +40,9 @@ fn panic_fwd() {
         }
     };
 
-    let configuration = Configuration::new().panic_handler(panic_handler);
+    let builder = ThreadPoolBuilder::new().panic_handler(panic_handler);
 
-    ThreadPool::new(configuration).unwrap().spawn(move || panic!("Hello, world!"));
+    builder.build().unwrap().spawn(move || panic!("Hello, world!"));
 
     assert_eq!(1, rx.recv().unwrap());
 }
@@ -58,7 +58,7 @@ fn termination_while_things_are_executing() {
     // Create a thread-pool and spawn some code in it, but then drop
     // our reference to it.
     {
-        let thread_pool = ThreadPool::new(Configuration::new()).unwrap();
+        let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         thread_pool.spawn(move || {
             let data = rx0.recv().unwrap();
 
@@ -89,8 +89,8 @@ fn custom_panic_handler_and_spawn() {
     };
 
     // Execute an async that will panic.
-    let config = Configuration::new().panic_handler(panic_handler);
-    ThreadPool::new(config).unwrap().spawn(move || {
+    let builder = ThreadPoolBuilder::new().panic_handler(panic_handler);
+    builder.build().unwrap().spawn(move || {
         panic!("Hello, world!");
     });
 
@@ -117,8 +117,8 @@ fn custom_panic_handler_and_nested_spawn() {
 
     // Execute an async that will (eventually) panic.
     const PANICS: usize = 3;
-    let config = Configuration::new().panic_handler(panic_handler);
-    ThreadPool::new(config).unwrap().spawn(move || {
+    let builder = ThreadPoolBuilder::new().panic_handler(panic_handler);
+    builder.build().unwrap().spawn(move || {
         // launch 3 nested spawn-asyncs; these should be in the same
         // thread-pool and hence inherit the same panic handler
         for _ in 0 .. PANICS {

--- a/rayon-core/src/test.rs
+++ b/rayon-core/src/test.rs
@@ -1,13 +1,14 @@
 #![cfg(test)]
 
+#[allow(deprecated)]
 use Configuration;
+use {ThreadPoolBuilder, ThreadPoolInitError};
 use std::sync::{Arc, Barrier};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use thread_pool::*;
 
 #[test]
 fn worker_thread_index() {
-    let pool = ThreadPool::new(Configuration::new().num_threads(22)).unwrap();
+    let pool = ThreadPoolBuilder::new().num_threads(22).build().unwrap();
     assert_eq!(pool.current_num_threads(), 22);
     assert_eq!(pool.current_thread_index(), None);
     let index = pool.install(|| pool.current_thread_index().unwrap());
@@ -28,10 +29,10 @@ fn start_callback_called() {
         b.wait();
     };
 
-    let conf = Configuration::new()
+    let conf = ThreadPoolBuilder::new()
         .num_threads(n_threads)
         .start_handler(start_handler);
-    let _ = ThreadPool::new(conf).unwrap();
+    let _ = conf.build().unwrap();
 
     // Wait for all the threads to have been scheduled to run.
     barrier.wait();
@@ -54,11 +55,11 @@ fn exit_callback_called() {
         b.wait();
     };
 
-    let conf = Configuration::new()
+    let conf = ThreadPoolBuilder::new()
         .num_threads(n_threads)
         .exit_handler(exit_handler);
     {
-        let _ = ThreadPool::new(conf).unwrap();
+        let _ = conf.build().unwrap();
         // Drop the pool so it stops the running threads.
     }
 
@@ -96,13 +97,13 @@ fn handler_panics_handled_correctly() {
         }
     };
 
-    let conf = Configuration::new()
+    let conf = ThreadPoolBuilder::new()
         .num_threads(n_threads)
         .start_handler(start_handler)
         .exit_handler(exit_handler)
         .panic_handler(panic_handler);
     {
-        let _ = ThreadPool::new(conf).unwrap();
+        let _ = conf.build().unwrap();
 
         // Wait for all the threads to start, panic in the start handler,
         // and been taken care of by the panic handler.
@@ -117,4 +118,40 @@ fn handler_panics_handled_correctly() {
 
     // The panic handler must have been called twice on every thread.
     assert_eq!(n_called.load(Ordering::SeqCst), 2 * n_threads);
+}
+
+#[test]
+#[allow(deprecated)]
+fn check_config_build() {
+    let pool = ThreadPoolBuilder::new().num_threads(22).build().unwrap();
+    assert_eq!(pool.current_num_threads(), 22);
+}
+
+
+/// Helper used by check_error_send_sync to ensure ThreadPoolInitError is Send + Sync
+fn _send_sync<T: Send + Sync>() { }
+
+#[test]
+fn check_error_send_sync() {
+    _send_sync::<ThreadPoolInitError>();
+}
+
+#[allow(deprecated)]
+#[test]
+fn configuration() {
+    let start_handler = move |_| { };
+    let exit_handler = move |_| {  };
+    let panic_handler = move |_| { };
+    let thread_name = move |i| { format!("thread_name_{}", i) };
+
+    // Ensure we can call all public methods on Configuration
+    Configuration::new()
+        .thread_name(thread_name)
+        .num_threads(5)
+        .panic_handler(panic_handler)
+        .stack_size(4e6 as usize)
+        .breadth_first()
+        .start_handler(start_handler)
+        .exit_handler(exit_handler)
+        .build().unwrap();
 }

--- a/rayon-futures/src/test.rs
+++ b/rayon-futures/src/test.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use futures::task;
 use futures::executor::Notify;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use rayon_core::{scope, ThreadPool, Configuration};
+use rayon_core::{scope, ThreadPool, ThreadPoolBuilder};
 use super::ScopeFutureExt;
 
 #[cfg(not(all(windows, target_env = "gnu")))]
@@ -37,7 +37,7 @@ fn future_test() {
     // Here we call `wait` on a select future, which will block at
     // least one thread. So we need a second thread to ensure no
     // deadlock.
-    ThreadPool::new(Configuration::new().num_threads(2)).unwrap().install(|| {
+    ThreadPoolBuilder::new().num_threads(2).build().unwrap().install(|| {
         scope(|s| {
             let a = s.spawn_future(futures::future::ok::<_, ()>(&data[0]));
             let b = s.spawn_future(futures::future::ok::<_, ()>(&data[1]));
@@ -110,7 +110,7 @@ fn future_panic_prop() {
 fn future_rayon_wait_1_thread() {
     // run with only 1 worker thread; this would deadlock if we couldn't make progress
     let mut result = None;
-    ThreadPool::new(Configuration::new().num_threads(1)).unwrap().install(|| {
+    ThreadPoolBuilder::new().num_threads(1).build().unwrap().install(|| {
         scope(|s| {
             use std::sync::mpsc::channel;
             let (tx, rx) = channel();

--- a/src/iter/find_first_last/test.rs
+++ b/src/iter/find_first_last/test.rs
@@ -141,8 +141,8 @@ fn find_last_octillion() {
     // It would be nice if `find_last` could prioritize the later splits,
     // basically flipping the `join` args, without needing indexed `rev`.
     // (or could we have an unindexed `rev`?)
-    let config = ::Configuration::new().num_threads(2);
-    let pool = ::ThreadPool::new(config).unwrap();
+    let builder = ::ThreadPoolBuilder::new().num_threads(2);
+    let pool = builder.build().unwrap();
 
     let x = pool.install(|| octillion().find_last(|_| true));
     assert_eq!(x, Some(999999999999999999999999999));

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1841,7 +1841,7 @@ fn check_interleave_shortest() {
 fn check_repeat_unbounded() {
     // use just one thread, so we don't get infinite adaptive splitting
     // (forever stealing and re-splitting jobs that will panic on overflow)
-    let pool = ::ThreadPool::new(::Configuration::new().num_threads(1)).unwrap();
+    let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
     pool.install(|| {
         println!("counted {} repeats", repeat(()).count());
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,8 @@ mod par_either;
 mod test;
 
 pub use rayon_core::current_num_threads;
-pub use rayon_core::Configuration;
-pub use rayon_core::initialize;
 pub use rayon_core::ThreadPool;
+pub use rayon_core::ThreadPoolBuilder;
 pub use rayon_core::{join, join_context};
 pub use rayon_core::FnContext;
 pub use rayon_core::{scope, Scope};

--- a/tests/run-pass/double_init_fail.rs
+++ b/tests/run-pass/double_init_fail.rs
@@ -1,10 +1,11 @@
 extern crate rayon;
 
 use rayon::*;
+use std::error::Error;
 
 fn main() {
-    let result1 = initialize(Configuration::new());
+    let result1 = ThreadPoolBuilder::new().build_global();
     assert_eq!(result1.unwrap(), ());
-    let err = initialize(Configuration::new()).unwrap_err();
+    let err = ThreadPoolBuilder::new().build_global().unwrap_err();
     assert!(err.description() == "The global thread pool has already been initialized.");
 }

--- a/tests/run-pass/init_zero_threads.rs
+++ b/tests/run-pass/init_zero_threads.rs
@@ -3,5 +3,5 @@ extern crate rayon;
 use rayon::*;
 
 fn main() {
-    initialize(Configuration::new().num_threads(0)).unwrap();
+    ThreadPoolBuilder::new().num_threads(0).build_global().unwrap();
 }

--- a/tests/run-pass/named-threads.rs
+++ b/tests/run-pass/named-threads.rs
@@ -6,7 +6,7 @@ use rayon::*;
 use rayon::prelude::*;
 
 fn main() {
-    let result = initialize(Configuration::new().thread_name(|i| format!("hello-name-test-{}", i)));
+    let result = ThreadPoolBuilder::new().thread_name(|i| format!("hello-name-test-{}", i)).build_global();
 
     const N: usize = 10000;
 

--- a/tests/run-pass/stack_overflow_crash.rs
+++ b/tests/run-pass/stack_overflow_crash.rs
@@ -50,7 +50,7 @@ fn main() {
         }
     } else {
         let stack_size_in_mb: usize = env::args().nth(1).unwrap().parse().unwrap();
-        let pool = ThreadPool::new(Configuration::new().stack_size(stack_size_in_mb * 1024 * 1024)).unwrap();
+        let pool = ThreadPoolBuilder::new().stack_size(stack_size_in_mb * 1024 * 1024).build().unwrap();
         let index = pool.install(|| {
             force_stack_overflow(32);
         });


### PR DESCRIPTION
Addresses #417. Still a work in progress.
Remaining questions:
- [x] * Documentation on new error type
- [x] * Should we remove `pub use rayon_core::initialize` in `rayon/src/lib.rs`
- [x] * Finalize name decision for `ThreadPoolInitError` and `Configuration::init()`

Define ThreadPoolInitError. Deprecate methods that returned
Box<Error> types in favor of new methods returning the concrete
ThreadPoolInitError.

Deprecations in rayon-core:
initialize() => Configuration::init_global()
Configuration::build() => Configuration::init()
ThreadPool::new() => Configuration::init()