### PR TITLE
revise the "overall documentation strategy"

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,227 @@
+# Rayon FAQ
+
+These file is for general questions that don't fit into the README or
+crate docs.
+
+## How many threads will Rayon spawn?
+
+By default, Rayon uses the same number of threads as the number of CPUs
+available. Note that on systems with hyperthreading enabled this
+equals to the number of logical cores and not the physical ones.
+
+If you want to alter the number of threads spawned, you can set the
+environmental variable `RAYON_NUM_THREADS` to the desired number of
+threads or use the
+[`ThreadPoolBuilder::build_global` function](https://docs.rs/rayon/*/rayon/struct.ThreadPoolBuilder.html#method.build_global)
+method.
+
+## How does Rayon balance work between threads?
+
+Behind the scenes, Rayon uses a technique called **work stealing** to
+try and dynamically ascertain how much parallelism is available and
+exploit it. The idea is very simple: we always have a pool of worker
+threads available, waiting for some work to do. When you call `join`
+the first time, we shift over into that pool of threads. But if you
+call `join(a, b)` from a worker thread W, then W will place `b` into
+its work queue, advertising that this is work that other worker
+threads might help out with. W will then start executing `a`.
+
+While W is busy with `a`, other threads might come along and take `b`
+from its queue. That is called *stealing* `b`. Once `a` is done, W
+checks whether `b` was stolen by another thread and, if not, executes
+`b` itself. If W runs out of jobs in its own queue, it will look
+through the other threads' queues and try to steal work from them.
+
+This technique is not new. It was first introduced by the
+[Cilk project][cilk], done at MIT in the late nineties. The name Rayon
+is an homage to that work.
+
+[cilk]: http://supertech.csail.mit.edu/cilk/
+
+## What should I do if I use `Rc`, `Cell`, `RefCell` or other non-Send-and-Sync types?
+
+There a number of non-threadsafe types in the Rust standard library,
+and if your code is using them, you will not be able to combine it
+with Rayon. Similarly, even if you don't have such types, but you try
+to have multiple closures mutating the same state, you will get
+compilation errors; for example, this function won't work, because
+both closures access `slice`:
+
+```rust
+/// Increment all values in slice.
+fn increment_all(slice: &mut [i32]) {
+    rayon::join(|| process(slice), || process(slice));
+}
+```
+
+The correct way to resolve such errors will depend on the case.  Some
+cases are easy: for example, uses of [`Rc`] can typically be replaced
+with [`Arc`], which is basically equivalent, but thread-safe.
+
+Code that uses `Cell` or `RefCell`, however, can be a mite more complicated.
+If you can refactor your code to avoid those types, that is often the best way
+forward, but otherwise, you can try to replace those types with their threadsafe
+equivalents:
+
+- `Cell` -- replacement: `AtomicUsize`, `AtomicBool`, etc
+- `RefCell` -- replacement: `RwLock`, or perhaps `Mutex`
+
+However, you have to be wary! The parallel versions of these types
+have different atomicity guarantees. For example, with a `Cell`, you
+can increment a counter like so:
+
+```rust
+let value = counter.get();
+counter.set(value + 1);
+```
+
+But when you use the equivalent `AtomicUsize` methods, you are
+actually introducing a potential race condition (not a data race,
+technically, but it can be an awfully fine distinction):
+
+```rust
+let value = tscounter.load(Ordering::SeqCst);
+tscounter.store(value + 1, Ordering::SeqCst);
+```
+
+You can already see that the `AtomicUsize` API is a bit more complex,
+as it requires you to specify an
+[ordering](http://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html). (I
+won't go into the details on ordering here, but suffice to say that if
+you don't know what an ordering is, and probably even if you do, you
+should use `Ordering::SeqCst`.) The danger in this parallel version of
+the counter is that other threads might be running at the same time
+and they could cause our counter to get out of sync. For example, if
+we have two threads, then they might both execute the "load" before
+either has a chance to execute the "store":
+
+```
+Thread 1                                          Thread 2
+let value = tscounter.load(Ordering::SeqCst);
+// value = X                                      let value = tscounter.load(Ordering::SeqCst);
+                                                  // value = X
+tscounter.store(value+1);                         tscounter.store(value+1);
+// tscounter = X+1                                // tscounter = X+1
+```
+
+Now even though we've had two increments, we'll only increase the
+counter by one!  Even though we've got no data race, this is still
+probably not the result we wanted. The problem here is that the `Cell`
+API doesn't make clear the scope of a "transaction" -- that is, the
+set of reads/writes that should occur atomically. In this case, we
+probably wanted the get/set to occur together.
+
+In fact, when using the `Atomic` types, you very rarely want a plain
+`load` or plain `store`. You probably want the more complex
+operations. A counter, for example, would use `fetch_add` to
+atomically load and increment the value in one step. Compare-and-swap
+is another popular building block.
+
+A similar problem can arise when converting `RefCell` to `RwLock`, but
+it is somewhat less likely, because the `RefCell` API does in fact
+have a notion of a transaction: the scope of the handle returned by
+`borrow` or `borrow_mut`. So if you convert each call to `borrow` to
+`read` (and `borrow_mut` to `write`), things will mostly work fine in
+a parallel setting, but there can still be changes in behavior.
+Consider using a `handle: RefCell<Vec<i32>>` like :
+
+```rust
+let len = handle.borrow().len();
+for i in 0 .. len {
+    let data = handle.borrow()[i];
+    println!("{}", data);
+}
+```
+
+In sequential code, we know that this loop is safe. But if we convert
+this to parallel code with an `RwLock`, we do not: this is because
+another thread could come along and do
+`handle.write().unwrap().pop()`, and thus change the length of the
+vector. In fact, even in *sequential* code, using very small borrow
+sections like this is an anti-pattern: you ought to be enclosing the
+entire transaction together, like so:
+
+```rust
+let vec = handle.borrow();
+let len = vec.len();
+for i in 0 .. len {
+    let data = vec[i];
+    println!("{}", data);
+}
+```
+
+Or, even better, using an iterator instead of indexing:
+
+```rust
+let vec = handle.borrow();
+for data in vec {
+    println!("{}", data);
+}
+```
+
+There are several reasons to prefer one borrow over many. The most
+obvious is that it is more efficient, since each borrow has to perform
+some safety checks. But it's also more reliable: suppose we modified
+the loop above to not just print things out, but also call into a
+helper function:
+
+```rust
+let vec = handle.borrow();
+for data in vec {
+    helper(...);
+}
+```
+
+And now suppose, independently, this helper fn evolved and had to pop
+something off of the vector:
+
+```rust
+fn helper(...) {
+    handle.borrow_mut().pop();
+}
+```
+
+Under the old model, where we did lots of small borrows, this would
+yield precisely the same error that we saw in parallel land using an
+`RwLock`: the length would be out of sync and our indexing would fail
+(note that in neither case would there be an actual *data race* and
+hence there would never be undefined behavior). But now that we use a
+single borrow, we'll see a borrow error instead, which is much easier
+to diagnose, since it occurs at the point of the `borrow_mut`, rather
+than downstream. Similarly, if we move to an `RwLock`, we'll find that
+the code either deadlocks (if the write is on the same thread as the
+read) or, if the write is on another thread, works just fine. Both of
+these are preferable to random failures in my experience.
+
+## But wait, isn't Rust supposed to free me from this kind of thinking?
+
+You might think that Rust is supposed to mean that you don't have to
+think about atomicity at all. In fact, if you avoid inherent
+mutability (`Cell` and `RefCell` in a sequential setting, or
+`AtomicUsize`, `RwLock`, `Mutex`, et al. in parallel code), then this
+is true: the type system will basically guarantee that you don't have
+to think about atomicity at all. But often there are times when you
+WANT threads to interleave in the ways I showed above.
+
+Consider for example when you are conducting a search in parallel, say
+to find the shortest route. To avoid fruitless search, you might want
+to keep a cell with the shortest route you've found thus far.  This
+way, when you are searching down some path that's already longer than
+this shortest route, you can just stop and avoid wasted effort. In
+sequential land, you might model this "best result" as a shared value
+like `Rc<Cell<usize>>` (here the `usize` represents the length of best
+path found so far); in parallel land, you'd use a `Arc<AtomicUsize>`.
+Now we can make our search function look like:
+
+```rust
+fn search(path: &Path, cost_so_far: usize, best_cost: &Arc<AtomicUsize>) {
+    if cost_so_far >= best_cost.load(Ordering::SeqCst) {
+        return;
+    }
+    ...
+    best_cost.store(...);
+}
+```
+
+Now in this case, we really WANT to see results from other threads
+interjected into our execution!

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,13 +1,13 @@
 # Rayon FAQ
 
-These file is for general questions that don't fit into the README or
+This file is for general questions that don't fit into the README or
 crate docs.
 
 ## How many threads will Rayon spawn?
 
-By default, Rayon uses the same number of threads as the number of CPUs
-available. Note that on systems with hyperthreading enabled this
-equals to the number of logical cores and not the physical ones.
+By default, Rayon uses the same number of threads as the number of
+CPUs available. Note that on systems with hyperthreading enabled this
+equals the number of logical cores and not the physical ones.
 
 If you want to alter the number of threads spawned, you can set the
 environmental variable `RAYON_NUM_THREADS` to the desired number of

--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,7 @@ The correct way to resolve such errors will depend on the case.  Some
 cases are easy: for example, uses of [`Rc`] can typically be replaced
 with [`Arc`], which is basically equivalent, but thread-safe.
 
-Code that uses `Cell` or `RefCell`, however, can be a mite more complicated.
+Code that uses `Cell` or `RefCell`, however, can be somewhat more complicated.
 If you can refactor your code to avoid those types, that is often the best way
 forward, but otherwise, you can try to replace those types with their threadsafe
 equivalents:
@@ -123,7 +123,7 @@ have a notion of a transaction: the scope of the handle returned by
 `borrow` or `borrow_mut`. So if you convert each call to `borrow` to
 `read` (and `borrow_mut` to `write`), things will mostly work fine in
 a parallel setting, but there can still be changes in behavior.
-Consider using a `handle: RefCell<Vec<i32>>` like :
+Consider using a `handle: RefCell<Vec<i32>>` like:
 
 ```rust
 let len = handle.borrow().len();

--- a/README.md
+++ b/README.md
@@ -10,29 +10,60 @@ Rayon is a data-parallelism library for Rust. It is extremely
 lightweight and makes it easy to convert a sequential computation into
 a parallel one. It also guarantees data-race freedom. (You may also
 enjoy [this blog post][blog] about Rayon, which gives more background
-and details about how it works, or [this video][video], from the Rust Belt Rust conference.) Rayon is
+and details about how it works, or [this video][video], from the Rust
+Belt Rust conference.) Rayon is
 [available on crates.io](https://crates.io/crates/rayon), and
 [API Documentation is available on docs.rs](https://docs.rs/rayon/).
 
 [blog]: http://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/
 [video]: https://www.youtube.com/watch?v=gof_OEv71Aw
 
-You can use Rayon in two ways. Which way you will want will depend on
-what you are doing:
+## Parallel iterators and more
 
-- Parallel iterators: convert iterator chains to execute in parallel.
-- The `join` method: convert recursive, divide-and-conquer style
-  problems to execute in parallel.
+Rayon makes it drop-dead simple to convert sequential iterators into
+parallel ones: usually, you just change your `foo.iter()` call into
+`foo.par_iter()`, and Rayon does the rest:
 
-No matter which way you choose, you don't have to worry about data
-races: Rayon statically guarantees data-race freedom. For the most
-part, adding calls to Rayon should not change how your programs works
-at all, in fact. However, if you operate on mutexes or atomic
-integers, please see the [notes on atomicity](#atomicity).
+```rust
+use rayon::prelude::*;
+fn sum_of_squares(input: &[i32]) -> i32 {
+    input.par_iter() // <-- just change that!
+         .map(|&i| i * i)
+         .sum()
+}
+```
 
-Rayon currently requires `rustc 1.12.0` or greater.
+[Parallel iterators] take care of deciding how to divide your data
+into tasks; it will dynamically adapt for maximum performance. If you
+need more flexibility than that, Rayon also offers the [join] and
+[scope] functions, which let you create parallel tasks on your own.
+For even more control, you can create [custom threadpools] rather than
+using Rayon's default, global threadpool.
 
-### Using Rayon
+[Parallel iterators]: https://docs.rs/rayon/*/rayon/iter/index.html
+[join]: https://docs.rs/rayon/*/rayon/fn.join.html
+[scope]: https://docs.rs/rayon/*/rayon/fn.scope.html
+[custom threadpools]: https://docs.rs/rayon/*/rayon/struct.ThreadPool.html
+
+## No data races
+
+You may have heard that parallel execution can produce all kinds of
+crazy bugs. Well, rest easy. Rayon's APIs all guarantee **data-race
+freedom**, which generally rules out most parallel bugs (though not
+all). In other words, **if your code compiles**, it typically does the
+same thing it did before.
+
+For the most, parallel iterators in particular are guaranteed to
+produce the same results as their sequential counterparts. One caevat:
+If your iterator has side effects (for example, sending methods to
+other threads through a [Rust channel] or writing to disk), those side
+effects may occur in a different order. Note also that, in some cases,
+parallel iterators offer alternative versions of the sequential
+iterator methods that can have higher performance.
+
+[Rust channel]: https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html
+
+## Using Rayon
 
 [Rayon is available on crates.io](https://crates.io/crates/rayon). The
 recommended way to use it is to add a line into your Cargo.toml such
@@ -51,19 +82,21 @@ extern crate rayon;
 
 To use the Parallel Iterator APIs, a number of traits have to be in
 scope. The easiest way to bring those things into scope is to use the
-[Rayon prelude](https://docs.rs/rayon/*/rayon/prelude/index.html).
-In each module where you would like to use the parallel iterator APIs,
+[Rayon prelude](https://docs.rs/rayon/*/rayon/prelude/index.html).  In
+each module where you would like to use the parallel iterator APIs,
 just add:
 
 ```rust
 use rayon::prelude::*;
 ```
 
-### Contribution
+Rayon currently requires `rustc 1.12.0` or greater.
+
+## Contribution
 
 Rayon is an open source project! If you'd like to contribute to Rayon, check out [the list of "help wanted" issues](https://github.com/rayon-rs/rayon/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). These are all (or should be) issues that are suitable for getting started, and they generally include a detailed set of instructions for what to do. Please ask questions if anything is unclear! Also, check out the [Guide to Development](https://github.com/rayon-rs/rayon/wiki/Guide-to-Development) page on the wiki. Note that all code submitted in PRs to Rayon is assumed to [be licensed under Rayon's dual MIT/Apache2 licensing](https://github.com/rayon-rs/rayon/blob/master/README.md#license).
 
-### Quick demo
+## Quick demo
 
 To see Rayon in action, check out the `rayon-demo` directory, which
 includes a number of demos of code using Rayon. For example, run this
@@ -85,380 +118,11 @@ For more information on demos, try:
 
 **Note:** While Rayon is usable as a library with the stable compiler, running demos or executing tests requires nightly Rust.
 
-### How many threads will Rayon spawn?
+## Other questions?
 
-By default, Rayon uses the same number of threads as the number of CPUs
-available. Note that on systems with hyperthreading enabled this
-equals to the number of logical cores and not the physical ones.
+See [the Rayon FAQ][faq].
 
-If you want to alter the number of threads spawned, you can set the
-environmental variable `RAYON_NUM_THREADS` to the desired number of threads
-or use the [`ThreadPoolBuilder::build_global` function](https://docs.rs/rayon/*/rayon/struct.ThreadPoolBuilder.html#method.build_global) method
-
-### Parallel Iterators
-
-Rayon supports an experimental API called "parallel iterators". These
-let you write iterator-like chains that execute in parallel. For
-example, to compute the sum of the squares of a sequence of integers,
-one might write:
-
-```rust
-use rayon::prelude::*;
-fn sum_of_squares(input: &[i32]) -> i32 {
-    input.par_iter()
-         .map(|&i| i * i)
-         .sum()
-}
-```
-
-Or, to increment all the integers in a slice, you could write:
-
-```rust
-use rayon::prelude::*;
-fn increment_all(input: &mut [i32]) {
-    input.par_iter_mut()
-         .for_each(|p| *p += 1);
-}
-```
-
-To use parallel iterators, first import the traits by adding something
-like `use rayon::prelude::*` to your module. You can then call
-`par_iter` and `par_iter_mut` to get a parallel iterator.  Like a
-[regular iterator][], parallel iterators work by first constructing a
-computation and then executing it. See the
-[`ParallelIterator` trait][pt] for the list of available methods and
-more details. (Sorry, proper documentation is still somewhat lacking.)
-
-[regular iterator]: http://doc.rust-lang.org/std/iter/trait.Iterator.html
-[pt]: https://github.com/rayon-rs/rayon/blob/master/src/iter/mod.rs
-
-### Using join for recursive, divide-and-conquer problems
-
-Parallel iterators are actually implemented in terms of a more
-primitive method called `join`. `join` simply takes two closures and
-potentially runs them in parallel. For example, we could rewrite the
-`increment_all` function we saw for parallel iterators as follows
-(this function increments all the integers in a slice):
-
-```rust
-/// Increment all values in slice.
-fn increment_all(slice: &mut [i32]) {
-    if slice.len() < 1000 {
-        for p in slice { *p += 1; }
-    } else {
-        let mid_point = slice.len() / 2;
-        let (left, right) = slice.split_at_mut(mid_point);
-        rayon::join(|| increment_all(left), || increment_all(right));
-    }
-}
-```
-
-Perhaps a more interesting example is this parallel quicksort:
-
-```rust
-fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
-    if v.len() <= 1 {
-        return;
-    }
-
-    let mid = partition(v);
-    let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(lo), || quick_sort(hi));
-}
-```
-
-**Note though that calling `join` is very different from just spawning
-two threads in terms of performance.** This is because `join` does not
-*guarantee* that the two closures will run in parallel. If all of your
-CPUs are already busy with other work, Rayon will instead opt to run
-them sequentially. The call to `join` is designed to have very low
-overhead in that case, so that you can safely call it even with very
-small workloads (as in the example above).
-
-However, in practice, the overhead is still noticeable. Therefore, for
-maximal performance, you want to have some kind of sequential fallback
-once your problem gets small enough. The parallel iterator APIs try to
-handle this for you. When using join, you have to code it yourself.
-For an example, see the [quicksort demo][], which includes sequential
-fallback after a certain size.
-
-[quicksort demo]: https://github.com/rayon-rs/rayon/blob/master/rayon-demo/src/quicksort/mod.rs
-
-### Safety
-
-You've probably heard that parallel programming can be the source of
-bugs that are really hard to diagnose. That is certainly true!
-However, thanks to Rust's type system, you basically don't have to
-worry about that when using Rayon. The Rayon APIs are guaranteed to be
-data-race free. The Rayon APIs themselves also cannot cause deadlocks
-(though if your closures or callbacks use locks or ports, those locks
-might trigger deadlocks).
-
-For example, if you write code that tries to process the same mutable
-state from both closures, you will find that fails to compile:
-
-```rust
-/// Increment all values in slice.
-fn increment_all(slice: &mut [i32]) {
-    rayon::join(|| process(slice), || process(slice));
-}
-```
-
-However, this safety does have some implications. You will not be able
-to use types which are not thread-safe (i.e., do not implement `Send`)
-from inside a `join` closure. Note that almost all types *are* in fact
-thread-safe in Rust; the only exception is those types that employ
-"interior mutability" without some form of synchronization, such as
-`RefCell` or `Rc`. Here is a list of the most common types in the
-standard library that are not `Send`, along with an alternative that
-you can use instead which *is* `Send` (but which also has higher
-overhead, because it must work across threads):
-
-- `Cell` -- replacement: `AtomicUsize`, `AtomicBool`, etc (but see warning below)
-- `RefCell` -- replacement: `RwLock`, or perhaps `Mutex` (but see warning below)
-- `Rc` -- replacement: `Arc`
-
-However, if you are converting uses of `Cell` or `RefCell`, you must
-be prepared for other threads to interject changes. For more
-information, read the section on atomicity below.
-
-### How it works: Work stealing
-
-Behind the scenes, Rayon uses a technique called work stealing to try
-and dynamically ascertain how much parallelism is available and
-exploit it. The idea is very simple: we always have a pool of worker
-threads available, waiting for some work to do. When you call `join`
-the first time, we shift over into that pool of threads. But if you
-call `join(a, b)` from a worker thread W, then W will place `b` into
-its work queue, advertising that this is work that other worker
-threads might help out with. W will then start executing `a`.
-
-While W is busy with `a`, other threads might come along and take `b`
-from its queue. That is called *stealing* `b`. Once `a` is done, W
-checks whether `b` was stolen by another thread and, if not, executes
-`b` itself. If W runs out of jobs in its own queue, it will look
-through the other threads' queues and try to steal work from them.
-
-This technique is not new. It was first introduced by the
-[Cilk project][cilk], done at MIT in the late nineties. The name Rayon
-is an homage to that work.
-
-[cilk]: http://supertech.csail.mit.edu/cilk/
-
-<a name="atomicity"></a>
-
-#### Warning: Be wary of atomicity
-
-Converting a `Cell` (or, to a lesser extent, a `RefCell`) to work in
-parallel merits special mention for a number of reasons. `Cell` and
-`RefCell` are handy types that permit you to modify data even when
-that data is shared (aliased). They work somewhat differently, but
-serve a common purpose:
-
-1. A `Cell` offers a mutable slot with just two methods, `get` and
-   `set`.  Cells can only be used for `Copy` types that are safe to
-   memcpy around, such as `i32`, `f32`, or even something bigger like a tuple of
-   `(usize, usize, f32)`.
-2. A `RefCell` is kind of like a "single-threaded read-write lock"; it
-   can be used with any sort of type `T`. To gain access to the data
-   inside, you call `borrow` or `borrow_mut`. Dynamic checks are done
-   to ensure that you have either readers or one writer but not both.
-
-While there are threadsafe types that offer similar APIs, caution is
-warranted because, in a threadsafe setting, other threads may
-"interject" modifications in ways that are not possible in sequential
-code. While this will never lead to a *data race* --- that is, you
-need not fear *undefined behavior* --- you can certainly still have
-*bugs*.
-
-Let me give you a concrete example using `Cell`. A common use of `Cell`
-is to implement a shared counter. In that case, you would have something
-like `counter: Rc<Cell<usize>>`. Now I can increment the counter by
-calling `get` and `set` as follows:
-
-```rust
-let value = counter.get();
-counter.set(value + 1);
-```
-
-If I convert this to be a thread-safe counter, I would use the
-corresponding types `tscounter: Arc<AtomicUsize>`. If I then were to
-convert the `Cell` API calls directly, I would do something like this:
-
-```rust
-let value = tscounter.load(Ordering::SeqCst);
-tscounter.store(value + 1, Ordering::SeqCst);
-```
-
-You can already see that the `AtomicUsize` API is a bit more complex,
-as it requires you to specify an
-[ordering](http://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html). (I
-won't go into the details on ordering here, but suffice to say that if
-you don't know what an ordering is, and probably even if you do, you
-should use `Ordering::SeqCst`.) The danger in this parallel version of
-the counter is that other threads might be running at the same time
-and they could cause our counter to get out of sync. For example, if
-we have two threads, then they might both execute the "load" before
-either has a chance to execute the "store":
-
-```
-Thread 1                                          Thread 2
-let value = tscounter.load(Ordering::SeqCst);
-// value = X                                      let value = tscounter.load(Ordering::SeqCst);
-                                                  // value = X
-tscounter.store(value+1);                         tscounter.store(value+1);
-// tscounter = X+1                                // tscounter = X+1
-```
-
-Now even though we've had two increments, we'll only increase the
-counter by one!  Even though we've got no data race, this is still
-probably not the result we wanted. The problem here is that the `Cell`
-API doesn't make clear the scope of a "transaction" -- that is, the
-set of reads/writes that should occur atomically. In this case, we
-probably wanted the get/set to occur together.
-
-In fact, when using the `Atomic` types, you very rarely want a plain
-`load` or plain `store`. You probably want the more complex
-operations. A counter, for example, would use `fetch_add` to
-atomically load and increment the value in one step. Compare-and-swap
-is another popular building block.
-
-A similar problem can arise when converting `RefCell` to `RwLock`, but
-it is somewhat less likely, because the `RefCell` API does in fact
-have a notion of a transaction: the scope of the handle returned by
-`borrow` or `borrow_mut`. So if you convert each call to `borrow` to
-`read` (and `borrow_mut` to `write`), things will mostly work fine in
-a parallel setting, but there can still be changes in behavior.
-Consider using a `handle: RefCell<Vec<i32>>` like :
-
-```rust
-let len = handle.borrow().len();
-for i in 0 .. len {
-    let data = handle.borrow()[i];
-    println!("{}", data);
-}
-```
-
-In sequential code, we know that this loop is safe. But if we convert
-this to parallel code with an `RwLock`, we do not: this is because
-another thread could come along and do
-`handle.write().unwrap().pop()`, and thus change the length of the
-vector. In fact, even in *sequential* code, using very small borrow
-sections like this is an anti-pattern: you ought to be enclosing the
-entire transaction together, like so:
-
-```rust
-let vec = handle.borrow();
-let len = vec.len();
-for i in 0 .. len {
-    let data = vec[i];
-    println!("{}", data);
-}
-```
-
-Or, even better, using an iterator instead of indexing:
-
-```rust
-let vec = handle.borrow();
-for data in vec {
-    println!("{}", data);
-}
-```
-
-There are several reasons to prefer one borrow over many. The most
-obvious is that it is more efficient, since each borrow has to perform
-some safety checks. But it's also more reliable: suppose we modified
-the loop above to not just print things out, but also call into a
-helper function:
-
-```rust
-let vec = handle.borrow();
-for data in vec {
-    helper(...);
-}
-```
-
-And now suppose, independently, this helper fn evolved and had to pop
-something off of the vector:
-
-```rust
-fn helper(...) {
-    handle.borrow_mut().pop();
-}
-```
-
-Under the old model, where we did lots of small borrows, this would
-yield precisely the same error that we saw in parallel land using an
-`RwLock`: the length would be out of sync and our indexing would fail
-(note that in neither case would there be an actual *data race* and
-hence there would never be undefined behavior). But now that we use a
-single borrow, we'll see a borrow error instead, which is much easier
-to diagnose, since it occurs at the point of the `borrow_mut`, rather
-than downstream. Similarly, if we move to an `RwLock`, we'll find that
-the code either deadlocks (if the write is on the same thread as the
-read) or, if the write is on another thread, works just fine. Both of
-these are preferable to random failures in my experience.
-
-#### But wait, isn't Rust supposed to free me from this kind of thinking?
-
-You might think that Rust is supposed to mean that you don't have to
-think about atomicity at all. In fact, if you avoid inherent
-mutability (`Cell` and `RefCell` in a sequential setting, or
-`AtomicUsize`, `RwLock`, `Mutex`, et al. in parallel code), then this
-is true: the type system will basically guarantee that you don't have
-to think about atomicity at all. But often there are times when you
-WANT threads to interleave in the ways I showed above.
-
-Consider for example when you are conducting a search in parallel, say
-to find the shortest route. To avoid fruitless search, you might want
-to keep a cell with the shortest route you've found thus far.  This
-way, when you are searching down some path that's already longer than
-this shortest route, you can just stop and avoid wasted effort. In
-sequential land, you might model this "best result" as a shared value
-like `Rc<Cell<usize>>` (here the `usize` represents the length of best
-path found so far); in parallel land, you'd use a `Arc<AtomicUsize>`.
-Now we can make our search function look like:
-
-```rust
-fn search(path: &Path, cost_so_far: usize, best_cost: &Arc<AtomicUsize>) {
-    if cost_so_far >= best_cost.load(Ordering::SeqCst) {
-        return;
-    }
-    ...
-    best_cost.store(...);
-}
-```
-
-Now in this case, we really WANT to see results from other threads
-interjected into our execution!
-
-## Semver policy, the rayon-core crate, and unstable features
-
-Rayon follows semver versioning. However, we also have APIs that are
-still in the process of development and which may break from release
-to release -- those APIs are not subject to semver. To use them,
-you have to set the cfg flag `rayon_unstable`. The easiest way to do this
-is to use the `RUSTFLAGS` environment variable:
-
-```
-RUSTFLAGS='--cfg rayon_unstable' cargo build
-```
-
-Note that this must not only be done for your crate, but for any crate
-that depends on your crate. This infectious nature is intentional, as
-it serves as a reminder that you are outside of the normal semver
-guarantees. **If you see unstable APIs that you would like to use,
-please request stabilization on the correspond tracking issue!**
-
-Rayon itself is internally split into two crates. The `rayon` crate is
-intended to be the main, user-facing crate, and hence all the
-documentation refers to `rayon`. This crate is still evolving and
-regularly goes through (minor) breaking changes. The `rayon-core`
-crate contains the global thread-pool and defines the core APIs: we no
-longer permit breaking changes in this crate (except to unstable
-features). The intention is that multiple semver-incompatible versions
-of the rayon crate can peacefully coexist; they will all share one
-global thread-pool through the `rayon-core` crate.
+[faq]: https://github.com/rayon-rs/rayon/blob/master/FAQ.md
 
 ## License
 

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -34,10 +34,19 @@ mod test;
 ///
 /// # Examples
 ///
-/// This example uses join to perform a quick-sort:
+/// This example uses join to perform a quick-sort (note this is not a
+/// particularly optimized implementation: if you **actually** want to
+/// sort for real, you should prefer [the `par_sort` method] offered
+/// by Rayon).
+///
+/// [the `par_sort` method]: ../slice/trait.ParallelSliceMut.html#method.par_sort
 ///
 /// ```rust
 /// # use rayon_core as rayon;
