### PR TITLE
Fix typo in task.rs code-comment

### DIFF
--- a/rayon-core/src/internal/task.rs
+++ b/rayon-core/src/internal/task.rs
@@ -71,7 +71,7 @@ pub unsafe trait ScopeHandle<'scope>: 'scope {
     fn ok(self);
 }
 
-/// Converts a Rayon structure (typicaly a `Scope` or `ThreadPool`)
+/// Converts a Rayon structure (typically a `Scope` or `ThreadPool`)
 /// into a "scope handle". See the `ScopeHandle` trait for more
 /// details.
 pub trait ToScopeHandle<'scope> {


### PR DESCRIPTION
Just fixing a typo: s/typicaly/typically/