### PR TITLE
add bridge from Iterator to ParallelIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.4", path = "rayon-core" }
+crossbeam-deque = "0.2.0"
 
 # This is a public dependency!
 [dependencies.either]

--- a/rayon-demo/src/life/bench.rs
+++ b/rayon-demo/src/life/bench.rs
@@ -9,3 +9,8 @@ fn generations(b: &mut ::test::Bencher) {
 fn parallel_generations(b: &mut ::test::Bencher) {
     b.iter(|| super::parallel_generations(Board::new(200, 200).random(), 100));
 }
+
+#[bench]
+fn as_parallel_generations(b: &mut ::test::Bencher) {
+    b.iter(|| super::as_parallel_generations(Board::new(200, 200).random(), 100));
+}

--- a/rayon-demo/src/life/bench.rs
+++ b/rayon-demo/src/life/bench.rs
@@ -12,5 +12,5 @@ fn parallel_generations(b: &mut ::test::Bencher) {
 
 #[bench]
 fn as_parallel_generations(b: &mut ::test::Bencher) {
-    b.iter(|| super::as_parallel_generations(Board::new(200, 200).random(), 100));
+    b.iter(|| super::par_bridge_generations(Board::new(200, 200).random(), 100));
 }

--- a/rayon-demo/src/life/mod.rs
+++ b/rayon-demo/src/life/mod.rs
@@ -20,7 +20,7 @@ use time;
 
 use docopt::Docopt;
 use rayon::prelude::*;
-use rayon::iter::AsParallel;
+use rayon::iter::ParallelBridge;
 
 #[cfg(test)]
 mod bench;
@@ -94,9 +94,9 @@ impl Board {
         self.next_board(new_brd)
     }
 
-    pub fn as_parallel_next_generation(&self) -> Board {
+    pub fn par_bridge_next_generation(&self) -> Board {
         let new_brd = (0..self.len())
-            .as_parallel()
+            .par_bridge()
             .map(|cell| self.successor_cell(cell))
             .collect();
 
@@ -155,9 +155,9 @@ fn parallel_generations(board: Board, gens: usize) {
     for _ in 0..gens { brd = brd.parallel_next_generation(); }
 }
 
-fn as_parallel_generations(board: Board, gens: usize) {
+fn par_bridge_generations(board: Board, gens: usize) {
     let mut brd = board;
-    for _ in 0..gens { brd = brd.as_parallel_next_generation(); }
+    for _ in 0..gens { brd = brd.par_bridge_next_generation(); }
 }
 
 fn measure(f: fn(Board, usize) -> (), args: &Args) -> u64 {
@@ -184,8 +184,8 @@ pub fn main(args: &[String]) {
         println!("parallel: {:10} ns -> {:.2}x speedup", parallel,
                  serial as f64 / parallel as f64);
 
-        let as_parallel = measure(as_parallel_generations, &args);
-        println!("as_parallel: {:10} ns -> {:.2}x speedup", as_parallel,
-                 serial as f64 / as_parallel as f64);
+        let par_bridge = measure(par_bridge_generations, &args);
+        println!("par_bridge: {:10} ns -> {:.2}x speedup", par_bridge,
+                 serial as f64 / par_bridge as f64);
     }
 }

--- a/rayon-demo/src/nbody/bench.rs
+++ b/rayon-demo/src/nbody/bench.rs
@@ -31,8 +31,8 @@ fn nbody_par(b: &mut ::test::Bencher) {
 }
 
 #[bench]
-fn nbody_par_as_parallel(b: &mut ::test::Bencher) {
-    nbody_bench(b, |n| { n.tick_par_as_parallel(); });
+fn nbody_par_bridge(b: &mut ::test::Bencher) {
+    nbody_bench(b, |n| { n.tick_par_bridge(); });
 }
 
 #[bench]

--- a/rayon-demo/src/nbody/bench.rs
+++ b/rayon-demo/src/nbody/bench.rs
@@ -31,6 +31,11 @@ fn nbody_par(b: &mut ::test::Bencher) {
 }
 
 #[bench]
+fn nbody_par_as_parallel(b: &mut ::test::Bencher) {
+    nbody_bench(b, |n| { n.tick_par_as_parallel(); });
+}
+
+#[bench]
 fn nbody_parreduce(b: &mut ::test::Bencher) {
     nbody_bench(b, |n| { n.tick_par_reduce(); });
 }

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -111,6 +111,32 @@ impl NBodyBenchmark {
         out_bodies
     }
 
+    pub fn tick_par_as_parallel(&mut self) -> &[Body] {
+        let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
+            (&self.bodies.0, &mut self.bodies.1)
+        } else {
+            (&self.bodies.1, &mut self.bodies.0)
+        };
+
+        let time = self.time;
+        out_bodies
+            .iter_mut()
+            .as_parallel()
+            .zip(&in_bodies[..])
+            .for_each(|(out, prev)| {
+                let (vel, vel2) = next_velocity(time, prev, in_bodies);
+                out.velocity = vel;
+                out.velocity2 = vel2;
+
+                let next_velocity = vel - vel2;
+                out.position = prev.position + next_velocity;
+            });
+
+        self.time += 1;
+
+        out_bodies
+    }
+
     pub fn tick_par_reduce(&mut self) -> &[Body] {
         let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
             (&self.bodies.0, &mut self.bodies.1)

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -33,7 +33,7 @@ use cgmath::{InnerSpace, Point3, Vector3, Zero};
 use rand::{Rand, Rng};
 use rayon::prelude::*;
 #[cfg(test)]
-use rayon::iter::AsParallel;
+use rayon::iter::ParallelBridge;
 use std::f64::consts::PI;
 
 const INITIAL_VELOCITY: f64 = 8.0; // set to 0.0 to turn off.
@@ -114,7 +114,7 @@ impl NBodyBenchmark {
     }
 
     #[cfg(test)]
-    pub fn tick_par_as_parallel(&mut self) -> &[Body] {
+    pub fn tick_par_bridge(&mut self) -> &[Body] {
         let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
             (&self.bodies.0, &mut self.bodies.1)
         } else {
@@ -125,7 +125,7 @@ impl NBodyBenchmark {
         out_bodies
             .iter_mut()
             .zip(&in_bodies[..])
-            .as_parallel()
+            .par_bridge()
             .for_each(|(out, prev)| {
                 let (vel, vel2) = next_velocity(time, prev, in_bodies);
                 out.velocity = vel;

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -30,8 +30,8 @@
 // [1]: https://github.com/IntelLabs/RiverTrail/blob/master/examples/nbody-webgl/NBody.js
 
 use cgmath::{InnerSpace, Point3, Vector3, Zero};
-use rayon::prelude::*;
 use rand::{Rand, Rng};
+use rayon::prelude::*;
 use std::f64::consts::PI;
 
 const INITIAL_VELOCITY: f64 = 8.0; // set to 0.0 to turn off.
@@ -50,8 +50,7 @@ pub struct Body {
 
 impl NBodyBenchmark {
     pub fn new<R: Rng>(num_bodies: usize, rng: &mut R) -> NBodyBenchmark {
-        let bodies0: Vec<_> =
-            (0..num_bodies)
+        let bodies0: Vec<_> = (0..num_bodies)
             .map(|_| {
                 let position = Point3 {
                     x: f64::rand(rng).floor() * 40_000.0,
@@ -71,7 +70,11 @@ impl NBodyBenchmark {
                     z: f64::rand(rng) * INITIAL_VELOCITY,
                 };
 
-                Body { position: position, velocity: velocity, velocity2: velocity2 }
+                Body {
+                    position: position,
+                    velocity: velocity,
+                    velocity2: velocity2,
+                }
             })
             .collect();
 
@@ -91,16 +94,17 @@ impl NBodyBenchmark {
         };
 
         let time = self.time;
-        out_bodies.par_iter_mut()
-                  .zip(&in_bodies[..])
-                  .for_each(|(out, prev)| {
-                      let (vel, vel2) = next_velocity(time, prev, in_bodies);
-                      out.velocity = vel;
-                      out.velocity2 = vel2;
+        out_bodies
+            .par_iter_mut()
+            .zip(&in_bodies[..])
+            .for_each(|(out, prev)| {
+                let (vel, vel2) = next_velocity(time, prev, in_bodies);
+                out.velocity = vel;
+                out.velocity2 = vel2;
 
-                      let next_velocity = vel - vel2;
-                      out.position = prev.position + next_velocity;
-                  });
+                let next_velocity = vel - vel2;
+                out.position = prev.position + next_velocity;
+            });
 
         self.time += 1;
 
@@ -115,16 +119,17 @@ impl NBodyBenchmark {
         };
 
         let time = self.time;
-        out_bodies.par_iter_mut()
-                  .zip(&in_bodies[..])
-                  .for_each(|(out, prev)| {
-                      let (vel, vel2) = next_velocity_par(time, prev, in_bodies);
-                      out.velocity = vel;
-                      out.velocity2 = vel2;
+        out_bodies
+            .par_iter_mut()
+            .zip(&in_bodies[..])
+            .for_each(|(out, prev)| {
+                let (vel, vel2) = next_velocity_par(time, prev, in_bodies);
+                out.velocity = vel;
+                out.velocity2 = vel2;
 
-                      let next_velocity = vel - vel2;
-                      out.position = prev.position + next_velocity;
-                  });
+                let next_velocity = vel - vel2;
+                out.position = prev.position + next_velocity;
+            });
 
         self.time += 1;
 
@@ -207,57 +212,57 @@ fn next_velocity(time: usize, prev: &Body, bodies: &[Body]) -> (Vector3<f64>, Ve
     let zero: Vector3<f64> = Vector3::zero();
     let (diff, diff2) = bodies
         .iter()
-        .fold(
-            (zero, zero),
-            |(mut diff, mut diff2), body| {
-                let r = body.position - prev.position;
+        .fold((zero, zero), |(mut diff, mut diff2), body| {
+            let r = body.position - prev.position;
 
-                // make sure we are not testing the particle against its own position
-                let are_same = r == Vector3::zero();
+            // make sure we are not testing the particle against its own position
+            let are_same = r == Vector3::zero();
 
-                let dist_sqrd = r.magnitude2();
+            let dist_sqrd = r.magnitude2();
 
-                if dist_sqrd < zone_sqrd && !are_same {
-                    let length = dist_sqrd.sqrt();
-                    let percent = dist_sqrd / zone_sqrd;
+            if dist_sqrd < zone_sqrd && !are_same {
+                let length = dist_sqrd.sqrt();
+                let percent = dist_sqrd / zone_sqrd;
 
-                    if dist_sqrd < repel {
-                        let f = (repel / percent - 1.0) * 0.025;
-                        let normal = (r / length) * f;
-                        diff += normal;
-                        diff2 += normal;
-                    } else if dist_sqrd < align {
-                        let thresh_delta = align - repel;
-                        let adjusted_percent = (percent - repel) / thresh_delta;
-                        let q = (0.5 - (adjusted_percent * PI * 2.0).cos() * 0.5 + 0.5) * 100.9;
+                if dist_sqrd < repel {
+                    let f = (repel / percent - 1.0) * 0.025;
+                    let normal = (r / length) * f;
+                    diff += normal;
+                    diff2 += normal;
+                } else if dist_sqrd < align {
+                    let thresh_delta = align - repel;
+                    let adjusted_percent = (percent - repel) / thresh_delta;
+                    let q = (0.5 - (adjusted_percent * PI * 2.0).cos() * 0.5 + 0.5) * 100.9;
 
-                        // normalize vel2 and multiply by factor
-                        let vel2_length = body.velocity2.magnitude();
-                        let vel2 = (body.velocity2 / vel2_length) * q;
+                    // normalize vel2 and multiply by factor
+                    let vel2_length = body.velocity2.magnitude();
+                    let vel2 = (body.velocity2 / vel2_length) * q;
 
-                        // normalize own velocity
-                        let vel_length = prev.velocity.magnitude();
-                        let vel = (prev.velocity / vel_length) * q;
+                    // normalize own velocity
+                    let vel_length = prev.velocity.magnitude();
+                    let vel = (prev.velocity / vel_length) * q;
 
-                        diff += vel2;
-                        diff2 += vel;
-                    }
-
-                    if dist_sqrd > attract { // attract
-                        let thresh_delta2 = 1.0 - attract;
-                        let adjusted_percent2 = (percent - attract) / thresh_delta2;
-                        let c = (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5)) * attract_power;
-
-                        // normalize the distance vector
-                        let d = (r / length) * c;
-
-                        diff += d;
-                        diff2 -= d;
-                    }
+                    diff += vel2;
+                    diff2 += vel;
                 }
 
-                (diff, diff2)
-            });
+                if dist_sqrd > attract {
+                    // attract
+                    let thresh_delta2 = 1.0 - attract;
+                    let adjusted_percent2 = (percent - attract) / thresh_delta2;
+                    let c =
+                        (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5)) * attract_power;
+
+                    // normalize the distance vector
+                    let d = (r / length) * c;
+
+                    diff += d;
+                    diff2 -= d;
+                }
+            }
+
+            (diff, diff2)
+        });
 
     acc += diff;
     acc2 += diff2;
@@ -294,8 +299,7 @@ fn next_velocity(time: usize, prev: &Body, bodies: &[Body]) -> (Vector3<f64>, Ve
 }
 
 /// Compute next velocity of `prev`
-fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
-                     -> (Vector3<f64>, Vector3<f64>) {
+fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body]) -> (Vector3<f64>, Vector3<f64>) {
     let time = time as f64;
     let center = Point3 {
         x: (time / 22.0).cos() * -4200.0,
@@ -344,8 +348,9 @@ fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
 
     let (diff, diff2) = bodies
         .par_iter()
-        .fold(|| (Vector3::zero(), Vector3::zero()),
-              |(mut diff, mut diff2), body| {
+        .fold(
+            || (Vector3::zero(), Vector3::zero()),
+            |(mut diff, mut diff2), body| {
                 let r = body.position - prev.position;
 
                 // make sure we are not testing the particle against its own position
@@ -379,10 +384,12 @@ fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
                         diff2 += vel;
                     }
 
-                    if dist_sqrd > attract { // attract
+                    if dist_sqrd > attract {
+                        // attract
                         let thresh_delta2 = 1.0 - attract;
                         let adjusted_percent2 = (percent - attract) / thresh_delta2;
-                        let c = (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5)) * attract_power;
+                        let c = (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5))
+                            * attract_power;
 
                         // normalize the distance vector
                         let d = (r / length) * c;
@@ -393,9 +400,12 @@ fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
                 }
 
                 (diff, diff2)
-              })
-        .reduce(|| (Vector3::zero(), Vector3::zero()),
-                |(diffa, diff2a), (diffb, diff2b)| (diffa + diffb, diff2a + diff2b));
+            },
+        )
+        .reduce(
+            || (Vector3::zero(), Vector3::zero()),
+            |(diffa, diff2a), (diffb, diff2b)| (diffa + diffb, diff2a + diff2b),
+        );
 
     acc += diff;
     acc2 += diff2;

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -32,6 +32,8 @@
 use cgmath::{InnerSpace, Point3, Vector3, Zero};
 use rand::{Rand, Rng};
 use rayon::prelude::*;
+#[cfg(test)]
+use rayon::iter::AsParallel;
 use std::f64::consts::PI;
 
 const INITIAL_VELOCITY: f64 = 8.0; // set to 0.0 to turn off.
@@ -111,6 +113,7 @@ impl NBodyBenchmark {
         out_bodies
     }
 
+    #[cfg(test)]
     pub fn tick_par_as_parallel(&mut self) -> &[Body] {
         let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
             (&self.bodies.0, &mut self.bodies.1)
@@ -121,8 +124,8 @@ impl NBodyBenchmark {
         let time = self.time;
         out_bodies
             .iter_mut()
-            .as_parallel()
             .zip(&in_bodies[..])
+            .as_parallel()
             .for_each(|(out, prev)| {
                 let (vel, vel2) = next_velocity(time, prev, in_bodies);
                 out.velocity = vel;

--- a/src/iter/as_parallel.rs
+++ b/src/iter/as_parallel.rs
@@ -1,0 +1,160 @@
+use crossbeam_deque::{Deque, Stealer, Steal};
+
+use std::thread::yield_now;
+use std::sync::{Mutex, TryLockError};
+use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
+
+use iter::*;
+use current_num_threads;
+
+/// Conversion trait to convert an `Iterator` to a `ParallelIterator`.
+///
+/// This needs to be distinct from `IntoParallelIterator` because that trait is already implemented
+/// on a few `Iterator`s, like `std::ops::Range`.
+pub trait AsParallel {
+    /// What is the type of the output `ParallelIterator`?
+    type Iter: ParallelIterator<Item = Self::Item>;
+
+    /// What is the `Item` of the output `ParallelIterator`?
+    type Item: Send;
+
+    /// Convert this type to a `ParallelIterator`.
+    fn as_parallel(self) -> Self::Iter;
+}
+
+impl<T: Iterator + Send> AsParallel for T
+    where T::Item: Send
+{
+    type Iter = IterParallel<T>;
+    type Item = T::Item;
+
+    fn as_parallel(self) -> Self::Iter {
+        IterParallel {
+            iter: self,
+        }
+    }
+}
+
+/// `IterParallel` is a parallel iterator that wraps a sequential iterator.
+#[derive(Debug)]
+pub struct IterParallel<Iter> {
+    iter: Iter,
+}
+
+impl<Iter: Iterator + Send> ParallelIterator for IterParallel<Iter>
+    where Iter::Item: Send
+{
+    type Item = Iter::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        let split_count = AtomicUsize::new(current_num_threads());
+        let deque = Deque::new();
+        let stealer = deque.stealer();
+        let done = AtomicBool::new(false);
+        let iter = Mutex::new((self.iter, deque));
+
+        bridge_unindexed(IterParallelProducer {
+            split_count: &split_count,
+            done: &done,
+            iter: &iter,
+            items: stealer,
+        }, consumer)
+    }
+}
+
+struct IterParallelProducer<'a, Iter: Iterator + 'a> {
+    split_count: &'a AtomicUsize,
+    done: &'a AtomicBool,
+    iter: &'a Mutex<(Iter, Deque<Iter::Item>)>,
+    items: Stealer<Iter::Item>,
+}
+
+// manual clone because T doesn't need to be Clone, but the derive assumes it should be
+impl<'a, Iter: Iterator + 'a> Clone for IterParallelProducer<'a, Iter> {
+    fn clone(&self) -> Self {
+        IterParallelProducer {
+            split_count: self.split_count,
+            done: self.done,
+            iter: self.iter,
+            items: self.items.clone(),
+        }
+    }
+}
+
+impl<'a, Iter: Iterator + Send + 'a> UnindexedProducer for IterParallelProducer<'a, Iter>
+    where Iter::Item: Send
+{
+    type Item = Iter::Item;
+
+    fn split(self) -> (Self, Option<Self>) {
+        let mut count = self.split_count.load(Ordering::SeqCst);
+
+        loop {
+            let done = self.done.load(Ordering::SeqCst);
+            match count.checked_sub(1) {
+                Some(new_count) if !done => {
+                    let last_count = self.split_count.compare_and_swap(count, new_count, Ordering::SeqCst);
+                    if last_count == count {
+                        return (self.clone(), Some(self));
+                    } else {
+                        count = last_count;
+                    }
+                }
+                _ => {
+                    return (self, None);
+                }
+            }
+        }
+    }
+
+    fn fold_with<F>(self, mut folder: F) -> F
+        where F: Folder<Self::Item>
+    {
+        loop {
+            match self.items.steal() {
+                Steal::Data(it) => {
+                    folder = folder.consume(it);
+                    if folder.full() {
+                        return folder;
+                    }
+                }
+                Steal::Empty => {
+                    if self.done.load(Ordering::SeqCst) {
+                        // the iterator is out of items, no use in continuing
+                        return folder;
+                    } else {
+                        // our cache is out of items, time to load more from the iterator
+                        match self.iter.try_lock() {
+                            Ok(mut guard) => {
+                                let count = current_num_threads();
+                                let count = (count * count) * 2;
+
+                                let (ref mut iter, ref deque) = *guard;
+
+                                for _ in 0..count {
+                                    if let Some(it) = iter.next() {
+                                        deque.push(it);
+                                    } else {
+                                        self.done.store(true, Ordering::SeqCst);
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(TryLockError::WouldBlock) => {
+                                // someone else has the mutex, just sit tight until it's ready
+                                yield_now(); //TODO: use a thread=pool-aware yield? (#548)
+                            }
+                            Err(TryLockError::Poisoned(_)) => {
+                                // TODO: how to handle poison?
+                                return folder;
+                            }
+                        }
+                    }
+                }
+                Steal::Retry => (),
+            }
+        }
+    }
+}

--- a/src/iter/as_parallel.rs
+++ b/src/iter/as_parallel.rs
@@ -148,7 +148,8 @@ impl<'a, Iter: Iterator + Send + 'a> UnindexedProducer for IterParallelProducer<
                                 yield_now(); //TODO: use a thread=pool-aware yield? (#548)
                             }
                             Err(TryLockError::Poisoned(_)) => {
-                                // TODO: how to handle poison?
+                                // any panics from other threads will have been caught by the pool,
+                                // and will be re-thrown when joined - just exit
                                 return folder;
                             }
                         }

--- a/src/iter/as_parallel.rs
+++ b/src/iter/as_parallel.rs
@@ -4,7 +4,8 @@ use std::thread::yield_now;
 use std::sync::{Mutex, TryLockError};
 use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 
-use iter::*;
+use iter::ParallelIterator;
+use iter::plumbing::{UnindexedConsumer, UnindexedProducer, bridge_unindexed, Folder};
 use current_num_threads;
 
 /// Conversion trait to convert an `Iterator` to a `ParallelIterator`.

--- a/src/iter/as_parallel.rs
+++ b/src/iter/as_parallel.rs
@@ -134,7 +134,7 @@ impl<'a, Iter: Iterator + Send + 'a> UnindexedProducer for IterParallelProducer<
 
                                 let (ref mut iter, ref deque) = *guard;
 
-                                for _ in 0..count {
+                                while deque.len() < count {
                                     if let Some(it) = iter.next() {
                                         deque.push(it);
                                     } else {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -84,6 +84,9 @@ use self::plumbing::*;
 //   e.g. `find::find()`, are always used **prefixed**, so that they
 //   can be readily distinguished.
 
+mod as_parallel;
+pub use self::as_parallel::{AsParallel, IterParallel};
+
 mod find;
 mod find_first_last;
 mod chain;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -84,8 +84,8 @@ use self::plumbing::*;
 //   e.g. `find::find()`, are always used **prefixed**, so that they
 //   can be readily distinguished.
 
-mod as_parallel;
-pub use self::as_parallel::{AsParallel, IterParallel};
+mod par_bridge;
+pub use self::par_bridge::{ParallelBridge, IterParallel};
 
 mod find;
 mod find_first_last;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -85,7 +85,7 @@ use self::plumbing::*;
 //   can be readily distinguished.
 
 mod par_bridge;
-pub use self::par_bridge::{ParallelBridge, IterParallel};
+pub use self::par_bridge::{ParallelBridge, IterBridge};
 
 mod find;
 mod find_first_last;

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -12,7 +12,7 @@ use current_num_threads;
 ///
 /// This needs to be distinct from `IntoParallelIterator` because that trait is already implemented
 /// on a few `Iterator`s, like `std::ops::Range`.
-pub trait AsParallel {
+pub trait ParallelBridge {
     /// What is the type of the output `ParallelIterator`?
     type Iter: ParallelIterator<Item = Self::Item>;
 
@@ -20,16 +20,16 @@ pub trait AsParallel {
     type Item: Send;
 
     /// Convert this type to a `ParallelIterator`.
-    fn as_parallel(self) -> Self::Iter;
+    fn par_bridge(self) -> Self::Iter;
 }
 
-impl<T: Iterator + Send> AsParallel for T
+impl<T: Iterator + Send> ParallelBridge for T
     where T::Item: Send
 {
     type Iter = IterParallel<T>;
     type Item = T::Item;
 
-    fn as_parallel(self) -> Self::Iter {
+    fn par_bridge(self) -> Self::Iter {
         IterParallel {
             iter: self,
         }

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -64,7 +64,7 @@ impl<T: Iterator + Send> ParallelBridge for T
 /// [`ParallelBridge`] documentation for details.
 ///
 /// [`ParallelBridge`]: trait.ParallelBridge.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IterBridge<Iter> {
     iter: Iter,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@
 
 extern crate rayon_core;
 extern crate either;
+extern crate crossbeam_deque;
 
 #[cfg(test)]
 extern crate rand;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub use iter::IntoParallelRefMutIterator;
 pub use iter::IndexedParallelIterator;
 pub use iter::ParallelExtend;
 pub use iter::ParallelIterator;
+pub use iter::ParallelBridge;
 pub use slice::ParallelSlice;
 pub use slice::ParallelSliceMut;
 pub use str::ParallelString;


### PR DESCRIPTION
Half of https://github.com/rayon-rs/rayon/issues/46

This started getting reviewed in https://github.com/QuietMisdreavus/polyester/pull/6, but i decided to move my work to Rayon proper.

This PR adds a new trait, `AsParallel`, an implementation on `Iterator + Send`, and an iterator adapter `IterParallel` that implements `ParallelIterator` with a similar "cache items as you go" methodology as Polyester. I introduced a new trait because `ParallelIterator` was implemented on `Range`, which is itself an `Iterator`.

The basic idea is that you would start with a quick sequential `Iterator`, call `.as_parallel()` on it, and be able to use `ParallelIterator` adapters after that point, to do more expensive processing in multiple threads.

The design of `IterParallel` is like this:

* `IterParallel` defers background work to `IterParallelProducer`, which implements `UnindexedProducer`.
* `IterParallelProducer` will split as many times as there are threads in the current pool. (I've been told that https://github.com/rayon-rs/rayon/pull/492 is a better way to organize this, but until that's in, this is how i wrote it. `>_>`)
* When folding items, `IterParallelProducer` keeps a `Stealer` from `crossbeam-deque` (added as a dependency, but using the same version as `rayon-core`) to access a deque of items that have already been loaded from the iterator.
* If the `Stealer` is empty, a worker will attempt to lock the Mutex to access the source `Iterator` and the `Deque`.
  * If the Mutex is already locked, it will call `yield_now`. The implementation in polyester used a `synchronoise::SignalEvent` but i've been told that worker threads should not block. In lieu of https://github.com/rayon-rs/rayon/issues/548, a regular spin-loop was chosen instead.
  * If the Mutex is available, the worker will load a number of items from the iterator (currently (number of threads * number of threads * 2)) before closing the Mutex and continuing.
  * (If the Mutex is poisoned, the worker will just... stop. Is there a recommended approach here? `>_>`)

This design is effectively a first brush, has [the same caveats as polyester](https://docs.rs/polyester/0.1.0/polyester/trait.Polyester.html#implementation-note), probably needs some extra features in rayon-core, and needs some higher-level docs before i'm willing to let it go. However, i'm putting it here because it was not in the right place when i talked to @cuviper about it last time.