+/// let mut v = vec![5, 1, 8, 22, 0, 44];
+/// quick_sort(&mut v);
+/// assert_eq!(v, vec![0, 1, 5, 8, 22, 44]);
+///
 /// fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 ///    if v.len() > 1 {
 ///        let mid = partition(v);
@@ -47,26 +56,22 @@ mod test;
 ///    }
 /// }
 ///
-/// let mut v = vec![5, 1, 8, 22, 0, 44];
-/// quick_sort(&mut v);
-/// assert_eq!(v, vec![0, 1, 5, 8, 22, 44]);
-///
-/// # // Partition rearranges all items `<=` to the pivot
-/// # // item (arbitrary selected to be the last item in the slice)
-/// # // to the first half of the slice. It then returns the
-/// # // "dividing point" where the pivot is placed.
-/// # fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
-/// #     let pivot = v.len() - 1;
-/// #     let mut i = 0;
-/// #     for j in 0..pivot {
-/// #         if v[j] <= v[pivot] {
-/// #             v.swap(i, j);
-/// #             i += 1;
-/// #         }
-/// #     }
-/// #     v.swap(i, pivot);
-/// #     i
-/// # }
+/// // Partition rearranges all items `<=` to the pivot
+/// // item (arbitrary selected to be the last item in the slice)
+/// // to the first half of the slice. It then returns the
+/// // "dividing point" where the pivot is placed.
+/// fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
+///     let pivot = v.len() - 1;
+///     let mut i = 0;
+///     for j in 0..pivot {
+///         if v[j] <= v[pivot] {
+///             v.swap(i, j);
+///             i += 1;
+///         }
+///     }
+///     v.swap(i, pivot);
+///     i
+/// }
 /// ```
 ///
 /// # Warning about blocking I/O

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -32,7 +32,44 @@ mod test;
 /// while waiting for the thief to fully execute closure B. (This is the
 /// typical work-stealing strategy).
 ///
