### PR TITLE
Mention the split() method in the documentation of the iter module

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -58,13 +58,13 @@
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
 //! traits.
 //!
-//! If you'd like to offer parallel iterators for your own collector,
-//! or write your own combinator, then check out the [plumbing]
-//! module.
+//! If you'd like to build a custom parallel iterator, or to write your own
+//! combinator, then check out the [split] function and the [plumbing] module.
 //!
 //! [regular iterator]: http://doc.rust-lang.org/std/iter/trait.Iterator.html
 //! [`ParallelIterator`]: trait.ParallelIterator.html
 //! [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+//! [split]: fn.split.html
 //! [plumbing]: plumbing
 
 pub use either::Either;

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -8,77 +8,106 @@ use std::fmt::{self, Debug};
 ///
 /// # Examples
 ///
+/// As a simple example, Rayon can recursively split ranges of indices
+///
 /// ```
 /// use rayon::iter;
 /// use rayon::prelude::*;
 /// use std::ops::Range;
 ///
 ///
-/// // This is a range of bi-dimensional indices
-/// #[derive(Debug)]
-/// struct Range2D {
-///     // Horizontal range of indices
-///     pub rx: Range<usize>,
+/// // We define a range of indices as follows
+/// type Range1D = Range<usize>;
 ///
-///     // Vertical range of indices
-///     pub ry: Range<usize>,
+/// // Splitting it in two can be done like this
+/// fn split_range1(r: Range1D) -> (Range1D, Option<Range1D>) {
+///     // We are mathematically unable to split the range if there is only
+///     // one point inside of it, but we could stop splitting before that.
+///     if r.end - r.start <= 1 { return (r, None); }
+///
+///     // Here, our range is considered large enough to be splittable
+///     let midpoint = r.start + (r.end - r.start) / 2;
+///     let out1 = Range1D {
+///         start: r.start,
+///         end: midpoint,
+///     };
+///     let out2 = Range1D {
+///         start: midpoint,
+///         end: r.end,
+///     };
+///     (out1, Some(out2))
 /// }
 ///
-/// // We want to recursively split it by the largest dimension until we have
+/// // By using iter::split, Rayon will split the range until it has enough work
+/// // to feed the CPU cores, then give us the resulting sub-ranges
+/// iter::split(0..4096, split_range1).for_each(|sub_range| {
+///     // As our initial range had a power-of-two size, the final sub-ranges
+///     // should have power-of-two sizes too
+///     assert!((sub_range.end - sub_range.start).is_power_of_two());
+/// });
+/// ```
+///
+/// This recursive splitting can be extended to two or three dimensions,
+/// to reproduce a classic "block-wise" parallelization scheme of graphics and
+/// numerical simulations:
+///
+/// ```
+/// # type Range1D = Range<usize>;
+/// # fn split_range1(r: Range1D) -> (Range1D, Option<Range1D>) {
+/// #     if r.end - r.start <= 1 { return (r, None); }
+/// #     let midpoint = r.start + (r.end - r.start) / 2;
+/// #     let out1 = Range1D {
+/// #         start: r.start,
+/// #         end: midpoint,
+/// #     };
+/// #     let out2 = Range1D {
+/// #         start: midpoint,
+/// #         end: r.end,
+/// #     };
+/// #     (out1, Some(out2))
+/// # }
+/// #
+/// // A two-dimensional range of indices can be built out of two 1D ones
+/// #[derive(Debug)]
+/// struct Range2D {
+///     // Range of horizontal indices
+///     pub rx: Range1D,
+///
+///     // Range of vertical indices
+///     pub ry: Range1D,
+/// }
+///
+/// // We want to recursively split them by the largest dimension until we have
 /// // enough sub-ranges to feed our mighty multi-core CPU. This function
 /// // carries out one such split.
-/// fn split_range(r2: Range2D) -> (Range2D, Option<Range2D>) {
+/// fn split_range2(r2: Range2D) -> (Range2D, Option<Range2D>) {
 ///     // Decide on which axis (horizontal/vertical) the range should be split
 ///     let width = r2.rx.end - r2.rx.start;
 ///     let height = r2.ry.end - r2.ry.start;
 ///     if width >= height {
-///         // We are mathematically unable to split the range if there is only
-///         // one point inside of it, but we could stop splitting before that.
-///         if width <= 1 { return (r2, None); }
-///
-///         // Here, our range is considered large enough to be splittable on
-///         // the horizontal axis
-///         let midpoint = r2.rx.start + (r2.rx.end - r2.rx.start) / 2;
+///         // This is a wide rectangle, split it on the horizontal axis
+///         let (split_rx, ry) = (split_range1(r2.rx), r2.ry);
 ///         let out1 = Range2D {
