### PR TITLE
Add the ability to customize thread spawning

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -19,10 +19,12 @@ num_cpus = "1.2"
 lazy_static = "1"
 crossbeam-deque = "0.6.3"
 crossbeam-queue = "0.1.2"
+crossbeam-utils = "0.6.5"
 
 [dev-dependencies]
 rand = "0.6"
 rand_xorshift = "0.1"
+scoped-tls = "1.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"
@@ -49,3 +51,7 @@ path = "tests/scope_join.rs"
 [[test]]
 name = "simple_panic"
 path = "tests/simple_panic.rs"
+
+[[test]]
+name = "scoped_threadpool"
+path = "tests/scoped_threadpool.rs"

--- a/rayon-core/src/private.rs
+++ b/rayon-core/src/private.rs
@@ -1,0 +1,26 @@
+//! The public parts of this private module are used to create traits
+//! that cannot be implemented outside of our own crate.  This way we
+//! can feel free to extend those traits without worrying about it
+//! being a breaking change for other implementations.
+
+/// If this type is pub but not publicly reachable, third parties
+/// can't name it and can't implement traits using it.
+#[allow(missing_debug_implementations)]
+pub struct PrivateMarker;
+
+macro_rules! private_decl {
+    () => {
+        /// This trait is private; this method exists to make it
+        /// impossible to implement outside the crate.
+        #[doc(hidden)]
+        fn __rayon_private__(&self) -> ::private::PrivateMarker;
+    }
+}
+
+macro_rules! private_impl {
+    () => {
+        fn __rayon_private__(&self) -> ::private::PrivateMarker {
+            ::private::PrivateMarker
+        }
+    }
+}

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -103,12 +103,9 @@ static THE_REGISTRY_SET: Once = ONCE_INIT;
 /// initialization has not already occurred, use the default
 /// configuration.
 fn global_registry() -> &'static Arc<Registry> {
-    unsafe {
-        THE_REGISTRY.unwrap_or_else(|| {
-            init_global_registry(ThreadPoolBuilder::new())
-                .expect("The global thread pool has not been initialized.")
-        })
-    }
+    set_global_registry(|| Registry::new(ThreadPoolBuilder::new()))
+        .or_else(|err| unsafe { THE_REGISTRY.ok_or(err) })
+        .expect("The global thread pool has not been initialized.")
 }
 
 /// Starts the worker threads (if that has not already happened) with

--- a/rayon-core/src/test.rs
+++ b/rayon-core/src/test.rs
@@ -155,3 +155,8 @@ fn configuration() {
         .build()
         .unwrap();
 }
+
+#[test]
+fn default_pool() {
+    ThreadPoolBuilder::default().build().unwrap();
+}