-/// ### Warning about blocking I/O
+/// # Examples
+///
+/// This example uses join to perform a quick-sort:
+///
+/// ```rust
+/// # use rayon_core as rayon;
+/// fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
+///    if v.len() > 1 {
+///        let mid = partition(v);
+///        let (lo, hi) = v.split_at_mut(mid);
+///        rayon::join(|| quick_sort(lo),
+///                    || quick_sort(hi));
+///    }
+/// }
+///
+/// let mut v = vec![5, 1, 8, 22, 0, 44];
+/// quick_sort(&mut v);
+/// assert_eq!(v, vec![0, 1, 5, 8, 22, 44]);
+///
+/// # // Partition rearranges all items `<=` to the pivot
+/// # // item (arbitrary selected to be the last item in the slice)
+/// # // to the first half of the slice. It then returns the
+/// # // "dividing point" where the pivot is placed.
+/// # fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
+/// #     let pivot = v.len() - 1;
+/// #     let mut i = 0;
+/// #     for j in 0..pivot {
+/// #         if v[j] <= v[pivot] {
+/// #             v.swap(i, j);
+/// #             i += 1;
+/// #         }
+/// #     }
+/// #     v.swap(i, pivot);
+/// #     i
+/// # }
+/// ```
+///
+/// # Warning about blocking I/O
 ///
 /// The assumption is that the closures given to `join()` are
 /// CPU-bound tasks that do not perform I/O or other blocking
