### PR TITLE
Require rayon-core ^1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["rayon-demo", "rayon-core", "rayon-futures"]
 exclude = ["ci"]
 
 [dependencies]
-rayon-core = { version = "1.4", path = "rayon-core" }
+rayon-core = { version = "1.4.1", path = "rayon-core" }
 crossbeam-deque = "0.2.0"
 
 # This is a public dependency!


### PR DESCRIPTION
I'm trying to make my crates work with `cargo -Z minimal-versions` to ensure that versions specified in my Cargo.toml are actual versions that work with my crate.

The problem is, it's not true for Rayon's dependencies: rayon 1.0.3 uses rayon-core 1.4.0, which uses rand 0.3.12, which uses advapi32-sys 0.1.2, which uses winapi 0.0.1, which isn't compatible with Rust 1.0.

The problem has been fixed in rayon-core 1.4.1, so that should be the minimal version used by rayon.
