### PR TITLE
Deprecate breadth_first() and always spawn FIFO

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -23,6 +23,10 @@ lazy_static = "1"
 [dependencies.crossbeam-deque]
 version = "0.2.0"
 
+# Also held back for rustc compatibility
+[dependencies.crossbeam]
+version = "0.3.0"
+
 [dev-dependencies]
 rand = "0.5"
 

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -1,4 +1,3 @@
-use crossbeam::sync::SegQueue;
 use latch::Latch;
 use std::any::Any;
 use std::cell::UnsafeCell;
@@ -169,11 +168,5 @@ impl<T> JobResult<T> {
             JobResult::Ok(x) => x,
             JobResult::Panic(x) => unwind::resume_unwinding(x),
         }
-    }
-}
-
-impl Job for SegQueue<JobRef> {
-    unsafe fn execute(this: *const Self) {
-        (*this).try_pop().expect("job in scope queue").execute()
     }
 }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -1,4 +1,4 @@
-use crossbeam::sync::MsQueue;
+use crossbeam::sync::SegQueue;
 use latch::Latch;
 use std::any::Any;
 use std::cell::UnsafeCell;
@@ -172,8 +172,8 @@ impl<T> JobResult<T> {
     }
 }
 
-impl Job for MsQueue<JobRef> {
+impl Job for SegQueue<JobRef> {
     unsafe fn execute(this: *const Self) {
-        (*this).pop().execute()
+        (*this).try_pop().expect("job in scope queue").execute()
     }
 }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -1,3 +1,4 @@
+use crossbeam::sync::MsQueue;
 use latch::Latch;
 use std::any::Any;
 use std::cell::UnsafeCell;
@@ -168,5 +169,11 @@ impl<T> JobResult<T> {
             JobResult::Ok(x) => x,
             JobResult::Panic(x) => unwind::resume_unwinding(x),
         }
+    }
+}
+
+impl Job for MsQueue<JobRef> {
+    unsafe fn execute(this: *const Self) {
+        (*this).pop().execute()
     }
 }

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -31,6 +31,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::fmt;
 
+extern crate crossbeam;
 extern crate crossbeam_deque;
 #[macro_use]
 extern crate lazy_static;

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,5 +1,5 @@
 use ::{ExitHandler, PanicHandler, StartHandler, ThreadPoolBuilder, ThreadPoolBuildError, ErrorKind};
-use crossbeam::sync::MsQueue;
+use crossbeam::sync::SegQueue;
 use crossbeam_deque::{Deque, Steal, Stealer};
 use job::{JobRef, StackJob};
 #[cfg(rayon_unstable)]