@@ -42,7 +79,7 @@ mod test;
 /// on another (for example, using a channel), that could lead to a
 /// deadlock.
 ///
-/// ### Panics
+/// # Panics
 ///
 /// No matter what happens, both closures will always be executed.  If
 /// a single closure panics, whether it be the first or second

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -73,7 +73,7 @@ pub use spawn::spawn;
 /// parallel work (the parallel iterator traits use this value
 /// internally for this purpose).
 ///
-/// ### Future compatibility note
+/// # Future compatibility note
 ///
 /// Note that unless this thread-pool was created with a
 /// builder that specifies the number of threads, then this

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -61,7 +61,7 @@ pub struct Scope<'scope> {
 /// whereas `join()` can make exclusive use of the stack. **Prefer
 /// `join()` (or, even better, parallel iterators) where possible.**
 ///
-/// ### Example
+/// # Example
 ///
 /// The Rayon `join()` function launches two closures and waits for them
 /// to stop. One could implement `join()` using a scope like so, although
@@ -85,14 +85,14 @@ pub struct Scope<'scope> {
 /// }
 /// ```
 ///
-/// ### A note on threading
+/// # A note on threading
 ///
 /// The closure given to `scope()` executes in the Rayon thread-pool,
 /// as do those given to `spawn()`. This means that you can't access
 /// thread-local variables (well, you can, but they may have
 /// unexpected values).
 ///
