### PR TITLE
Specialize more `consume_iter`s

### DIFF
--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -205,6 +205,14 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = &'a T>
+    {
+        self.base = self.base.consume_iter(iter.into_iter().cloned());
+        self
+    }
+
     fn complete(self) -> F::Result {
         self.base.complete()
     }

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -207,7 +207,7 @@ where
 
     fn consume_iter<I>(mut self, iter: I) -> Self
     where
-        I: IntoIterator<Item = &'a T>
+        I: IntoIterator<Item = &'a T>,
     {
         self.base = self.base.consume_iter(iter.into_iter().cloned());
         self

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -136,14 +136,9 @@ where
         }
     }
 
-    fn consume_iter<I>(mut self, iter: I) -> Self
-    where
-        I: IntoIterator<Item = T>
-    {
-        self.base = self.base.consume_iter(iter.into_iter().filter(self.filter_op));
-        self
-    }
-
+    // This cannot easily specialize `consume_iter` to be better than
+    // the default, because that requires checking `self.base.full()`
+    // during a call to `self.base.consume_iter()`. (#632)
 
     fn complete(self) -> Self::Result {
         self.base.complete()

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -136,6 +136,15 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>
+    {
+        self.base = self.base.consume_iter(iter.into_iter().filter(self.filter_op));
+        self
+    }
+
+
     fn complete(self) -> Self::Result {
         self.base.complete()
     }

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -139,13 +139,10 @@ where
             self
         }
     }
-    fn consume_iter<I>(mut self, iter: I) -> Self
-    where
-        I: IntoIterator<Item = T>
-    {
-        self.base = self.base.consume_iter(iter.into_iter().filter_map(self.filter_op));
-        self
-    }
+
+    // This cannot easily specialize `consume_iter` to be better than
+    // the default, because that requires checking `self.base.full()`
+    // during a call to `self.base.consume_iter()`. (#632)
 
     fn complete(self) -> C::Result {
         self.base.complete()

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -139,6 +139,13 @@ where
             self
         }
     }
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>
+    {
+        self.base = self.base.consume_iter(iter.into_iter().filter_map(self.filter_op));
+        self
+    }
 
     fn complete(self) -> C::Result {
         self.base.complete()

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -87,7 +87,8 @@ where
     }
 
     fn consume_iter<I>(mut self, iter: I) -> Self