--- a/rayon-core/src/test.rs
+++ b/rayon-core/src/test.rs
@@ -160,3 +160,36 @@ fn configuration() {
 fn default_pool() {
     ThreadPoolBuilder::default().build().unwrap();
 }
+
+/// Test that custom spawned threads get their `WorkerThread` cleared once
+/// the pool is done with them, allowing them to be used with rayon again
+/// later. e.g. WebAssembly want to have their own pool of available threads.
+#[test]
+fn cleared_current_thread() -> Result<(), ThreadPoolBuildError> {
+    let n_threads = 5;
+    let mut handles = vec![];
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(n_threads)
+        .spawn_handler(|thread| {
+            let handle = std::thread::spawn(move || {
+                thread.run();
+
+                // Afterward, the current thread shouldn't be set anymore.
+                assert_eq!(crate::current_thread_index(), None);
+            });
+            handles.push(handle);
+            Ok(())
+        })
+        .build()?;
+    assert_eq!(handles.len(), n_threads);
+
+    pool.install(|| assert!(crate::current_thread_index().is_some()));
+    drop(pool);
+
+    // Wait for all threads to make their assertions and exit
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    Ok(())
+}

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -4,17 +4,16 @@
 //! [`ThreadPool`]: struct.ThreadPool.html
 
 use join;
-use registry::{Registry, WorkerThread};
+use registry::{Registry, ThreadSpawn, WorkerThread};
 use spawn;
 use std::error::Error;
 use std::fmt;
-use std::io;
 use std::sync::Arc;
 #[allow(deprecated)]
 use Configuration;
 use {scope, Scope};
 use {scope_fifo, ScopeFifo};
-use {ThreadBuilder, ThreadPoolBuildError, ThreadPoolBuilder};
+use {ThreadPoolBuildError, ThreadPoolBuilder};
 
 mod internal;
 mod test;
@@ -62,16 +61,13 @@ impl ThreadPool {
         Self::build(configuration.into_builder()).map_err(Box::from)
     }
 
-    pub(super) fn build(builder: ThreadPoolBuilder) -> Result<ThreadPool, ThreadPoolBuildError> {
+    pub(super) fn build<S>(
+        builder: ThreadPoolBuilder<S>,
+    ) -> Result<ThreadPool, ThreadPoolBuildError>
+    where
+        S: ThreadSpawn,
+    {
         let registry = Registry::new(builder)?;
-        Ok(ThreadPool { registry })
-    }
-
-    pub(super) fn build_spawn(
-        builder: ThreadPoolBuilder,
-        spawn: impl FnMut(ThreadBuilder) -> io::Result<()>,
-    ) -> Result<ThreadPool, ThreadPoolBuildError> {
-        let registry = Registry::spawn(builder, spawn)?;
         Ok(ThreadPool { registry })
     }
 

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -8,12 +8,13 @@ use registry::{Registry, WorkerThread};
 use spawn;
 use std::error::Error;
 use std::fmt;
+use std::io;
 use std::sync::Arc;
 #[allow(deprecated)]
 use Configuration;
 use {scope, Scope};
 use {scope_fifo, ScopeFifo};
-use {ThreadPoolBuildError, ThreadPoolBuilder};
+use {ThreadBuilder, ThreadPoolBuildError, ThreadPoolBuilder};
 
 mod internal;
 mod test;
@@ -63,6 +64,14 @@ impl ThreadPool {
 
     pub(super) fn build(builder: ThreadPoolBuilder) -> Result<ThreadPool, ThreadPoolBuildError> {
         let registry = Registry::new(builder)?;
+        Ok(ThreadPool { registry })
+    }
+
+    pub(super) fn build_spawn(
+        builder: ThreadPoolBuilder,
+        spawn: impl FnMut(ThreadBuilder) -> io::Result<()>,
+    ) -> Result<ThreadPool, ThreadPoolBuildError> {
+        let registry = Registry::spawn(builder, spawn)?;
         Ok(ThreadPool { registry })
     }
 

--- a/rayon-core/tests/scoped_threadpool.rs
+++ b/rayon-core/tests/scoped_threadpool.rs
@@ -1,0 +1,68 @@
+extern crate crossbeam_utils;
+extern crate rayon_core;
+
+#[macro_use]
+extern crate scoped_tls;
+
+use crossbeam_utils::thread;
+use rayon_core::ThreadPoolBuilder;
+
+#[derive(PartialEq, Eq, Debug)]
+struct Local(i32);
+
+scoped_thread_local!(static LOCAL: Local);
+
+#[test]
+fn scoped_tls_missing() {
+    LOCAL.set(&Local(42), || {
+        let pool = ThreadPoolBuilder::new()
+            .build()
+            .expect("thread pool created");
+
+        // `LOCAL` is not set in the pool.
+        pool.install(|| {
+            assert!(!LOCAL.is_set());
+        });
+    });
+}
+
+#[test]
+fn scoped_tls_threadpool() {
+    LOCAL.set(&Local(42), || {
+        LOCAL.with(|x| {
+            thread::scope(|scope| {
+                let pool = ThreadPoolBuilder::new()
+                    .spawn(move |thread| {
+                        scope
+                            .builder()
+                            .spawn(move |_| {
+                                // Borrow the same local value in the thread pool.
+                                LOCAL.set(x, || thread.run())
+                            })
+                            .map(|_| ())
+                    })
+                    .expect("thread pool created");
+
+                // The pool matches our local value.
+                pool.install(|| {
+                    assert!(LOCAL.is_set());
+                    LOCAL.with(|y| {
+                        assert_eq!(x, y);
+                    });
+                });
+
+                // If we change our local value, the pool is not affected.
+                LOCAL.set(&Local(-1), || {
+                    pool.install(|| {
+                        assert!(LOCAL.is_set());
+                        LOCAL.with(|y| {
+                            assert_eq!(x, y);
+                        });
+                    });
+                });
+            })
+            .expect("scope threads ok");
+            // `thread::scope` will wait for the threads to exit before returning.
+        });
+    });
+}

--- a/rayon-core/tests/scoped_threadpool.rs
+++ b/rayon-core/tests/scoped_threadpool.rs
@@ -32,7 +32,7 @@ fn spawn_scoped_tls_threadpool() {
         LOCAL.with(|x| {
             thread::scope(|scope| {
                 let pool = ThreadPoolBuilder::new()
-                    .spawn(move |thread| {
+                    .spawn_handler(move |thread| {
                         scope
                             .builder()
                             .spawn(move |_| {
@@ -41,6 +41,7 @@ fn spawn_scoped_tls_threadpool() {
                             })
                             .map(|_| ())
                     })
+                    .build()
                     .expect("thread pool created");
 
                 // The pool matches our local value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ mod par_either;
 mod compile_fail;
 
 pub use rayon_core::FnContext;
+pub use rayon_core::ThreadBuilder;
 pub use rayon_core::ThreadPool;
 pub use rayon_core::ThreadPoolBuildError;
 pub use rayon_core::ThreadPoolBuilder;


### PR DESCRIPTION
As an alternative to `ThreadPoolBuilder::build()` and `build_global()`,
the new `spawn()` and `spawn_global()` methods take a closure which will
be responsible for spawning the actual threads. This is called with a
`ThreadBuilder` argument that provides the thread index, name, and stack
size, with the expectation to call its `run()` method in the new thread.

The motivating use cases for this are:
- experimental WASM threading, to be externally implemented.
- scoped threads, like the new test using `scoped_tls`.