-/// ### Task execution
+/// # Task execution
 ///
 /// Task execution potentially starts as soon as `spawn()` is called.
 /// The task will end sometime before `scope()` returns. Note that the
@@ -156,7 +156,7 @@ pub struct Scope<'scope> {
 /// will be joined before that scope returns, which in turn occurs
 /// before the creating task (task `s.1.1` in this case) finishes.
 ///
-/// ### Accessing stack data
+/// # Accessing stack data
 ///
 /// In general, spawned tasks may access stack data in place that
 /// outlives the scope itself. Other data must be fully owned by the
@@ -246,7 +246,7 @@ pub struct Scope<'scope> {
 /// });
 /// ```
 ///
-/// ### Panics
+/// # Panics
 ///
 /// If a panic occurs, either in the closure given to `scope()` or in
 /// any of the spawned jobs, that panic will be propagated and the

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -126,7 +126,7 @@ impl ThreadPool {
 
     /// Returns the (current) number of threads in the thread pool.
     ///
-    /// ### Future compatibility note
+    /// # Future compatibility note
     ///
     /// Note that unless this thread-pool was created with a
     /// [`ThreadPoolBuilder`] that specifies the number of threads,
@@ -149,7 +149,7 @@ impl ThreadPool {
     /// lifetime. However, multiple threads may share the same index if
     /// they are in distinct thread-pools.
     ///
-    /// ### Future compatibility note
+    /// # Future compatibility note
     ///
     /// Currently, every thread-pool (including the global
     /// thread-pool) has a fixed number of threads, but this may
@@ -276,7 +276,7 @@ impl fmt::Debug for ThreadPool {
 ///
 /// [m]: struct.ThreadPool.html#method.current_thread_index
 ///
-/// ### Future compatibility note
+/// # Future compatibility note
 ///
 /// Currently, every thread-pool (including the global
 /// thread-pool) has a fixed number of threads, but this may

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -41,9 +41,10 @@
 //!   operations. See [the `ParallelSlice` trait] for the full list.
 //! - Strings (`&str`) offer methods like `par_split` and `par_lines`.
 //!   See [the `ParallelString` trait] for the full list.
-//! - Various collections offer [`par_extend`], which grows a collection
-//!   given a parallel iterator. (You can use [`collect()`] to create a parallel
-//!   iterator.)
+//! - Various collections offer [`par_extend`], which grows a
+//!   collection given a parallel iterator. (If you don't have a
+//!   collection to extend, you can use [`collect()`] to create a new
+//!   one from scratch.)
 //!
 //! [the `ParallelSlice` trait]: ../slice/trait.ParallelSlice.html
 //! [the `ParallelString` trait]: ../str/trait.ParallelString.html

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,13 +1,47 @@
-//! The `ParallelIterator` module makes it easy to write parallel
-//! programs using an iterator-style interface. To get access to all
-//! the methods you want, the easiest is to write `use
-//! rayon::prelude::*;` at the top of your module, which will import
-//! the various traits and methods you need.
+//! Contains the main "parallel iterator" traits.
 //!
-//! The submodules of this module mostly just contain implementaton
-//! details of little interest to an end-user. If you'd like to read
-//! the code itself, the `plumbing` module and `README.md` file are a
-//! good place to start.
+//! Parallel iterators make it easy to write iterator-like chains that
+//! execute in parallel. For example, to compute the sum of the
+//! squares of a sequence of integers, one might write:
+//!
+//! ```rust
+//! use rayon::prelude::*;
+//! fn sum_of_squares(input: &[i32]) -> i32 {
+//!     input.par_iter()
+//!          .map(|i| i * i)
+//!          .sum()
+//! }
+//! ```
+//!
+//! Or, to increment all the integers in a slice, you could write:
+//!
+//! ```rust
+//! use rayon::prelude::*;
+//! fn increment_all(input: &mut [i32]) {
+//!     input.par_iter_mut()
+//!          .for_each(|p| *p += 1);
+//! }
+//! ```
+//!
+//! To use parallel iterators, first import the traits by adding
+//! something like `use rayon::prelude::*` to your module. You can
+//! then call `par_iter`, `par_iter_mut`, or `into_par_iter` to get a
+//! parallel iterator. Like a [regular iterator][], parallel
+//! iterators work by first constructing a computation and then
+//! executing it.
+//!
+//! To see the full range of methods available on parallel iterators,
+//! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
+//! traits.
+//!
+//! If you'd like to offer parallel iterators for your own collector,
+//! or write your own combinator, then check out the [plumbing]
+//! module.
+//!
+//! [regular iterator]: http://doc.rust-lang.org/std/iter/trait.Iterator.html
+//! [`ParallelIterator`]: trait.ParallelIterator.html
+//! [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+//! [plumbing]: plumbing
 
 pub use either::Either;
 use std::cmp::{self, Ordering};
@@ -189,7 +223,20 @@ impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
     }
 }
 
-/// The `ParallelIterator` interface.
+/// Parallel version of the standard iterator trait.
+///
+/// The combinators on this trait are available on **all** parallel
+/// iterators.  Additional methods can be found on the
+/// [`IndexedParallelIterator`] trait: those methods are only
+/// available for parallel iterators where the number of items is
+/// known in advance (so, e.g., after invoking `filter`, those methods
+/// become unavailable).
+///
+/// For examples of using parallel iterators, see [the docs on the
+/// `iter` module][iter].
+///
+/// [iter]: index.html
+/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 pub trait ParallelIterator: Sized + Send {
     /// The type of item that this parallel iterator produces.
     /// For example, if you use the [`for_each`] method, this is the type of

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,8 +1,11 @@
 //! Contains the main "parallel iterator" traits.
 //!
 //! Parallel iterators make it easy to write iterator-like chains that
-//! execute in parallel. For example, to compute the sum of the
-//! squares of a sequence of integers, one might write:
+//! execute in parallel: typically all you have to do is convert the
+//! first `.iter()` (or `iter_mut()`, `into_iter()`, etc) method into
+//! `par_iter()` (or `par_iter_mut()`, `into_par_iter()`, etc). For
+//! example, to compute the sum of the squares of a sequence of
+//! integers, one might write:
 //!
 //! ```rust
 //! use rayon::prelude::*;
@@ -29,6 +32,30 @@
 //! parallel iterator. Like a [regular iterator][], parallel
 //! iterators work by first constructing a computation and then
 //! executing it.
+//!
+//! In addition to `par_iter()` and friends, some types offer other
+//! ways to create (or consume) parallel iterators:
+//!
+//! - Slices (`&[T]`, `&mut [T]`) offer methods like `par_split` and
+//!   `par_windows`, as well as various parallel sorting
+//!   operations. See [the `ParallelSlice` trait] for the full list.
+//! - Strings (`&str`) offer methods like `par_split` and `par_lines`.
+//!   See [the `ParallelString` trait] for the full list.
+//! - Various collections offer [`par_extend`], which grows a collection
+//!   given a parallel iterator. (You can use [`collect()`] to create a parallel
+//!   iterator.)
+//!
+//! [the `ParallelSlice` trait]: ../slice/trait.ParallelSlice.html
+//! [the `ParallelString` trait]: ../str/trait.ParallelString.html
+//! [`par_extend`]: trait.ParallelExtend.html
+//! [`collect()`]: trait.ParallelIterator.html#method.collect
+//!
+//! These are the full set of methods you can use to create a parallel iterator:
+//!
+//! - `par_iter` -- iterates over `&T` references to the items in the collection
+//! - `par_iter_mut` -- iterates over `&mut T` references to the items in the collection
+//! - `into_par_iter` -- iterates over the items in the collection, taking ownership of each
+//! - `par_split`
 //!
 //! To see the full range of methods available on parallel iterators,
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -50,13 +50,6 @@
 //! [`par_extend`]: trait.ParallelExtend.html
 //! [`collect()`]: trait.ParallelIterator.html#method.collect
 //!
-//! These are the full set of methods you can use to create a parallel iterator:
-//!
-//! - `par_iter` -- iterates over `&T` references to the items in the collection
-//! - `par_iter_mut` -- iterates over `&mut T` references to the items in the collection
-//! - `into_par_iter` -- iterates over the items in the collection, taking ownership of each
-//! - `par_split`
-//!
 //! To see the full range of methods available on parallel iterators,
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
 //! traits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,40 +4,48 @@
 #![cfg_attr(test, feature(i128_type))]
 #![deny(missing_docs)]
 
-//! Data-parallelism library that is easy to convert sequential computations into parallel.
+//! Data-parallelism library that makes it easy to convert sequential
+//! computations into parallel.
 //!
-//! Rayon is lightweight and convenient for application to existing code.  It guarantees
-//! data-race free executions, and takes advantage of parallelism when sensible, based
-//! on work-load at runtime.
+//! Rayon is a lightweight and convenient way to add parallellism into
+//! your existing code.  It guarantees data-race free executions, and
+//! takes advantage of parallelism when sensible, based on work-load
+//! at runtime.
 //!
 //! # How to use Rayon
 //!
 //! There are two ways to use Rayon:
 //!
-//! - [**Parallel iterators**][iter module] make it easy to convert a sequential iterator to
-//!   execute in parallel.
-//!   - Parallel iterators are the both the simplest and preferred way
-//!     to use Rayon, as the high-level interface gives the library
-//!     plenty of room to adapt the number of parallel tasks
-//!     dynamically for maximum efficiency.
-//!   - For more info, see the docs for the [iter module].
+//! - **High-level parallel constructs** are the simplest way to use Rayon and also
+//!   typically the most efficient.
+//!   - [Parallel iterators][iter module] make it easy to convert a sequential iterator to
+//!     execute in parallel.
+//!   - The [`par_sort`] method sorts `&mut [T]` slices (or vectors) in parallel.
+//!   - [`par_extend`] can be used to efficiently grow collections with items produced
+//!     by a parallel iterator.
 //! - **Custom tasks** let you divide your work into parallel tasks yourself.
-//!   - There are two main functions available:
-//!     - [`join`] is used to subdivide a task into two pieces.
-//!     - [`scope`] creates a scope within which you can create any number of parallel tasks.
-//!   - See the docs for those functions for examples and more information.
+//!   - [`join`] is used to subdivide a task into two pieces.
+//!   - [`scope`] creates a scope within which you can create any number of parallel tasks.
+//!   - [`ThreadPoolBuilder`] can be used to create your own thread pools or customize
+//!     the global one.
 //!
 //! [iter module]: iter
 //! [`join`]: fn.join.html
 //! [`scope`]: fn.scope.html
+//! [`par_sort`]: slice/trait.ParallelSliceMut.html#method.par_sort
+//! [`par_extend`]: iter/trait.ParallelExtend.html#tymethod.par_extend
+//! [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
 //!
-//! # Rayon prelude
+//! # Basic usage and the Rayon prelude
 //!
-//! To use parallel iterators, you need to import several
-//! traits. Those traits are bundled into the module
-//! [`rayon::prelude`]. It is recommended that you import all of these
-//! traits at once by adding `use rayon::prelude::*` at the top of
-//! each module that uses Rayon methods.
+//! First, you will need to add `rayon` to your `Cargo.toml` and put
+//! `extern crate rayon` in your main file (`lib.rs`, `main.rs`).
+//!
+//! Next, to use parallel iterators or the other high-level methods,
+//! you need to import several traits. Those traits are bundled into
+//! the module [`rayon::prelude`]. It is recommended that you import
+//! all of these traits at once by adding `use rayon::prelude::*` at
+//! the top of each module that uses Rayon methods.
 //!
 //! These traits will give you access to `par_iter` with parallel
 //! implementations of iterative functions including [`map`], [`for_each`], [`filter`],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,78 +8,38 @@
 //!
 //! Rayon is lightweight and convenient for application to existing code.  It guarantees
 //! data-race free executions, and takes advantage of parallelism when sensible, based
-//! on work-load at runtime.  There are two categories of rayon workloads: parallel
-//! iterators and multi-branched recursion (`join` method).
+//! on work-load at runtime.
 //!
-//! # Parallel Iterators
+//! # How to use Rayon
 //!
-//! Parallel iterators are formed using [`par_iter`], [`par_iter_mut`], and [`into_par_iter`]
-//! functions to iterate by shared reference, mutable reference, or by value respectively.
-//! These iterators are chained with computations that can take the
-//! shape of `map` or `for_each` as an example.  This solves [embarrassingly]
-//! parallel tasks that are completely independent of one another.
+//! There are two ways to use Rayon:
 //!
-//! [`par_iter`]: iter/trait.IntoParallelRefIterator.html#tymethod.par_iter
-//! [`par_iter_mut`]: iter/trait.IntoParallelRefMutIterator.html#tymethod.par_iter_mut
-//! [`into_par_iter`]: iter/trait.IntoParallelIterator.html#tymethod.into_par_iter
-//! [embarrassingly]: https://en.wikipedia.org/wiki/Embarrassingly_parallel
+//! - [**Parallel iterators**][iter module] make it easy to convert a sequential iterator to
+//!   execute in parallel.
+//!   - Parallel iterators are the both the simplest and preferred way
+//!     to use Rayon, as the high-level interface gives the library
+//!     plenty of room to adapt the number of parallel tasks
+//!     dynamically for maximum efficiency.
+//!   - For more info, see the docs for the [iter module].
+//! - **Custom tasks** let you divide your work into parallel tasks yourself.
+//!   - There are two main functions available:
+//!     - [`join`] is used to subdivide a task into two pieces.
+//!     - [`scope`] creates a scope within which you can create any number of parallel tasks.
+//!   - See the docs for those functions for examples and more information.
 //!
-//! # Examples
-//!
-//! Here a string is encrypted using ROT13 leveraging parallelism.  Once all the
-//! threads are complete, they are collected into a string.
-//!
-//! ```
-//! extern crate rayon;
-//! use rayon::prelude::*;
-//! # fn main() {
-//! let mut chars: Vec<char> = "A man, a plan, a canal - Panama!".chars().collect();
-//! let encrypted: String = chars.into_par_iter().map(|c| {
-//!        match c {
-//!            'A' ... 'M' | 'a' ... 'm' => ((c as u8) + 13) as char,
-//!            'N' ... 'Z' | 'n' ... 'z' => ((c as u8) - 13) as char,
-//!            _ => c
-//!        }
-//!    }).collect();
-//!    assert_eq!(encrypted, "N zna, n cyna, n pnany - Cnanzn!");
-//! # }
-//! ```
-//!
-//! # Divide and conquer with `join`
-//!
-//! [`join`] takes two closures and runs them in parallel if doing so will improve
-//! execution time.  Parallel Iterators are implemented using [`join`] with
-//! work-stealing.  Given two tasks that safely run in parallel, one task is queued
-//! and another starts processing.  If idle threads exist, they begin execution on
-//! the queued work.
-//!
+//! [iter module]: iter
 //! [`join`]: fn.join.html
+//! [`scope`]: fn.scope.html
 //!
-//! # Examples
+//! # Rayon prelude
 //!
-//! ```rust,ignore
-//! join(|| do_something(), || do_something_else())
-//! ```
+//! To use parallel iterators, you need to import several
+//! traits. Those traits are bundled into the module
+//! [`rayon::prelude`]. It is recommended that you import all of these
+//! traits at once by adding `use rayon::prelude::*` at the top of
+//! each module that uses Rayon methods.
 //!
-//! ```rust
-//! fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
-//!    if v.len() > 1 {
-//!        let mid = partition(v);
-//!        let (lo, hi) = v.split_at_mut(mid);
-//!        rayon::join(|| quick_sort(lo),
-//!                    || quick_sort(hi));
-//!    }
-//! }
-//! # fn main() { }
-//! # fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize { 0 }
-//! ```
-//!
-//! # Rayon Types
-//!
-//! Rayon traits are bundled into [`rayon::prelude::*`].  To get access to parallel
-//! implementations on various standard types include `use rayon::prelude::*;`
-//!
-//! These implementations will give you access to `par_iter` with parallel
+//! These traits will give you access to `par_iter` with parallel
 //! implementations of iterative functions including [`map`], [`for_each`], [`filter`],
 //! [`fold`], and [more].
 //!
@@ -105,6 +65,12 @@
 //! [the `option` module of `std`]: https://doc.rust-lang.org/std/option/index.html
 //! [the `collections` from `std`]: https://doc.rust-lang.org/std/collections/index.html
 //! [`std`]: https://doc.rust-lang.org/std/
+//!
+//! # Other questions?
+//!
+//! See [the Rayon FAQ][faq].
+//!
+//! [faq]: https://github.com/rayon-rs/rayon/blob/master/FAQ.md
 
 extern crate rayon_core;
 extern crate either;

--- a/src/option.rs
+++ b/src/option.rs
@@ -7,8 +7,15 @@ use iter::plumbing::*;
 use std;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-
-/// Parallel iterator over an option
+/// A parallel iterator over the value in [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
+///
+/// This `struct` is created by the [`par_iter_mut`] function.
+///
+/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
+/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+/// [`into_par_iter`]: ../iter/trait.IntoParallelIterator.html#tymethod.into_par_iter
 #[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     opt: Option<T>,
@@ -62,8 +69,15 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     }
 }
 
