### PR TITLE
Override `clone_from`.

### DIFF
--- a/rayon-futures/src/lib.rs
+++ b/rayon-futures/src/lib.rs
@@ -180,6 +180,10 @@ where
     fn clone(&self) -> Self {
         ArcScopeFuture(self.0.clone())
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.0.clone_from(&other.0);
+    }
 }
 
 impl<'scope, F, S> Notify for ArcScopeFuture<'scope, F, S>

--- a/src/collections/binary_heap.rs
+++ b/src/collections/binary_heap.rs
@@ -40,6 +40,10 @@ impl<'a, T: Ord + Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/btree_map.rs
+++ b/src/collections/btree_map.rs
@@ -36,6 +36,10 @@ impl<'a, K: Ord + Sync, V: Sync> Clone for Iter<'a, K, V> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/btree_set.rs
+++ b/src/collections/btree_set.rs
@@ -36,6 +36,10 @@ impl<'a, T: Ord + Sync + 'a> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/hash_map.rs
+++ b/src/collections/hash_map.rs
@@ -37,6 +37,10 @@ impl<'a, K: Hash + Eq + Sync, V: Sync> Clone for Iter<'a, K, V> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/hash_set.rs
+++ b/src/collections/hash_set.rs
@@ -37,6 +37,10 @@ impl<'a, T: Hash + Eq + Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/linked_list.rs
+++ b/src/collections/linked_list.rs
@@ -36,6 +36,10 @@ impl<'a, T: Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 into_par_vec!{

--- a/src/collections/vec_deque.rs
+++ b/src/collections/vec_deque.rs
@@ -37,6 +37,10 @@ impl<'a, T: Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {

--- a/src/iter/empty.rs
+++ b/src/iter/empty.rs
@@ -35,6 +35,8 @@ impl<T: Send> Clone for Empty<T> {
     fn clone(&self) -> Self {
         empty()
     }
+
+    fn clone_from(&mut self, _: &Self) {}
 }
 
 impl<T: Send> fmt::Debug for Empty<T> {

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -109,6 +109,13 @@ impl<'a, Iter: Iterator + 'a> Clone for IterParallelProducer<'a, Iter> {
             items: self.items.clone(),
         }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.split_count = other.split_count;
+        self.done = other.done;
+        self.iter = other.iter;
+        self.items.clone_from(&other.items);
+    }
 }
 
 impl<'a, Iter: Iterator + Send + 'a> UnindexedProducer for IterParallelProducer<'a, Iter>

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -25,6 +25,10 @@ impl<'r, R, ID> Clone for ReduceConsumer<'r, R, ID> {
     fn clone(&self) -> Self {
         *self
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        *self = *other;
+    }
 }
 
 impl<'r, R, ID, T> Consumer<T> for ReduceConsumer<'r, R, ID>

--- a/src/iter/try_reduce.rs
+++ b/src/iter/try_reduce.rs
@@ -31,6 +31,10 @@ impl<'r, R, ID> Clone for TryReduceConsumer<'r, R, ID> {
     fn clone(&self) -> Self {
         *self
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        *self = *other;
+    }
 }
 
 impl<'r, R, ID, T> Consumer<T> for TryReduceConsumer<'r, R, ID>

--- a/src/iter/try_reduce_with.rs
+++ b/src/iter/try_reduce_with.rs
@@ -28,6 +28,10 @@ impl<'r, R> Clone for TryReduceWithConsumer<'r, R> {
     fn clone(&self) -> Self {
         *self
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        *self = *other;
+    }
 }
 
 impl<'r, R, T> Consumer<T> for TryReduceWithConsumer<'r, R>

--- a/src/option.rs
+++ b/src/option.rs
@@ -90,6 +90,10 @@ impl<'a, T: Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a Option<T> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -42,6 +42,10 @@ impl<'a, T: Sync> Clone for Iter<'a, T> {
     fn clone(&self) -> Self {
         Iter { inner: self.inner.clone() }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+    }
 }
 
 impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -448,6 +448,10 @@ impl<'data, T: Sync> Clone for Iter<'data, T> {
     fn clone(&self) -> Self {
         Iter { ..*self }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.slice = other.slice;
+    }
 }
 
 impl<'data, T: Sync + 'data> ParallelIterator for Iter<'data, T> {
@@ -511,6 +515,11 @@ pub struct Chunks<'data, T: 'data + Sync> {
 impl<'data, T: Sync> Clone for Chunks<'data, T> {
     fn clone(&self) -> Self {
         Chunks { ..*self }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.chunk_size = other.chunk_size;
+        self.slice = other.slice;
     }
 }
 
@@ -587,6 +596,11 @@ pub struct Windows<'data, T: 'data + Sync> {
 impl<'data, T: Sync> Clone for Windows<'data, T> {
     fn clone(&self) -> Self {
         Windows { ..*self }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.window_size = other.window_size;
+        self.slice = other.slice;
     }
 }
 
@@ -791,6 +805,11 @@ pub struct Split<'data, T: 'data, P> {
 impl<'data, T, P: Clone> Clone for Split<'data, T, P> {
     fn clone(&self) -> Self {
         Split { separator: self.separator.clone(), ..*self }
+    }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.slice = other.slice;
+        self.separator.clone_from(&other.separator);
     }
 }
 

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -6,9 +6,14 @@ fn check<I>(iter: I)
     where I: ParallelIterator + Clone,
           I::Item: std::fmt::Debug + PartialEq
 {
+    let mut iterX = iter.clone();
     let a: Vec<_> = iter.clone().collect();
     let b: Vec<_> = iter.collect();
     assert_eq!(a, b);
+    let iterY = iterX.clone();
+    iterX.clone_from(&iterY);
+    let c: Vec<_> = iterX.collect();
+    assert_eq!(b, c);
 }
 
 #[test]


### PR DESCRIPTION
This shouldn't affect most people in any way, but in case somebody *is* using `clone_from` on parallel iterators, it could potentially make it more efficient (it shouldn't make anything *worse*).  **NOTE:** I have not benchmarked this; I don't know how best to do that, so any advice on the topic would be well-received.

This pull request only contains a very basic test for these overrides; advice on how to better test them would also be much appreciated.