### PR TITLE
Try another approach to hacking rand in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ matrix:
       #if: everything!
       before_script:
         # rand 0.4.2 requires rust 1.15, and rand-0.3.22 requires rand-0.4  :/
-        # manually hacking the lockfile due to the limitations of cargo#2773
+        # manually lowering the dependency in rayon-core:
+        - sed -i -e 's/^rand = .*$/rand = "=0.3.20"/' rayon-core/Cargo.toml
         - cargo generate-lockfile
-        - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-        - sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+        - git checkout rayon-core/Cargo.toml
 
     - rust: stable
       os: linux


### PR DESCRIPTION
Using `sed` to hack rand-0.3.20 in `Cargo.lock` worked for a while, but
now it's giving us an invalid lockfile, because some of the test/demo
dependencies need rand-0.4 themselves.

Instead, we now just tweak `rayon-core/Cargo.toml` long enough to
generate a complete lock file, which is enough to get a working CI build
on Rust 1.13 again.