### PR TITLE
fix the relative links to the iter module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!   - [`ThreadPoolBuilder`] can be used to create your own thread pools or customize
 //!     the global one.
 //!
-//! [iter module]: iter
+//! [iter module]: iter/index.html
 //! [`join`]: fn.join.html
 //! [`scope`]: fn.scope.html
 //! [`par_sort`]: slice/trait.ParallelSliceMut.html#method.par_sort


### PR DESCRIPTION
Browsing the Rayon 1.0 docs I hit a few snags.