### PR TITLE
Add ParallelIterator::{map_init,for_each_init,try_for_each_init}

### DIFF
--- a/src/compile_fail/must_use.rs
+++ b/src/compile_fail/must_use.rs
@@ -4,6 +4,20 @@
 
 macro_rules! must_use {
     ($( $name:ident #[$expr:meta] )*) => {$(
+        /// First sanity check that the expression is OK.
+        ///
+        /// ```
+        /// #![deny(unused_must_use)]
+        ///
+        /// use rayon::prelude::*;
+        ///
+        /// let v: Vec<_> = (0..100).map(Some).collect();
+        /// let _ =
+        #[$expr]
+        /// ```
+        ///
+        /// Now trigger the `must_use`.
+        ///
         /// ```compile_fail
         /// #![deny(unused_must_use)]
         ///
@@ -35,6 +49,7 @@ must_use! {
     intersperse         /** v.par_iter().intersperse(&None); */
     map                 /** v.par_iter().map(|x| x); */
     map_with            /** v.par_iter().map_with(0, |_, x| x); */
+    map_init            /** v.par_iter().map_init(|| 0, |_, x| x); */
     rev                 /** v.par_iter().rev(); */
     skip                /** v.par_iter().skip(1); */
     take                /** v.par_iter().take(1); */

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -180,7 +180,6 @@ struct MapWithIter<'f, I, U, F: 'f> {
 
 impl<'f, I, U, F, R> Iterator for MapWithIter<'f, I, U, F>
     where I: Iterator,
-          U: Send + Clone,
           F: Fn(&mut U, I::Item) -> R + Sync,
           R: Send
 {
@@ -197,7 +196,6 @@ impl<'f, I, U, F, R> Iterator for MapWithIter<'f, I, U, F>
 
 impl<'f, I, U, F, R> DoubleEndedIterator for MapWithIter<'f, I, U, F>
     where I: DoubleEndedIterator,
-          U: Send + Clone,
           F: Fn(&mut U, I::Item) -> R + Sync,
           R: Send
 {
@@ -208,7 +206,6 @@ impl<'f, I, U, F, R> DoubleEndedIterator for MapWithIter<'f, I, U, F>
 
 impl<'f, I, U, F, R> ExactSizeIterator for MapWithIter<'f, I, U, F>
     where I: ExactSizeIterator,
-          U: Send + Clone,
           F: Fn(&mut U, I::Item) -> R + Sync,
           R: Send
 {
@@ -287,7 +284,6 @@ struct MapWithFolder<'f, C, U, F: 'f> {
 
 impl<'f, T, U, R, C, F> Folder<T> for MapWithFolder<'f, C, U, F>
     where C: Folder<R>,
-          U: Clone,
           F: Fn(&mut U, T) -> R
 {
     type Result = C::Result;
@@ -316,5 +312,239 @@ impl<'f, T, U, R, C, F> Folder<T> for MapWithFolder<'f, C, U, F>
 
     fn full(&self) -> bool {
         self.base.full()
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+
+/// `MapInit` is an iterator that transforms the elements of an underlying iterator.
+///
+/// This struct is created by the [`map_init()`] method on [`ParallelIterator`]
+///
+/// [`map_init()`]: trait.ParallelIterator.html#method.map_init
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct MapInit<I: ParallelIterator, INIT, F> {
+    base: I,
+    init: INIT,
+    map_op: F,
+}
+
+impl<I: ParallelIterator + Debug, INIT, F> Debug for MapInit<I, INIT, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("MapInit")
+            .field("base", &self.base)
+            .finish()
+    }
+}
+
+/// Create a new `MapInit` iterator.
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new_init<I, INIT, F>(base: I, init: INIT, map_op: F) -> MapInit<I, INIT, F>
+    where I: ParallelIterator
+{
+    MapInit {
+        base: base,
+        init: init,
+        map_op: map_op,
+    }
+}
+
+impl<I, INIT, T, F, R> ParallelIterator for MapInit<I, INIT, F>
+    where I: ParallelIterator,
+          INIT: Fn() -> T + Sync + Send,
+          F: Fn(&mut T, I::Item) -> R + Sync + Send,
+          R: Send
+{
+    type Item = R;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        let consumer1 = MapInitConsumer::new(consumer, &self.init, &self.map_op);
+        self.base.drive_unindexed(consumer1)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        self.base.opt_len()
+    }
+}
+
+impl<I, INIT, T, F, R> IndexedParallelIterator for MapInit<I, INIT, F>
+    where I: IndexedParallelIterator,
+          INIT: Fn() -> T + Sync + Send,
+          F: Fn(&mut T, I::Item) -> R + Sync + Send,
+          R: Send
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        let consumer1 = MapInitConsumer::new(consumer, &self.init, &self.map_op);
+        self.base.drive(consumer1)
+    }
+
+    fn len(&self) -> usize {
+        self.base.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        return self.base.with_producer(Callback {
+                                           callback: callback,
+                                           init: self.init,
+                                           map_op: self.map_op,
+                                       });
+
+        struct Callback<CB, INIT, F> {
+            callback: CB,
+            init: INIT,
+            map_op: F,
+        }
+
+        impl<T, INIT, U, F, R, CB> ProducerCallback<T> for Callback<CB, INIT, F>
+            where CB: ProducerCallback<R>,
+                  INIT: Fn() -> U + Sync,
+                  F: Fn(&mut U, T) -> R + Sync,
+                  R: Send
+        {
+            type Output = CB::Output;
+
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item = T>
+            {
+                let producer = MapInitProducer {
+                    base: base,
+                    init: &self.init,
+                    map_op: &self.map_op,
+                };
+                self.callback.callback(producer)
+            }
+        }
+    }
+}
+
+/// ////////////////////////////////////////////////////////////////////////
+
+struct MapInitProducer<'f, P, INIT: 'f, F: 'f> {
+    base: P,
+    init: &'f INIT,
+    map_op: &'f F,
+}
+
+impl<'f, P, INIT, U, F, R> Producer for MapInitProducer<'f, P, INIT, F>
+    where P: Producer,
+          INIT: Fn() -> U + Sync,
+          F: Fn(&mut U, P::Item) -> R + Sync,
+          R: Send
+{
+    type Item = R;
+    type IntoIter = MapWithIter<'f, P::IntoIter, U, F>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        MapWithIter {
+            base: self.base.into_iter(),
+            item: (self.init)(),
+            map_op: self.map_op,
+        }
+    }
+
+    fn min_len(&self) -> usize {
+        self.base.min_len()
+    }
+    fn max_len(&self) -> usize {
+        self.base.max_len()
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (MapInitProducer {
+             base: left,
+             init: self.init,
+             map_op: self.map_op,
+         },
+         MapInitProducer {
+             base: right,
+             init: self.init,
+             map_op: self.map_op,
+         })
+    }
+
+    fn fold_with<G>(self, folder: G) -> G
+        where G: Folder<Self::Item>
+    {
+        let folder1 = MapWithFolder {
+            base: folder,
+            item: (self.init)(),
+            map_op: self.map_op,
+        };
+        self.base.fold_with(folder1).base
+    }
+}
+
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
+
+struct MapInitConsumer<'f, C, INIT: 'f, F: 'f> {
+    base: C,
+    init: &'f INIT,
+    map_op: &'f F,
+}
+
+impl<'f, C, INIT, F> MapInitConsumer<'f, C, INIT, F> {
+    fn new(base: C, init: &'f INIT, map_op: &'f F) -> Self {
+        MapInitConsumer {
+            base: base,
+            init: init,
+            map_op: map_op,
+        }
+    }
+}
+
+impl<'f, T, INIT, U, R, C, F> Consumer<T> for MapInitConsumer<'f, C, INIT, F>
+    where C: Consumer<R>,
+          INIT: Fn() -> U + Sync,
+          F: Fn(&mut U, T) -> R + Sync,
+          R: Send
+{
+    type Folder = MapWithFolder<'f, C::Folder, U, F>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (MapInitConsumer::new(left, self.init, self.map_op),
+         MapInitConsumer::new(right, self.init, self.map_op),
+         reducer)
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        MapWithFolder {
+            base: self.base.into_folder(),
+            item: (self.init)(),
+            map_op: self.map_op,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+impl<'f, T, INIT, U, R, C, F> UnindexedConsumer<T> for MapInitConsumer<'f, C, INIT, F>
+    where C: UnindexedConsumer<R>,
+          INIT: Fn() -> U + Sync,
+          F: Fn(&mut U, T) -> R + Sync,
+          R: Send
+{
+    fn split_off_left(&self) -> Self {
+        MapInitConsumer::new(self.base.split_off_left(), self.init, self.map_op)
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
     }
 }

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -124,6 +124,7 @@ fn clone_adaptors() {
     check(v.par_iter().chunks(3));
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
+    check(v.par_iter().map_init(|| 0, |_, x| x));
     check(v.par_iter().rev());
     check(v.par_iter().skip(1));
     check(v.par_iter().take(1));

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -135,6 +135,7 @@ fn debug_adaptors() {
     check(v.par_iter().chunks(3));
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
+    check(v.par_iter().map_init(|| 0, |_, x| x));
     check(v.par_iter().rev());
     check(v.par_iter().skip(1));
     check(v.par_iter().take(1));

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -249,6 +249,12 @@ fn map_with() {
 }
 
 #[test]
+fn map_init() {
+    let v: Vec<_> = (0..10).collect();
+    check(&v, || v.par_iter().map_init(|| vec![0], |_, &x| x));
+}
+
+#[test]
 fn rev() {
     let v: Vec<_> = (0..10).rev().collect();
     check(&v, || (0..10).into_par_iter().rev());


### PR DESCRIPTION
These are like `map_with` and all, except using an `init` function for
the paired value instead of a `Send + Clone` value.  The returned type
doesn't have to be `Send` nor `Sync` nor anything else, which makes it
feasible for things like a thread-local RNG.