### PR TITLE
Add ParallelIterator::panic_fuse()

### DIFF
--- a/src/compile_fail/must_use.rs
+++ b/src/compile_fail/must_use.rs
@@ -49,6 +49,7 @@ must_use! {
     map                 /** v.par_iter().map(|x| x); */
     map_with            /** v.par_iter().map_with(0, |_, x| x); */
     map_init            /** v.par_iter().map_init(|| 0, |_, x| x); */
+    panic_fuse          /** v.par_iter().panic_fuse(); */
     rev                 /** v.par_iter().rev(); */
     skip                /** v.par_iter().skip(1); */
     take                /** v.par_iter().take(1); */

--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -7,6 +7,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 pub struct CollectConsumer<'c, T: Send + 'c> {
     /// Tracks how many items we successfully wrote. Used to guarantee
     /// safety in the face of panics or buggy parallel iterators.
+    ///
+    /// In theory we could just produce this as a `CollectConsumer::Result`,
+    /// folding local counts and reducing by addition, but that requires a
+    /// certain amount of trust that the producer driving this will behave
+    /// itself. Since this count is important to the safety of marking the
+    /// memory initialized (`Vec::set_len`), we choose to keep it internal.
     writes: &'c AtomicUsize,
 
     /// A slice covering the target memory, not yet initialized!

--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -85,7 +85,8 @@ impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
     }
 
     fn complete(self) {
-        assert!(self.target.len() == 0, "too few values pushed to consumer");
+        // NB: We don't explicitly check that the local writes were complete,
+        // but `Collect::complete()` will assert the global write count.
 
         // track total values written
         self.global_writes

--- a/src/iter/collect/test.rs
+++ b/src/iter/collect/test.rs
@@ -25,15 +25,18 @@ fn produce_too_many_items() {
 /// Produces fewer items than promised. Does not do any
 /// splits at all.
 #[test]
-#[should_panic(expected = "too few values")]
+#[should_panic(expected = "expected 5 total writes, but got 2")]
 fn produce_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 5);
-    let consumer = collect.as_consumer();
-    let mut folder = consumer.into_folder();
-    folder = folder.consume(22);
-    folder = folder.consume(23);
-    folder.complete();
+    {
+        let consumer = collect.as_consumer();
+        let mut folder = consumer.into_folder();
+        folder = folder.consume(22);
+        folder = folder.consume(23);
+        folder.complete();
+    }
+    collect.complete();
 }
 
 // Complete is not called by the consumer.Hence,the collection vector is not fully initialized.
@@ -129,7 +132,7 @@ fn right_produces_too_many_items() {
 // The left consumer produces fewer items while the right
 // consumer produces correct number.
 #[test]
-#[should_panic(expected = "too few values")]
+#[should_panic(expected = "expected 4 total writes, but got 3")]
 fn left_produces_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
@@ -149,7 +152,7 @@ fn left_produces_fewer_items() {
 // The right consumer produces fewer items while the left
 // consumer produces correct number.
 #[test]
-#[should_panic(expected = "too few values")]
+#[should_panic(expected = "expected 4 total writes, but got 3")]
 fn right_produces_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);

--- a/src/iter/collect/test.rs
+++ b/src/iter/collect/test.rs
@@ -7,6 +7,7 @@
 
 use super::Collect;
 use iter::plumbing::*;
+use rayon_core::join;
 
 /// Promises to produce 2 items, but then produces 3.  Does not do any
 /// splits at all.
@@ -165,6 +166,58 @@ fn right_produces_fewer_items() {
         right_folder = right_folder.consume(2);
         left_folder.complete();
         right_folder.complete();
+    }
+    collect.complete();
+}
+
+// The left consumer panics and the right stops short, like `panic_fuse()`.
+// We should get the left panic without ever reaching `Collect::complete()`.
+#[test]
+#[should_panic(expected = "left consumer panic")]
+fn left_panics() {
+    let mut v = vec![];
+    let mut collect = Collect::new(&mut v, 4);
+    {
+        let consumer = collect.as_consumer();
+        let (left_consumer, right_consumer, _) = consumer.split_at(2);
+        join(
+            || {
+                let mut left_folder = left_consumer.into_folder();
+                left_folder = left_folder.consume(0);
+                panic!("left consumer panic");
+            },
+            || {
+                let mut right_folder = right_consumer.into_folder();
+                right_folder = right_folder.consume(2);
+                right_folder.complete() // early return
+            },
+        );
+    }
+    collect.complete();
+}
+
+// The right consumer panics and the left stops short, like `panic_fuse()`.
+// We should get the right panic without ever reaching `Collect::complete()`.
+#[test]
+#[should_panic(expected = "right consumer panic")]
+fn right_panics() {
+    let mut v = vec![];
+    let mut collect = Collect::new(&mut v, 4);
+    {
+        let consumer = collect.as_consumer();
+        let (left_consumer, right_consumer, _) = consumer.split_at(2);
+        join(
+            || {
+                let mut left_folder = left_consumer.into_folder();
+                left_folder = left_folder.consume(0);
+                left_folder.complete() // early return
+            },
+            || {
+                let mut right_folder = right_consumer.into_folder();
+                right_folder = right_folder.consume(2);
+                panic!("right consumer panic");
+            },
+        );
     }
     collect.complete();
 }

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -1,0 +1,338 @@
+use super::plumbing::*;
+use super::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+/// `PanicFuse` is an adaptor that wraps an iterator with a fuse in case
+/// of panics, to halt all threads as soon as possible.
+///
+/// This struct is created by the [`panic_fuse()`] method on [`ParallelIterator`]
+///
+/// [`panic_fuse()`]: trait.ParallelIterator.html#method.panic_fuse
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone)]
+pub struct PanicFuse<I: ParallelIterator> {
+    base: I,
+}
+
+/// Helper that sets a bool to `true` if dropped while unwinding.
+#[derive(Clone)]
+struct Fuse<'a>(&'a AtomicBool);
+
+impl<'a> Drop for Fuse<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        if thread::panicking() {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+impl<'a> Fuse<'a> {
+    #[inline]
+    fn panicked(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Create a new `PanicFuse` iterator.
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I>(base: I) -> PanicFuse<I>
+where
+    I: ParallelIterator,
+{
+    PanicFuse { base: base }
+}
+
+impl<I> ParallelIterator for PanicFuse<I>
+where
+    I: ParallelIterator,
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        let panicked = AtomicBool::new(false);
+        let consumer1 = PanicFuseConsumer {
+            base: consumer,
+            fuse: Fuse(&panicked),
+        };
+        self.base.drive_unindexed(consumer1)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        self.base.opt_len()
+    }
+}
+
+impl<I> IndexedParallelIterator for PanicFuse<I>
+where
+    I: IndexedParallelIterator,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        let panicked = AtomicBool::new(false);
+        let consumer1 = PanicFuseConsumer {
+            base: consumer,
+            fuse: Fuse(&panicked),
+        };
+        self.base.drive(consumer1)
+    }
+
+    fn len(&self) -> usize {
+        self.base.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        return self.base.with_producer(Callback { callback: callback });
+
+        struct Callback<CB> {
+            callback: CB,
+        }
+
+        impl<T, CB> ProducerCallback<T> for Callback<CB>
+        where
+            CB: ProducerCallback<T>,
+        {
+            type Output = CB::Output;
+
+            fn callback<P>(self, base: P) -> CB::Output
+            where
+                P: Producer<Item = T>,
+            {
+                let panicked = AtomicBool::new(false);
+                let producer = PanicFuseProducer {
+                    base: base,
+                    fuse: Fuse(&panicked),
+                };
+                self.callback.callback(producer)
+            }
+        }
+    }
+}
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Producer implementation
+
+struct PanicFuseProducer<'a, P> {
+    base: P,
+    fuse: Fuse<'a>,
+}
+
+impl<'a, P> Producer for PanicFuseProducer<'a, P>
+where
+    P: Producer,
+{
+    type Item = P::Item;
+    type IntoIter = PanicFuseIter<'a, P::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PanicFuseIter {
+            base: self.base.into_iter(),
+            fuse: self.fuse,
+        }
+    }
+
+    fn min_len(&self) -> usize {
+        self.base.min_len()
+    }
+    fn max_len(&self) -> usize {
+        self.base.max_len()
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (
+            PanicFuseProducer {
+                base: left,
+                fuse: self.fuse.clone(),
+            },
+            PanicFuseProducer {
+                base: right,
+                fuse: self.fuse,
+            },
+        )
+    }
+
+    fn fold_with<G>(self, folder: G) -> G
+    where
+        G: Folder<Self::Item>,
+    {
+        let folder1 = PanicFuseFolder {
+            base: folder,
+            fuse: self.fuse,
+        };
+        self.base.fold_with(folder1).base
+    }
+}
+
+struct PanicFuseIter<'a, I> {
+    base: I,
+    fuse: Fuse<'a>,
+}
+
+impl<'a, I> Iterator for PanicFuseIter<'a, I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.fuse.panicked() {
+            None
+        } else {
+            self.base.next()
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.base.size_hint()
+    }
+}
+
+impl<'a, I> DoubleEndedIterator for PanicFuseIter<'a, I>
+where
+    I: DoubleEndedIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.fuse.panicked() {
+            None
+        } else {
+            self.base.next_back()
+        }
+    }
+}
+
+impl<'a, I> ExactSizeIterator for PanicFuseIter<'a, I>
+where
+    I: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        self.base.len()
+    }
+}
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
+
+struct PanicFuseConsumer<'a, C> {
+    base: C,
+    fuse: Fuse<'a>,
+}
+
+impl<'a, T, C> Consumer<T> for PanicFuseConsumer<'a, C>
+where
+    C: Consumer<T>,
+{
+    type Folder = PanicFuseFolder<'a, C::Folder>;
+    type Reducer = PanicFuseReducer<'a, C::Reducer>;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (
+            PanicFuseConsumer {
+                base: left,
+                fuse: self.fuse.clone(),
+            },
+            PanicFuseConsumer {
+                base: right,
+                fuse: self.fuse.clone(),
+            },
+            PanicFuseReducer {
+                base: reducer,
+                _fuse: self.fuse,
+            },
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        PanicFuseFolder {
+            base: self.base.into_folder(),
+            fuse: self.fuse,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.fuse.panicked() || self.base.full()
+    }
+}
+
+impl<'a, T, C> UnindexedConsumer<T> for PanicFuseConsumer<'a, C>
+where
+    C: UnindexedConsumer<T>,
+{
+    fn split_off_left(&self) -> Self {
+        PanicFuseConsumer {
+            base: self.base.split_off_left(),
+            fuse: self.fuse.clone(),
+        }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        PanicFuseReducer {
+            base: self.base.to_reducer(),
+            _fuse: self.fuse.clone(),
+        }
+    }
+}
+
+struct PanicFuseFolder<'a, C> {
+    base: C,
+    fuse: Fuse<'a>,
+}
+
+impl<'a, T, C> Folder<T> for PanicFuseFolder<'a, C>
+where
+    C: Folder<T>,
+{
+    type Result = C::Result;
+
+    fn consume(mut self, item: T) -> Self {
+        self.base = self.base.consume(item);
+        self
+    }
+
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.base = {
+            let fuse = &self.fuse;
+            let iter = iter.into_iter().take_while(move |_| !fuse.panicked());
+            self.base.consume_iter(iter)
+        };
+        self
+    }
+
+    fn complete(self) -> C::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        self.fuse.panicked() || self.base.full()
+    }
+}
+
+struct PanicFuseReducer<'a, C> {
+    base: C,
+    _fuse: Fuse<'a>,
+}
+
+impl<'a, T, C> Reducer<T> for PanicFuseReducer<'a, C>
+where
+    C: Reducer<T>,
+{
+    fn reduce(self, left: T, right: T) -> T {
+        self.base.reduce(left, right)
+    }
+}

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -126,6 +126,7 @@ fn clone_adaptors() {
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
     check(v.par_iter().map_init(|| 0, |_, x| x));
+    check(v.par_iter().panic_fuse());
     check(v.par_iter().rev());
     check(v.par_iter().skip(1));
     check(v.par_iter().take(1));

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -137,6 +137,7 @@ fn debug_adaptors() {
     check(v.par_iter().map(|x| x));
     check(v.par_iter().map_with(0, |_, x| x));
     check(v.par_iter().map_init(|| 0, |_, x| x));
+    check(v.par_iter().panic_fuse());
     check(v.par_iter().rev());
     check(v.par_iter().skip(1));
     check(v.par_iter().take(1));

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -268,6 +268,12 @@ fn map_init() {
 }
 
 #[test]
+fn panic_fuse() {
+    let v: Vec<_> = (0..10).collect();
+    check(&v, || (0..10).into_par_iter().panic_fuse());
+}
+
+#[test]
 fn rev() {
     let v: Vec<_> = (0..10).rev().collect();
     check(&v, || (0..10).into_par_iter().rev());


### PR DESCRIPTION
This wraps an iterator with a fuse in case of panics, to halt all
threads as soon as possible. While we always propagate panics anyway,
that doesn't usually synchronize across threads, so iterators may end up
processing many more items before the panic is realized. With
`panic_fuse()`, a shared `AtomicBool` is checked before processing each
item, and set for any panic unwinding in its path.