-///             rx: Range {
-///                 start: r2.rx.start,
-///                 end: midpoint,
-///             },
-///             ry: r2.ry.clone(),
+///             rx: split_rx.0,
+///             ry: ry.clone(),
 ///         };
-///         let out2 = Range2D {
-///             rx: Range {
-///                 start: midpoint,
-///                 end: r2.rx.end,
-///             },
-///             ry: r2.ry,
-///         };
-///         (out1, Some(out2))
+///         let out2 = split_rx.1.map(|rx| Range2D { rx, ry });
+///         (out1, out2)
 ///     } else {
-///         // This is essentially the same work as above, but vertically
-///         if height <= 1 { return (r2, None); }
-///         let midpoint = r2.ry.start + (r2.ry.end - r2.ry.start) / 2;
+///         // This is a tall rectangle, split it on the vertical axis
+///         let (rx, split_ry) = (r2.rx, split_range1(r2.ry));
 ///         let out1 = Range2D {
-///             rx: r2.rx.clone(),
-///             ry: Range {
-///                 start: r2.ry.start,
-///                 end: midpoint,
-///             },
+///             rx: rx.clone(),
+///             ry: split_ry.0,
 ///         };
-///         let out2 = Range2D {
-///             rx: r2.rx,
-///             ry: Range {
-///                 start: midpoint,
-///                 end: r2.ry.end,
-///             },
-///         };
-///         (out1, Some(out2))
+///         let out2 = split_ry.1.map(|ry| Range2D { rx, ry, });
+///         (out1, out2)
 ///     }
 /// }
 ///
-/// // By using iter::split, Rayon will gladly do the recursive splitting for us
+/// // Again, rayon can handle the recursive splitting for us
 /// let range = Range2D { rx: 0..800, ry: 0..600 };
-/// iter::split(range, split_range).for_each(|sub_range| {
+/// iter::split(range, split_range2).for_each(|sub_range| {
 ///     // If the sub-ranges were indeed split by the largest dimension, then
 ///     // if no dimension was twice larger than the other initially, this
 ///     // property will remain true in the final sub-ranges.

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -9,6 +9,11 @@ use std::fmt::{self, Debug};
 /// # Examples
 ///
 /// ```
+/// use rayon::iter;
+/// use rayon::prelude::*;
+/// use std::ops::Range;
+///
+///
 /// // This is a range of bi-dimensional indices
 /// #[derive(Debug)]
 /// struct Range2D {

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -52,6 +52,9 @@ use std::fmt::{self, Debug};
 /// numerical simulations:
 ///
 /// ```
+/// # use rayon::iter;
+/// # use rayon::prelude::*;
+/// # use std::ops::Range;
 /// # type Range1D = Range<usize>;
 /// # fn split_range1(r: Range1D) -> (Range1D, Option<Range1D>) {
 /// #     if r.end - r.start <= 1 { return (r, None); }

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -5,6 +5,84 @@ use std::fmt::{self, Debug};
 
 /// The `split` function takes arbitrary data and a closure that knows how to
 /// split it, and turns this into a `ParallelIterator`.
