### PR TITLE
split: use floored division in example assertion

### DIFF
--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -99,7 +99,7 @@ use std::fmt::{self, Debug};
 ///     // property will remain true in the final sub-ranges.
 ///     let width = sub_range.rx.end - sub_range.rx.start;
 ///     let height = sub_range.ry.end - sub_range.ry.start;
-///     assert!((width < 2 * height) && (height < 2 * width));
+///     assert!((width / 2 <= height) && (height / 2 <= width));
 /// });
 /// ```
 ///


### PR DESCRIPTION
Rounding can falsify the previous `width < 2 * height` assertions.  For
example, given lengths `(3, 3)`, it will split to `(1, 3)` and `(2, 3)`.

cc #539 @HadrienG2