### PR TITLE
Allow the deprecated ATOMIC_USIZE_INIT

### DIFF
--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -13,7 +13,9 @@ use std::cell::Cell;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[allow(deprecated)]
+use std::sync::atomic::ATOMIC_USIZE_INIT;
 use std::sync::{Arc, Once, ONCE_INIT};
 use std::thread;
 use std::usize;
@@ -748,6 +750,7 @@ impl XorShift64Star {
         let mut seed = 0;
         while seed == 0 {
             let mut hasher = DefaultHasher::new();
+            #[allow(deprecated)]
             static COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
             hasher.write_usize(COUNTER.fetch_add(1, Ordering::Relaxed));
             seed = hasher.finish();

--- a/tests/sort-panic-safe.rs
+++ b/tests/sort-panic-safe.rs
@@ -10,9 +10,12 @@ use std::cell::Cell;
 use std::cmp::{self, Ordering};
 use std::panic;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use std::sync::atomic::AtomicUsize;
+#[allow(deprecated)]
+use std::sync::atomic::ATOMIC_USIZE_INIT;
 use std::thread;
 
+#[allow(deprecated)]
 static VERSIONS: AtomicUsize = ATOMIC_USIZE_INIT;
 
 lazy_static! {


### PR DESCRIPTION
Nightly 1.34 suggests the const `AtomicUsize::new()` instead, but we
still want to support older compilers, so just allow it for now.