@@ -24,7 +24,7 @@ use util::leak;
 pub struct Registry {
     thread_infos: Vec<ThreadInfo>,
     sleep: Sleep,
-    injected_jobs: MsQueue<JobRef>,
+    injected_jobs: SegQueue<JobRef>,
     panic_handler: Option<Box<PanicHandler>>,
     start_handler: Option<Box<StartHandler>>,
     exit_handler: Option<Box<ExitHandler>>,
@@ -106,7 +106,7 @@ impl Registry {
                 .map(|s| ThreadInfo::new(s))
                 .collect(),
             sleep: Sleep::new(),
-            injected_jobs: MsQueue::new(),
+            injected_jobs: SegQueue::new(),
             terminate_latch: CountLatch::new(),
             panic_handler: builder.take_panic_handler(),
             start_handler: builder.take_start_handler(),

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,4 +1,5 @@
 use ::{ExitHandler, PanicHandler, StartHandler, ThreadPoolBuilder, ThreadPoolBuildError, ErrorKind};
+use crossbeam::sync::MsQueue;
 use crossbeam_deque::{Deque, Steal, Stealer};
 use job::{JobRef, StackJob};
 #[cfg(rayon_unstable)]
@@ -12,7 +13,7 @@ use std::any::Any;
 use std::cell::Cell;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
-use std::sync::{Arc, Mutex, Once, ONCE_INIT};
+use std::sync::{Arc, Once, ONCE_INIT};
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::thread;
 use std::mem;
@@ -22,9 +23,8 @@ use util::leak;
 
 pub struct Registry {
     thread_infos: Vec<ThreadInfo>,
-    state: Mutex<RegistryState>,
     sleep: Sleep,
-    job_uninjector: Stealer<JobRef>,
+    injected_jobs: MsQueue<JobRef>,
     panic_handler: Option<Box<PanicHandler>>,
     start_handler: Option<Box<StartHandler>>,
     exit_handler: Option<Box<ExitHandler>>,
@@ -43,10 +43,6 @@ pub struct Registry {
     //   These are always owned by some other job (e.g., one injected by `ThreadPool::install()`)
     //   and that job will keep the pool alive.
     terminate_latch: CountLatch,
-}
-
-struct RegistryState {
-    job_injector: Deque<JobRef>,
 }
 
 /// ////////////////////////////////////////////////////////////////////////
@@ -100,8 +96,6 @@ impl Registry {
         let n_threads = builder.get_num_threads();
         let breadth_first = builder.get_breadth_first();
 
-        let inj_worker = Deque::new();
-        let inj_stealer = inj_worker.stealer();
         let workers: Vec<_> = (0..n_threads)
             .map(|_| Deque::new())
             .collect();
@@ -111,9 +105,8 @@ impl Registry {
             thread_infos: stealers.into_iter()
                 .map(|s| ThreadInfo::new(s))
                 .collect(),
-            state: Mutex::new(RegistryState::new(inj_worker)),
             sleep: Sleep::new(),
-            job_uninjector: inj_stealer,
+            injected_jobs: MsQueue::new(),
             terminate_latch: CountLatch::new(),
             panic_handler: builder.take_panic_handler(),
             start_handler: builder.take_start_handler(),
@@ -291,34 +284,26 @@ impl Registry {
     /// you are not on a worker of this registry.
     pub fn inject(&self, injected_jobs: &[JobRef]) {
         log!(InjectJobs { count: injected_jobs.len() });
-        {
-            let state = self.state.lock().unwrap();
 
-            // It should not be possible for `state.terminate` to be true
-            // here. It is only set to true when the user creates (and
-            // drops) a `ThreadPool`; and, in that case, they cannot be
-            // calling `inject()` later, since they dropped their
-            // `ThreadPool`.
-            assert!(!self.terminate_latch.probe(), "inject() sees state.terminate as true");
+        // It should not be possible for `state.terminate` to be true
+        // here. It is only set to true when the user creates (and
+        // drops) a `ThreadPool`; and, in that case, they cannot be
+        // calling `inject()` later, since they dropped their
+        // `ThreadPool`.
+        assert!(!self.terminate_latch.probe(), "inject() sees state.terminate as true");
 
-            for &job_ref in injected_jobs {
-                state.job_injector.push(job_ref);
-            }
+        for &job_ref in injected_jobs {
+            self.injected_jobs.push(job_ref);
         }
         self.sleep.tickle(usize::MAX);
     }
 
     fn pop_injected_job(&self, worker_index: usize) -> Option<JobRef> {
-        loop {
-            match self.job_uninjector.steal() {
-                Steal::Empty => return None,
-                Steal::Data(d) => {
-                    log!(UninjectedWork { worker: worker_index });
-                    return Some(d);
-                },
-                Steal::Retry => {},
-            }
+        let job = self.injected_jobs.try_pop();
+        if job.is_some() {
+            log!(UninjectedWork { worker: worker_index });
         }
+        job
     }
 
     /// If already in a worker-thread of this registry, just execute `op`.
@@ -414,14 +399,6 @@ impl Registry {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegistryId {
     addr: usize
-}
-
-impl RegistryState {
-    pub fn new(job_injector: Deque<JobRef>) -> RegistryState {
-        RegistryState {
-            job_injector: job_injector,
-        }
-    }
 }
 
 struct ThreadInfo {

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -4,7 +4,7 @@
 //! [`scope()`]: fn.scope.html
 //! [`join()`]: ../join/join.fn.html
 
-use crossbeam::sync::MsQueue;
+use crossbeam::sync::SegQueue;
 use latch::{Latch, CountLatch};
 use log::Event::*;
 use job::{HeapJob, JobRef};
@@ -34,7 +34,7 @@ pub struct Scope<'scope> {
     /// thread registry where `scope()` was executed.
     registry: Arc<Registry>,
 
-    queue: MsQueue<JobRef>,
+    queue: SegQueue<JobRef>,
 
     /// if some job panicked, the error is stored here; it will be
     /// propagated to the one who created the scope
@@ -270,7 +270,7 @@ pub fn scope<'scope, OP, R>(op: OP) -> R
                 panic: AtomicPtr::new(ptr::null_mut()),
                 job_completed_latch: CountLatch::new(),
                 marker: PhantomData,
-                queue: MsQueue::new(),
+                queue: SegQueue::new(),
             };
             let result = scope.execute_job_closure(op);
             scope.steal_till_jobs_complete(owner_thread);

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -87,7 +87,9 @@ pub unsafe fn spawn_in<F>(func: F, registry: &Arc<Registry>)
     // enqueued into some deque for later execution.
     let abort_guard = unwind::AbortIfPanic; // just in case we are wrong, and code CAN panic
     let job_ref = HeapJob::as_job_ref(async_job);
-    registry.inject_or_push(job_ref);
+
+    // We always inject in the global queue to prioritize jobs in FIFO order.
+    registry.inject(&[job_ref]);
     mem::forget(abort_guard);
 }
 


### PR DESCRIPTION
The former default behavior was that spawns would be processed in FIFO order from the global injector queue, but would effectively use LIFO order when a thread popped from the back of its local deque.  The `breadth_first()` flag made it so threads always popped from the front of their own deque, just like a stealer would, and this made spawns look breadth-first/FIFO in all cases.  However, #590 showed that this had a bad effect on stack-oriented jobs like parallel iterators.

Now we always make unscoped `spawn` use the global injector queue, so they're always FIFO.

For scoped `spawn`, it's trickier, because we still want the thread which owns that scope to prioritize its own items so it can return.  So we want to use the local deque, but still achieve FIFO of its `spawn` jobs.  Now each scope gets its own private queue, and each `spawn` is pushed on this queue and pushes a reference to that queue (`ScopeQueue`) as an indirect job on the local deque.

When a `ScopeQueue` job is executed, it pops the real job from the front of its queue and executes that.  No matter whether the `ScopeQueue` was popped from the back of a thread's deque or stolen from the front, the actual `spawn` will be processed in a consistent FIFO order.

Fixes #590.