### PR TITLE
#[allow(deprecated)] impl Default for Configuration

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -155,7 +155,6 @@ pub struct ThreadPoolBuilder {
 ///
 /// [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
 #[deprecated(note = "Use `ThreadPoolBuilder`")]
-#[derive(Default)]
 pub struct Configuration {
     builder: ThreadPoolBuilder,
 }
@@ -536,6 +535,15 @@ impl fmt::Debug for ThreadPoolBuilder {
             .field("exit_handler", &exit_handler)
             .field("breadth_first", &breadth_first)
             .finish()
+    }
+}
+
+#[allow(deprecated)]
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            builder: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
Using `#[derive(Default)]` started triggering `Configuration`'s own
deprecation message on nightly, as it has been on our compat 1.13 as
well (though stable has been fine). We can easily `#[allow(deprecated)]`
on a manual `impl` to avoid this.