-    where I: IntoIterator<Item = T>
+    where
+        I: IntoIterator<Item = T>,
     {
         self.item = iter
             .into_iter()

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -86,6 +86,16 @@ where
         self
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where I: IntoIterator<Item = T>
+    {
+        self.item = iter.into_iter().find(self.find_op);
+        if self.item.is_some() {
+            self.found.store(true, Ordering::Relaxed)
+        }
+        self
+    }
+
     fn complete(self) -> Self::Result {
         self.item
     }

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -89,7 +89,11 @@ where
     fn consume_iter<I>(mut self, iter: I) -> Self
     where I: IntoIterator<Item = T>
     {
-        self.item = iter.into_iter().find(self.find_op);
+        self.item = iter
+            .into_iter()
+            // stop iterating if another thread has found something
+            .take_while(|_| !self.full())
+            .find(self.find_op);
         if self.item.is_some() {
             self.found.store(true, Ordering::Relaxed)
         }

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -143,7 +143,7 @@ where
 
     fn consume_iter<I>(self, iter: I) -> Self
     where
-        I: IntoIterator<Item = T>
+        I: IntoIterator<Item = T>,
     {
         let base = self.base;
         let item = iter
@@ -152,7 +152,11 @@ where
             .take_while(|_| !base.full())
             .fold(self.item, self.fold_op);
 
-        FoldFolder { base: base, item: item, fold_op: self.fold_op }
+        FoldFolder {
+            base: base,
+            item: item,
+            fold_op: self.fold_op,
+        }
     }
 
     fn complete(self) -> C::Result {

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -141,6 +141,14 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>
+    {
+        self.item = iter.into_iter().fold(self.item, self.fold_op);
+        self
+    }
+
     fn complete(self) -> C::Result {
         self.base.consume(self.item).complete()
     }

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -243,6 +243,14 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>
+    {
+        self.base = self.base.consume_iter(iter.into_iter().inspect(self.inspect_op));
+        self
+    }
+
     fn complete(self) -> C::Result {
         self.base.complete()
     }

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -245,9 +245,11 @@ where
 
     fn consume_iter<I>(mut self, iter: I) -> Self
     where
-        I: IntoIterator<Item = T>
+        I: IntoIterator<Item = T>,
     {
-        self.base = self.base.consume_iter(iter.into_iter().inspect(self.inspect_op));
+        self.base = self
+            .base
+            .consume_iter(iter.into_iter().inspect(self.inspect_op));
         self
     }
 

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -383,22 +383,20 @@ where
     }
 
     fn consume_iter<I>(self, iter: I) -> Self
-    where I: IntoIterator<Item = T>
+    where
+        I: IntoIterator<Item = T>,
     {
         let mut clone_first = self.clone_first;
         let between_item = self.item;
-        let base = self.base.consume_iter(
-            iter.into_iter()
-                .flat_map(|item| {
-                    let first = if clone_first {
-                        Some(between_item.clone())
-                    } else {
-                        clone_first = true;
-                        None
-                    };
-                    first.into_iter().chain(iter::once(item))
-                })
-        );
+        let base = self.base.consume_iter(iter.into_iter().flat_map(|item| {
+            let first = if clone_first {
+                Some(between_item.clone())
+            } else {
+                clone_first = true;
+                None
+            };
+            first.into_iter().chain(iter::once(item))
+        }));
         IntersperseFolder {
             base: base,
             item: between_item,

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -247,6 +247,14 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.base = self.base.consume_iter(iter.into_iter().map(self.map_op));
+        self
+    }
+
     fn complete(self) -> C::Result {
         self.base.complete()
     }

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -247,15 +247,13 @@ where
 
     fn consume_iter<I>(mut self, iter: I) -> Self
     where
-        I: IntoIterator<Item = T>
+        I: IntoIterator<Item = T>,
     {
         let update_op = self.update_op;
-        self.base = self.base.consume_iter(
-            iter.into_iter().map(|mut item| {
-                update_op(&mut item);
-                item
-            })
-        );
+        self.base = self.base.consume_iter(iter.into_iter().map(|mut item| {
+            update_op(&mut item);
+            item
+        }));
         self
     }
 

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -245,6 +245,20 @@ where
         }
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>
+    {
+        let update_op = self.update_op;
+        self.base = self.base.consume_iter(
+            iter.into_iter().map(|mut item| {
+                update_op(&mut item);
+                item
+            })
+        );
+        self
+    }
+
     fn complete(self) -> C::Result {
         self.base.complete()
     }

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -123,21 +123,20 @@ where
     }
 
     fn consume_iter<I>(mut self, iter: I) -> Self
-    where I: IntoIterator<Item = Option<T>>
+    where
+        I: IntoIterator<Item = Option<T>>,
     {
         let full = self.full;
         self.base = self.base.consume_iter(
             iter.into_iter()
-                .take_while(|x| {
-                    match *x {
-                        Some(_) => !full.load(Ordering::Relaxed),
-                        None => {
-                            full.store(true, Ordering::Relaxed);
-                            false
-                        }
+                .take_while(|x| match *x {
+                    Some(_) => !full.load(Ordering::Relaxed),
+                    None => {
+                        full.store(true, Ordering::Relaxed);
+                        false
                     }
                 })
-                .map(|x| x.unwrap())
+                .map(|x| x.unwrap()),
         );
         self
     }

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -122,6 +122,26 @@ where
         self
     }
 
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where I: IntoIterator<Item = Option<T>>
+    {
+        let full = self.full;
+        self.base = self.base.consume_iter(
+            iter.into_iter()
+                .take_while(|x| {
+                    match *x {
+                        Some(_) => !full.load(Ordering::Relaxed),
+                        None => {
+                            full.store(true, Ordering::Relaxed);
+                            false
+                        }
+                    }
+                })
+                .map(|x| x.unwrap())
+        );
+        self
+    }
+
     fn complete(self) -> C::Result {
         self.base.complete()
     }

--- a/tests/octillion.rs
+++ b/tests/octillion.rs
@@ -42,27 +42,57 @@ fn find_first_octillion_flat() {
     assert_eq!(x, Some(0));
 }
 
-#[test]
-fn find_last_octillion() {
+fn two_threads<F: Send + FnOnce() -> R, R: Send>(f: F) -> R {
     // FIXME: If we don't use at least two threads, then we end up walking
     // through the entire iterator sequentially, without the benefit of any
     // short-circuiting.  We probably don't want testing to wait that long. ;)
-    // It would be nice if `find_last` could prioritize the later splits,
-    // basically flipping the `join` args, without needing indexed `rev`.
-    // (or could we have an unindexed `rev`?)
     let builder = rayon::ThreadPoolBuilder::new().num_threads(2);
     let pool = builder.build().unwrap();
 
-    let x = pool.install(|| octillion().find_last(|_| true));
+    pool.install(f)
+}
+
+#[test]
+fn find_last_octillion() {
+    // It would be nice if `find_last` could prioritize the later splits,
+    // basically flipping the `join` args, without needing indexed `rev`.
+    // (or could we have an unindexed `rev`?)
+    let x = two_threads(|| octillion().find_last(|_| true));
     assert_eq!(x, Some(OCTILLION - 1));
 }
 
 #[test]
 fn find_last_octillion_flat() {
-    // FIXME: Ditto, need two threads.
-    let builder = rayon::ThreadPoolBuilder::new().num_threads(2);
-    let pool = builder.build().unwrap();
-
-    let x = pool.install(|| octillion_flat().find_last(|_| true));
+    let x = two_threads(|| octillion_flat().find_last(|_| true));
     assert_eq!(x, Some(OCTILLION - 1));
+}
+
+#[test]
+fn find_any_octillion() {
+    let x = two_threads(|| octillion().find_any(|x| *x > OCTILLION / 2));
+    assert!(x.is_some());
+}
+
+#[test]
+fn find_any_octillion_flat() {
+    let x = two_threads(|| octillion_flat().find_any(|x| *x > OCTILLION / 2));
+    assert!(x.is_some());
+}
+
+#[test]
+fn filter_find_any_octillion() {
+    let x = two_threads(|| octillion().filter(|x| *x > OCTILLION / 2).find_any(|_| true));
+    assert!(x.is_some());
+}
+
+#[test]
+fn filter_find_any_octillion_flat() {
+    let x = two_threads(|| octillion_flat().filter(|x| *x > OCTILLION / 2).find_any(|_| true));
+    assert!(x.is_some());
+}
+
+#[test]
+fn fold_find_any_octillion_flat() {
+    let x = two_threads(|| octillion_flat().fold(|| (), |_, _| ()).find_any(|_| true));
+    assert!(x.is_some());
 }

--- a/tests/octillion.rs
+++ b/tests/octillion.rs
@@ -81,13 +81,21 @@ fn find_any_octillion_flat() {
 
 #[test]
 fn filter_find_any_octillion() {
-    let x = two_threads(|| octillion().filter(|x| *x > OCTILLION / 2).find_any(|_| true));
+    let x = two_threads(|| {
+        octillion()
+            .filter(|x| *x > OCTILLION / 2)
+            .find_any(|_| true)
+    });
     assert!(x.is_some());
 }
 
 #[test]
 fn filter_find_any_octillion_flat() {
-    let x = two_threads(|| octillion_flat().filter(|x| *x > OCTILLION / 2).find_any(|_| true));
+    let x = two_threads(|| {
+        octillion_flat()
+            .filter(|x| *x > OCTILLION / 2)
+            .find_any(|_| true)
+    });
     assert!(x.is_some());
 }
 


### PR DESCRIPTION
This specializes the remaining "obvious" `consume_iter`s for the second part of #465. Benchmarks are included in each commit (the first specializes the types that can just defer to a `std` API, the second two require a bit more work); summary (on a 6 core/12 thread machine):

- on the included benchmarks:
  - `find` is up to 1.5x faster (`find::size1::parallel_find_middle`)
  - `collect` is up to 4x faster (`vec_collect::vec_i_filtered::with_collect`)
- using basic program that does something like `(0..std::u32::MAX).into_par_iter().<OPERATION>.map(test::black_box).count()`
  - with no operation (i.e. just testing `map`/`count`): 8x faster
  - with `.map(Some).while_some()`: 3x faster
  - with `.intersperse(1)`: 10x faster

The remaining types without a specialization are:

```
$ rg --files-with-matches 'fn consume' src/iter | xargs rg --files-without-match 'fn consume_iter'
src/iter/filter_map.rs
src/iter/unzip.rs
src/iter/try_fold.rs
src/iter/try_reduce_with.rs
src/iter/try_reduce.rs
src/iter/filter.rs
src/iter/flat_map.rs
src/iter/find_first_last/mod.rs
src/iter/collect/consumer.rs
```

(I've started a WIP branch for the `try_*` types at https://github.com/huonw/rayon/tree/try_fold; diff to this PR: https://github.com/huonw/rayon/compare/iter-opts...try_fold.)

