### PR TITLE
Implement chunks_exact and chunks_exact_mut

### DIFF
--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -962,8 +962,31 @@ impl<'data, T: Send> ChunksExactMut<'data, T> {
     /// Return the remainder of the original slice that is not going to be
     /// returned by the iterator. The returned slice has at most `chunk_size-1`
     /// elements.
+    ///
+    /// Note that this has to consume `self` to return the original lifetime of
+    /// the data, which prevents this from actually being used as a parallel
+    /// iterator since that also consumes. This method is provided for parity
+    /// with `std::iter::ChunksExactMut`, but consider calling `remainder()` or
+    /// `take_remainder()` as alternatives.
     pub fn into_remainder(self) -> &'data mut [T] {
         self.rem
+    }
+
+    /// Return the remainder of the original slice that is not going to be
+    /// returned by the iterator. The returned slice has at most `chunk_size-1`
+    /// elements.
+    ///
+    /// Consider `take_remainder()` if you need access to the data with its
+    /// original lifetime, rather than borrowing through `&mut self` here.
+    pub fn remainder(&mut self) -> &mut [T] {
+        self.rem
+    }
+
+    /// Return the remainder of the original slice that is not going to be
+    /// returned by the iterator. The returned slice has at most `chunk_size-1`
+    /// elements. Subsequent calls will return an empty slice.
+    pub fn take_remainder(&mut self) -> &'data mut [T] {
+        std::mem::replace(&mut self.rem, &mut [])
     }
 }
 

--- a/src/slice/test.rs
+++ b/src/slice/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use super::ParallelSliceMut;
+use crate::prelude::*;
 use rand::distributions::Uniform;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
@@ -123,4 +123,26 @@ fn test_par_sort_stability() {
             assert!(v.windows(2).all(|w| w[0] <= w[1]));
         }
     }
+}
+
+#[test]
+fn test_par_chunks_exact_remainder() {
+    let v: &[i32] = &[0, 1, 2, 3, 4];
+    let c = v.par_chunks_exact(2);
+    assert_eq!(c.remainder(), &[4]);
+    assert_eq!(c.len(), 2);
+}
+
+#[test]
+fn test_par_chunks_exact_mut_remainder() {
+    let v: &mut [i32] = &mut [0, 1, 2, 3, 4];
+    let mut c = v.par_chunks_exact_mut(2);
+    assert_eq!(c.remainder(), &[4]);
+    assert_eq!(c.len(), 2);
+    assert_eq!(c.into_remainder(), &[4]);
+
+    let mut c = v.par_chunks_exact_mut(2);
+    assert_eq!(c.take_remainder(), &[4]);
+    assert_eq!(c.take_remainder(), &[]);
+    assert_eq!(c.len(), 2);
 }

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -101,6 +101,7 @@ fn clone_vec() {
     let v: Vec<_> = (0..1000).collect();
     check(v.par_iter());
     check(v.par_chunks(42));
+    check(v.par_chunks_exact(42));
     check(v.par_windows(42));
     check(v.par_split(|x| x % 3 == 0));
     check(v.into_par_iter());

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -110,7 +110,9 @@ fn debug_vec() {
     check(v.par_iter());
     check(v.par_iter_mut());
     check(v.par_chunks(42));
+    check(v.par_chunks_exact(42));
     check(v.par_chunks_mut(42));
+    check(v.par_chunks_exact_mut(42));
     check(v.par_windows(42));
     check(v.par_split(|x| x % 3 == 0));
     check(v.par_split_mut(|x| x % 3 == 0));

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -173,6 +173,15 @@ fn slice_chunks() {
 }
 
 #[test]
+fn slice_chunks_exact() {
+    let s: Vec<_> = (0..10).collect();
+    for len in 1..s.len() + 2 {
+        let v: Vec<_> = s.chunks_exact(len).collect();
+        check(&v, || s.par_chunks_exact(len));
+    }
+}
+
+#[test]
 fn slice_chunks_mut() {
     let mut s: Vec<_> = (0..10).collect();
     let mut v: Vec<_> = s.clone();
@@ -181,6 +190,19 @@ fn slice_chunks_mut() {
         map_triples(expected.len() + 1, |i, j, k| {
             Split::forward(s.par_chunks_mut(len), i, j, k, &expected);
             Split::reverse(s.par_chunks_mut(len), i, j, k, &expected);
+        });
+    }
+}
+
+#[test]
+fn slice_chunks_exact_mut() {
+    let mut s: Vec<_> = (0..10).collect();
+    let mut v: Vec<_> = s.clone();
+    for len in 1..s.len() + 2 {
+        let expected: Vec<_> = v.chunks_exact_mut(len).collect();
+        map_triples(expected.len() + 1, |i, j, k| {
+            Split::forward(s.par_chunks_exact_mut(len), i, j, k, &expected);
+            Split::reverse(s.par_chunks_exact_mut(len), i, j, k, &expected);
         });
     }
 }


### PR DESCRIPTION
Follow-up PR from #510. `chunks_exact` (and its mutable counterpart) are not yet implemented on `ParallelIterator`, only `ParallelSlice`.