### PR TITLE
Fix doc links to avoid warning on nightly

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -65,7 +65,7 @@
 //! [`ParallelIterator`]: trait.ParallelIterator.html
 //! [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 //! [split]: fn.split.html
-//! [plumbing]: plumbing
+//! [plumbing]: plumbing/index.html
 //!
 //! Note: Several of the `ParallelIterator` methods rely on a `Try` trait which
 //! has been deliberately obscured from the public API.  This trait is intended

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! parallel implementations of many iterative functions such as [`map`],
 //! [`for_each`], [`filter`], [`fold`], and [more].
 //!
-//! [`rayon::prelude::*`]: prelude/index.html
+//! [`rayon::prelude`]: prelude/index.html
 //! [`map`]: iter/trait.ParallelIterator.html#method.map
 //! [`for_each`]: iter/trait.ParallelIterator.html#method.for_each
 //! [`filter`]: iter/trait.ParallelIterator.html#method.filter


### PR DESCRIPTION
Hi there!

- one link was just a typo (incorrect `::*`)
- the other one was a wrong intra-link (which are still unstable)

I converted the wrong intra-link to a normal one for now. Would be awesome if this can be merged, as `cargo doc` is quite noisy on nightly when you have many dependencies :)