### PR TITLE
Rename collect_into to collect_into_vec

### DIFF
--- a/rayon-demo/src/vec_collect.rs
+++ b/rayon-demo/src/vec_collect.rs
@@ -168,20 +168,20 @@ mod vec_i {
     }
 
     #[bench]
-    fn with_collect_into(b: &mut ::test::Bencher) {
+    fn with_collect_into_vec(b: &mut ::test::Bencher) {
         let mut vec = None;
         b.iter(|| {
             let mut v = vec![];
-            generate().collect_into(&mut v);
+            generate().collect_into_vec(&mut v);
             vec = Some(v);
         });
         check(&vec.unwrap());
     }
 
     #[bench]
-    fn with_collect_into_reused(b: &mut ::test::Bencher) {
+    fn with_collect_into_vec_reused(b: &mut ::test::Bencher) {
         let mut vec = vec![];
-        b.iter(|| generate().collect_into(&mut vec));
+        b.iter(|| generate().collect_into_vec(&mut vec));
         check(&vec);
     }
 

--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -90,7 +90,7 @@ impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
     }
 }
 
-/// Pretend to be unindexed for `special_collect_into`,
+/// Pretend to be unindexed for `special_collect_into_vec`,
 /// but we should never actually get used that way...
 impl<'c, T: Send + 'c> UnindexedConsumer<T> for CollectConsumer<'c, T> {
     fn split_off_left(&self) -> Self {

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -44,8 +44,8 @@ fn special_extend<I, T>(pi: I, len: usize, v: &mut Vec<T>)
 
 /// Unzips the results of the exact iterator into the specified vectors.
 ///
-/// This is not directly public, but called by `IndexedParallelIterator::unzip_into`.
-pub fn unzip_into<I, A, B>(pi: I, left: &mut Vec<A>, right: &mut Vec<B>)
+/// This is not directly public, but called by `IndexedParallelIterator::unzip_into_vecs`.
+pub fn unzip_into_vecs<I, A, B>(pi: I, left: &mut Vec<A>, right: &mut Vec<B>)
     where I: IndexedParallelIterator<Item = (A, B)>,
           A: Send,
           B: Send

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -11,8 +11,8 @@ mod test;
 
 /// Collects the results of the exact iterator into the specified vector.
 ///
-/// This is not directly public, but called by `IndexedParallelIterator::collect_into`.
-pub fn collect_into<I, T>(pi: I, v: &mut Vec<T>)
+/// This is not directly public, but called by `IndexedParallelIterator::collect_into_vec`.
+pub fn collect_into_vec<I, T>(pi: I, v: &mut Vec<T>)
     where I: IndexedParallelIterator<Item = T>,
           T: Send
 {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1094,7 +1094,7 @@ pub trait ParallelIterator: Sized + Send {
     /// Create a fresh collection containing all the element produced
     /// by this parallel iterator.
     ///
-    /// You may prefer to use `collect_into()`, which allocates more
+    /// You may prefer to use `collect_into_vec()`, which allocates more
     /// efficiently with precise knowledge of how many elements the
     /// iterator contains, and even allows you to reuse an existing
     /// vector's backing store rather than allocating a fresh vector.
@@ -1276,8 +1276,8 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// vector. The vector is always truncated before execution
     /// begins. If possible, reusing the vector across calls can lead
     /// to better performance since it reuses the same backing buffer.
-    fn collect_into(self, target: &mut Vec<Self::Item>) {
-        collect::collect_into(self, target);
+    fn collect_into_vec(self, target: &mut Vec<Self::Item>) {
+        collect::collect_into_vec(self, target);
     }
 
     /// Unzips the results of the iterator into the specified

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1119,7 +1119,7 @@ pub trait ParallelIterator: Sized + Send {
     /// Unzips the items of a parallel iterator into a pair of arbitrary
     /// `ParallelExtend` containers.
     ///
-    /// You may prefer to use `unzip_into()`, which allocates more
+    /// You may prefer to use `unzip_into_vecs()`, which allocates more
     /// efficiently with precise knowledge of how many elements the
     /// iterator contains, and even allows you to reuse existing
     /// vectors' backing stores rather than allocating fresh vectors.
@@ -1284,12 +1284,12 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// vectors. The vectors are always truncated before execution
     /// begins. If possible, reusing the vectors across calls can lead
     /// to better performance since they reuse the same backing buffer.
-    fn unzip_into<A, B>(self, left: &mut Vec<A>, right: &mut Vec<B>)
+    fn unzip_into_vecs<A, B>(self, left: &mut Vec<A>, right: &mut Vec<B>)
         where Self: IndexedParallelIterator<Item = (A, B)>,
               A: Send,
               B: Send
     {
-        collect::unzip_into(self, left, right);
+        collect::unzip_into_vecs(self, left, right);
     }
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from

--- a/src/iter/plumbing/README.md
+++ b/src/iter/plumbing/README.md
@@ -47,7 +47,7 @@ modes (which is why there are two):
     data falls in the overall stream.
     - Not all consumers can operate in this mode. It works for
       `for_each` and `reduce`, for example, but it does not work for
-      `collect_into`, since in that case the position of each item is
+      `collect_into_vec`, since in that case the position of each item is
       important for knowing where it ends up in the target collection.
 
 ## How iterator execution proceeds

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -19,7 +19,7 @@ fn is_indexed<T: IndexedParallelIterator>(_: T) {}
 pub fn execute() {
     let a: Vec<i32> = (0..1024).collect();
     let mut b = vec![];
-    a.par_iter().map(|&i| i + 1).collect_into(&mut b);
+    a.par_iter().map(|&i| i + 1).collect_into_vec(&mut b);
     let c: Vec<i32> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
@@ -28,7 +28,7 @@ pub fn execute() {
 pub fn execute_cloned() {
     let a: Vec<i32> = (0..1024).collect();
     let mut b: Vec<i32> = vec![];
-    a.par_iter().cloned().collect_into(&mut b);
+    a.par_iter().cloned().collect_into_vec(&mut b);
     let c: Vec<i32> = (0..1024).collect();
     assert_eq!(b, c);
 }
@@ -37,7 +37,7 @@ pub fn execute_cloned() {
 pub fn execute_range() {
     let a = 0i32..1024;
     let mut b = vec![];
-    a.into_par_iter().map(|i| i + 1).collect_into(&mut b);
+    a.into_par_iter().map(|i| i + 1).collect_into_vec(&mut b);
     let c: Vec<i32> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
@@ -204,7 +204,7 @@ pub fn check_enumerate() {
     a.par_iter()
         .enumerate()
         .map(|(i, &x)| i + x)
-        .collect_into(&mut b);
+        .collect_into_vec(&mut b);
     assert!(b.iter().all(|&x| x == a.len() - 1));
 }
 
@@ -217,7 +217,7 @@ pub fn check_enumerate_rev() {
         .enumerate()
         .rev()
         .map(|(i, &x)| i + x)
-        .collect_into(&mut b);
+        .collect_into_vec(&mut b);
     assert!(b.iter().all(|&x| x == a.len() - 1));
 }
 
@@ -259,17 +259,17 @@ pub fn check_skip() {
     let a: Vec<usize> = (0..1024).collect();
 
     let mut v1 = Vec::new();
-    a.par_iter().skip(16).collect_into(&mut v1);
+    a.par_iter().skip(16).collect_into_vec(&mut v1);
     let v2 = a.iter().skip(16).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 
     let mut v1 = Vec::new();
-    a.par_iter().skip(2048).collect_into(&mut v1);
+    a.par_iter().skip(2048).collect_into_vec(&mut v1);
     let v2 = a.iter().skip(2048).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 
     let mut v1 = Vec::new();
-    a.par_iter().skip(0).collect_into(&mut v1);
+    a.par_iter().skip(0).collect_into_vec(&mut v1);
     let v2 = a.iter().skip(0).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 
@@ -288,17 +288,17 @@ pub fn check_take() {
     let a: Vec<usize> = (0..1024).collect();
 
     let mut v1 = Vec::new();
-    a.par_iter().take(16).collect_into(&mut v1);
+    a.par_iter().take(16).collect_into_vec(&mut v1);
     let v2 = a.iter().take(16).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 
     let mut v1 = Vec::new();
-    a.par_iter().take(2048).collect_into(&mut v1);
+    a.par_iter().take(2048).collect_into_vec(&mut v1);
     let v2 = a.iter().take(2048).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 
     let mut v1 = Vec::new();
-    a.par_iter().take(0).collect_into(&mut v1);
+    a.par_iter().take(0).collect_into_vec(&mut v1);
     let v2 = a.iter().take(0).collect::<Vec<_>>();
     assert_eq!(v1, v2);
 }
@@ -320,7 +320,7 @@ pub fn check_move() {
     let ptr = a[0].as_ptr();
 
     let mut b = vec![];
-    a.into_par_iter().collect_into(&mut b);
+    a.into_par_iter().collect_into_vec(&mut b);
 
     // a simple move means the inner vec will be completely unchanged
     assert_eq!(ptr, b[0].as_ptr());
@@ -334,7 +334,7 @@ pub fn check_drops() {
     let a = vec![DropCounter(&c); 10];
 
     let mut b = vec![];
-    a.clone().into_par_iter().collect_into(&mut b);
+    a.clone().into_par_iter().collect_into_vec(&mut b);
     assert_eq!(c.load(Ordering::Relaxed), 0);
 
     b.into_par_iter();
@@ -1136,7 +1136,7 @@ pub fn check_chain() {
         .enumerate()
         .map(|(a, (b, c))| (a, b, c))
         .chain(None)
-        .collect_into(&mut res);
+        .collect_into_vec(&mut res);
 
     assert_eq!(res,
                vec![(0, 'a', 0),
@@ -1783,7 +1783,7 @@ fn check_interleave_eq() {
     let ys: Vec<usize> = (10..20).collect();
 
     let mut actual = vec![];
-    xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut actual);
+    xs.par_iter().interleave(&ys).map(|&i| i).collect_into_vec(&mut actual);
 
     let expected: Vec<usize> = (0..10).zip(10..20).flat_map(|(i, j)| vec![i, j].into_iter()).collect();
     assert_eq!(expected, actual);
@@ -1802,11 +1802,11 @@ fn check_interleave_uneven() {
 
     for (i, (xs, ys, expected)) in cases.into_iter().enumerate() {
         let mut res = vec![];
-        xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut res);
+        xs.par_iter().interleave(&ys).map(|&i| i).collect_into_vec(&mut res);
         assert_eq!(expected, res, "Case {} failed", i);
 
         res.truncate(0);
-        xs.par_iter().interleave(&ys).rev().map(|&i| i).collect_into(&mut res);
+        xs.par_iter().interleave(&ys).rev().map(|&i| i).collect_into_vec(&mut res);
         assert_eq!(expected.into_iter().rev().collect::<Vec<usize>>(), res, "Case {} reversed failed", i);
     }
 }
@@ -1825,11 +1825,11 @@ fn check_interleave_shortest() {
 
     for (i, (xs, ys, expected)) in cases.into_iter().enumerate() {
         let mut res = vec![];
-        xs.par_iter().interleave_shortest(&ys).map(|&i| i).collect_into(&mut res);
+        xs.par_iter().interleave_shortest(&ys).map(|&i| i).collect_into_vec(&mut res);
         assert_eq!(expected, res, "Case {} failed", i);
 
         res.truncate(0);
-        xs.par_iter().interleave_shortest(&ys).rev().map(|&i| i).collect_into(&mut res);
+        xs.par_iter().interleave_shortest(&ys).rev().map(|&i| i).collect_into_vec(&mut res);
         assert_eq!(expected.into_iter().rev().collect::<Vec<usize>>(), res, "Case {} reversed failed", i);
     }
 }
@@ -1896,7 +1896,7 @@ fn check_empty() {
     assert!(v.is_empty());
 
     // drive (indexed)
-    empty().collect_into(&mut v);
+    empty().collect_into_vec(&mut v);
     assert!(v.is_empty());
 
     // with_producer
@@ -1911,7 +1911,7 @@ fn check_once() {
     assert_eq!(v, &[42]);
 
     // drive (indexed)
-    once(42).collect_into(&mut v);
+    once(42).collect_into_vec(&mut v);
     assert_eq!(v, &[42]);
 
     // with_producer

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1663,14 +1663,14 @@ fn check_extend_pairs() {
 }
 
 #[test]
-fn check_unzip_into() {
+fn check_unzip_into_vecs() {
     let mut a = vec![];
     let mut b = vec![];
     (0..1024)
         .into_par_iter()
         .map(|i| i * i)
         .enumerate()
-        .unzip_into(&mut a, &mut b);
+        .unzip_into_vecs(&mut a, &mut b);
 
     let (c, d): (Vec<_>, Vec<_>) = (0..1024).map(|i| i * i).enumerate().unzip();
     assert_eq!(a, c);

--- a/src/iter/unzip.rs
+++ b/src/iter/unzip.rs
@@ -64,7 +64,7 @@ pub fn unzip<I, A, B, FromA, FromB>(pi: I) -> (FromA, FromB)
 
 /// Unzip an `IndexedParallelIterator` into two arbitrary `Consumer`s.
 ///
-/// This is not directly public, but called by `super::collect::unzip_into`.
+/// This is not directly public, but called by `super::collect::unzip_into_vecs`.
 pub fn unzip_indexed<I, A, B, CA, CB>(pi: I, left: CA, right: CB) -> (CA::Result, CB::Result)
     where I: IndexedParallelIterator<Item = (A, B)>,
           CA: Consumer<A>,

--- a/tests/compile-fail/cannot_collect_filtermap_data.rs
+++ b/tests/compile-fail/cannot_collect_filtermap_data.rs
@@ -10,5 +10,5 @@ fn main() {
     let mut v = vec![];
     a.par_iter()
      .filter_map(|&x| Some(x as f32))
-     .collect_into(&mut v); //~ ERROR no method
+     .collect_into_vec(&mut v); //~ ERROR no method
 }

--- a/tests/compile-fail/rc_par_iter.rs
+++ b/tests/compile-fail/rc_par_iter.rs
@@ -11,5 +11,5 @@ fn main() {
     let mut y = vec![];
     x.into_par_iter() //~ ERROR no method named `into_par_iter`
      .map(|rc| *rc)
-     .collect_into(&mut y);
+     .collect_into_vec(&mut y);
 }


### PR DESCRIPTION
Preempts the possibility that Rust will add a collect_into method
on Iterator.