+///
+/// # Examples
+///
+/// ```
+/// // This is a range of bi-dimensional indices
+/// #[derive(Debug)]
+/// struct Range2D {
+///     // Horizontal range of indices
+///     pub rx: Range<usize>,
+///
+///     // Vertical range of indices
+///     pub ry: Range<usize>,
+/// }
+///
+/// // We want to recursively split it by the largest dimension until we have
+/// // enough sub-ranges to feed our mighty multi-core CPU. This function
+/// // carries out one such split.
+/// fn split_range(r2: Range2D) -> (Range2D, Option<Range2D>) {
+///     // Decide on which axis (horizontal/vertical) the range should be split
+///     let width = r2.rx.end - r2.rx.start;
+///     let height = r2.ry.end - r2.ry.start;
+///     if width >= height {
+///         // We are mathematically unable to split the range if there is only
+///         // one point inside of it, but we could stop splitting before that.
+///         if width <= 1 { return (r2, None); }
+///
+///         // Here, our range is considered large enough to be splittable on
+///         // the horizontal axis
+///         let midpoint = r2.rx.start + (r2.rx.end - r2.rx.start) / 2;
+///         let out1 = Range2D {
+///             rx: Range {
+///                 start: r2.rx.start,
+///                 end: midpoint,
+///             },
+///             ry: r2.ry.clone(),
+///         };
+///         let out2 = Range2D {
+///             rx: Range {
+///                 start: midpoint,
+///                 end: r2.rx.end,
+///             },
+///             ry: r2.ry,
+///         };
+///         (out1, Some(out2))
+///     } else {
+///         // This is essentially the same work as above, but vertically
+///         if height <= 1 { return (r2, None); }
+///         let midpoint = r2.ry.start + (r2.ry.end - r2.ry.start) / 2;
+///         let out1 = Range2D {
+///             rx: r2.rx.clone(),
+///             ry: Range {
+///                 start: r2.ry.start,
+///                 end: midpoint,
+///             },
+///         };
+///         let out2 = Range2D {
+///             rx: r2.rx,
+///             ry: Range {
+///                 start: midpoint,
+///                 end: r2.ry.end,
+///             },
+///         };
+///         (out1, Some(out2))
+///     }
+/// }
+///
+/// // By using iter::split, Rayon will gladly do the recursive splitting for us
+/// let range = Range2D { rx: 0..800, ry: 0..600 };
+/// iter::split(range, split_range).for_each(|sub_range| {
+///     // If the sub-ranges were indeed split by the largest dimension, then
+///     // if no dimension was twice larger than the other initially, this
+///     // property will remain true in the final sub-ranges.
+///     let width = sub_range.rx.end - sub_range.rx.start;
+///     let height = sub_range.ry.end - sub_range.ry.start;
+///     assert!((width < 2 * height) && (height < 2 * width));
+/// });
+/// ```
+///
 pub fn split<D, S>(data: D, splitter: S) -> Split<D, S>
     where D: Send,
           S: Fn(D) -> (D, Option<D>) + Sync

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -27,15 +27,7 @@ use std::fmt::{self, Debug};
 ///
 ///     // Here, our range is considered large enough to be splittable
 ///     let midpoint = r.start + (r.end - r.start) / 2;
-///     let out1 = Range1D {
-///         start: r.start,
-///         end: midpoint,
-///     };
-///     let out2 = Range1D {
-///         start: midpoint,
-///         end: r.end,
-///     };
-///     (out1, Some(out2))
+///     (r.start..midpoint, Some(midpoint..r.end))
 /// }
 ///
 /// // By using iter::split, Rayon will split the range until it has enough work
@@ -59,15 +51,7 @@ use std::fmt::{self, Debug};
 /// # fn split_range1(r: Range1D) -> (Range1D, Option<Range1D>) {
 /// #     if r.end - r.start <= 1 { return (r, None); }
 /// #     let midpoint = r.start + (r.end - r.start) / 2;
-/// #     let out1 = Range1D {
-/// #         start: r.start,
-/// #         end: midpoint,
-/// #     };
-/// #     let out2 = Range1D {
-/// #         start: midpoint,
-/// #         end: r.end,
-/// #     };
-/// #     (out1, Some(out2))
+/// #     (r.start..midpoint, Some(midpoint..r.end))
 /// # }
 /// #
 /// // A two-dimensional range of indices can be built out of two 1D ones
@@ -87,7 +71,7 @@ use std::fmt::{self, Debug};
 ///     let width = r2.rx.end - r2.rx.start;
 ///     let height = r2.ry.end - r2.ry.start;
 ///     if width >= height {
-///         // This is a wide rectangle, split it on the horizontal axis
+///         // This is a wide range, split it on the horizontal axis
 ///         let (split_rx, ry) = (split_range1(r2.rx), r2.ry);
 ///         let out1 = Range2D {
 ///             rx: split_rx.0,
@@ -96,7 +80,7 @@ use std::fmt::{self, Debug};
 ///         let out2 = split_rx.1.map(|rx| Range2D { rx, ry });
 ///         (out1, out2)
 ///     } else {
-///         // This is a tall rectangle, split it on the vertical axis
+///         // This is a tall range, split it on the vertical axis
 ///         let (rx, split_ry) = (r2.rx, split_range1(r2.ry));
 ///         let out1 = Range2D {
 ///             rx: rx.clone(),

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -68,7 +68,6 @@ use std::fmt::{self, Debug};
 /// # }
 /// #
 /// // A two-dimensional range of indices can be built out of two 1D ones
-/// #[derive(Debug)]
 /// struct Range2D {
 ///     // Range of horizontal indices
 ///     pub rx: Range1D,


### PR DESCRIPTION
I think the split() method is a nice way to quickly build custom parallel iterators, which deserves a bit more publicity. This is an attempt at making it happen.