### PR TITLE
Replace coco with crossbeam-deque

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ matrix:
   fast_finish: true
   include:
     # NB: To help with CI delays, each `pull_request` is only tested on Linux,
-    # with 1.12 for compatibility and nightly+rayon_unstable for broad test
+    # with 1.13 for compatibility and nightly+rayon_unstable for broad test
     # coverage.  The bors bot counts as a `push` type, which will run it all.
 
-    - rust: 1.12.0
+    - rust: 1.13.0
       os: linux
       #if: everything!
       before_script:
-        # rand 0.4.2 requires rust 1.22, and rand-0.3.22 requires rand-0.4  :/
+        # rand 0.4.2 requires rust 1.15, and rand-0.3.22 requires rand-0.4  :/
         # manually hacking the lockfile due to the limitations of cargo#2773
         - cargo generate-lockfile
         - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ just add:
 use rayon::prelude::*;
 ```
 
-Rayon currently requires `rustc 1.12.0` or greater.
+Rayon currently requires `rustc 1.13.0` or greater.
 
 ## Contribution
 

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["concurrency"]
 [dependencies]
 rand = ">= 0.3, < 0.5"
 num_cpus = "1.2"
-coco = "0.3.2"
+crossbeam-deque = "0.2.0"
 libc = "0.2.16"
 lazy_static = "1"
 

--- a/rayon-core/README.md
+++ b/rayon-core/README.md
@@ -7,3 +7,5 @@ rayon-core aims to never, or almost never, have a breaking change to its API, be
 Please see [Rayon Docs] for details about using Rayon.
 
 [Rayon Docs]: https://docs.rs/rayon/
+
+Rayon-core currently requires `rustc 1.13.0` or greater.

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -32,7 +32,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::fmt;
 
-extern crate coco;
+extern crate crossbeam_deque;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;


### PR DESCRIPTION
These are the changes from @stjepang and @jeehoonkang, replacing and closing #480.  The minimum rustc is *slightly* increased from 1.12 to 1.13 for the transitive requirements.