-
-/// Parallel iterator over an immutable reference to an option
+/// A parallel iterator over a reference to the [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
+///
+/// This `struct` is created by the [`par_iter`] function.
+///
+/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
+/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+/// [`par_iter`]: ../iter/trait.IntoParallelRefIterator.html#tymethod.par_iter
 #[derive(Debug)]
 pub struct Iter<'a, T: Sync + 'a> {
     inner: IntoIter<&'a T>,
@@ -90,7 +104,15 @@ delegate_indexed_iterator!{
 }
 
 
-/// Parallel iterator over a mutable reference to an option
+/// A parallel iterator over a mutable reference to the [`Some`] variant of an [`Option`].
+///
+/// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
+///
+/// This `struct` is created by the [`par_iter_mut`] function.
+///
+/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
+/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
+/// [`par_iter_mut`]: ../iter/trait.IntoParallelRefMutIterator.html#tymethod.par_iter_mut
 #[derive(Debug)]
 pub struct IterMut<'a, T: Send + 'a> {
     inner: IntoIter<&'a mut T>,

--- a/src/option.rs
+++ b/src/option.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// The iterator yields one value if the [`Option`] is a [`Some`], otherwise none.
 ///
-/// This `struct` is created by the [`par_iter_mut`] function.
+/// This `struct` is created by the [`into_par_iter`] function.
 ///
 /// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
 /// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some


### PR DESCRIPTION
The iter module and join/scope functions now host the primary docs. The README and crate-level docs mostly forward to those. Some of the detailed material from the README is moved to a FAQ and lightly edited.