### PR TITLE
Introduce IndexedParallelIterator::mapfold_collect_into_vec

### DIFF
--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -1,63 +1,99 @@
 use super::super::noop::*;
 use super::super::plumbing::*;
+use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub struct CollectConsumer<'c, T: Send + 'c> {
+pub struct CollectConsumer<'c, T: Send + 'c, U, F: MapFolder<U>, R> {
     /// Tracks how many items we successfully wrote. Used to guarantee
     /// safety in the face of panics or buggy parallel iterators.
     writes: &'c AtomicUsize,
 
     /// A slice covering the target memory, not yet initialized!
     target: &'c mut [T],
+
+    marker: PhantomData<U>,
+    map_folder: F,
+    reducer: R,
 }
 
-pub struct CollectFolder<'c, T: Send + 'c> {
+pub struct CollectFolder<'c, T: Send + 'c, U, F: MapFolder<U>> {
     global_writes: &'c AtomicUsize,
     local_writes: usize,
 
     /// An iterator over the *uninitialized* target memory.
     target: slice::IterMut<'c, T>,
+
+    marker: PhantomData<U>,
+    map_folder: F,
 }
 
-impl<'c, T: Send + 'c> CollectConsumer<'c, T> {
+impl<'c, T, U, F, R> CollectConsumer<'c, T, U, F, R>
+where
+    T: Send + 'c,
+    F: MapFolder<U>,
+    R: Reducer<F::Result>,
+{
     /// The target memory is considered uninitialized, and will be
     /// overwritten without dropping anything.
-    pub fn new(writes: &'c AtomicUsize, target: &'c mut [T]) -> CollectConsumer<'c, T> {
+    pub fn new(
+        writes: &'c AtomicUsize,
+        target: &'c mut [T],
+        map_folder: F,
+        reducer: R,
+    ) -> CollectConsumer<'c, T, U, F, R> {
         CollectConsumer {
             writes: writes,
             target: target,
+            marker: PhantomData,
+            map_folder: map_folder,
+            reducer: reducer,
         }
     }
 }
 
-impl<'c, T: Send + 'c> Consumer<T> for CollectConsumer<'c, T> {
-    type Folder = CollectFolder<'c, T>;
-    type Reducer = NoopReducer;
-    type Result = ();
+impl<'c, T, U, F, R> Consumer<U> for CollectConsumer<'c, T, U, F, R>
+where
+    T: Send + 'c,
+    U: Send,
+    F: Clone + MapFolder<U, Output = T> + Send,
+    F::Result: Send,
+    R: Clone + Reducer<F::Result> + Send,
+{
+    type Folder = CollectFolder<'c, T, U, F>;
+    type Reducer = R;
+    type Result = F::Result;
 
-    fn split_at(self, index: usize) -> (Self, Self, NoopReducer) {
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
         // instances Read in the fields from `self` and then
         // forget `self`, since it has been legitimately consumed
         // (and not dropped during unwinding).
-        let CollectConsumer { writes, target } = self;
+        let CollectConsumer {
+            writes,
+            target,
+            map_folder,
+            reducer,
+            ..
+        } = self;
 
         // Produce new consumers. Normal slicing ensures that the
         // memory range given to each consumer is disjoint.
         let (left, right) = target.split_at_mut(index);
         (
-            CollectConsumer::new(writes, left),
-            CollectConsumer::new(writes, right),
-            NoopReducer,
+            CollectConsumer::new(writes, left, map_folder.clone(), reducer.clone()),
+            CollectConsumer::new(writes, right, map_folder, reducer.clone()),
+            reducer,
         )
     }
 
-    fn into_folder(self) -> CollectFolder<'c, T> {
+    fn into_folder(self) -> CollectFolder<'c, T, U, F> {
         CollectFolder {
             global_writes: self.writes,
             local_writes: 0,
             target: self.target.into_iter(),
+            marker: PhantomData,
+            map_folder: self.map_folder,
         }
     }
 
@@ -66,10 +102,17 @@ impl<'c, T: Send + 'c> Consumer<T> for CollectConsumer<'c, T> {
     }
 }
 
-impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
-    type Result = ();
+impl<'c, T, U, F> Folder<U> for CollectFolder<'c, T, U, F>
+where
+    T: Send + 'c,
+    F: MapFolder<U, Output = T>,
+{
+    type Result = F::Result;
 
-    fn consume(mut self, item: T) -> CollectFolder<'c, T> {
+    fn consume(mut self, item: U) -> Self {
+        let (map_folder, item) = self.map_folder.consume(item);
+        self.map_folder = map_folder;
+
         // Compute target pointer and write to it. Safe because the iterator
         // does all the bounds checking; we're only avoiding the target drop.
         let head = self
@@ -84,12 +127,14 @@ impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
         self
     }
 
-    fn complete(self) {
+    fn complete(self) -> Self::Result {
         assert!(self.target.len() == 0, "too few values pushed to consumer");
 
         // track total values written
         self.global_writes
             .fetch_add(self.local_writes, Ordering::Relaxed);
+
+        self.map_folder.complete()
     }
 
     fn full(&self) -> bool {
@@ -99,10 +144,13 @@ impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
 
 /// Pretend to be unindexed for `special_collect_into_vec`,
 /// but we should never actually get used that way...
-impl<'c, T: Send + 'c> UnindexedConsumer<T> for CollectConsumer<'c, T> {
+impl<'c, T: Send + 'c> UnindexedConsumer<T>
+    for CollectConsumer<'c, T, T, NoopConsumer, NoopReducer>
+{
     fn split_off_left(&self) -> Self {
         unreachable!("CollectConsumer must be indexed!")
     }
+
     fn to_reducer(&self) -> Self::Reducer {
         NoopReducer
     }

--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -1,5 +1,6 @@
 use super::super::noop::*;
 use super::super::plumbing::*;
+use super::MapFolder;
 use std::marker::PhantomData;
 use std::ptr;
 use std::slice;

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -16,7 +16,7 @@ mod test;
 ///
 /// This is not directly public, but called by
 /// `IndexedParallelIterator::collect_into_vec_and_fold_reduce`.
-pub fn mapfold_collect_into_vec<'c, I, T, F, R>(
+pub fn map_collect_fold_reduce_into_vec_with<'c, I, T, F, R>(
     pi: I,
     v: &'c mut Vec<T>,
     map_folder: F,
@@ -43,7 +43,7 @@ where
     I: IndexedParallelIterator<Item = T>,
     T: Send,
 {
-    mapfold_collect_into_vec(pi, v, NoopConsumer, NoopReducer)
+    map_collect_fold_reduce_into_vec_with(pi, v, NoopConsumer, NoopReducer)
 }
 
 /// Collects the results of the iterator into the specified vector.

--- a/src/iter/collect/test.rs
+++ b/src/iter/collect/test.rs
@@ -15,7 +15,7 @@ use iter::plumbing::*;
 fn produce_too_many_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 2);
-    let consumer = collect.as_consumer();
+    let consumer = collect.as_noop_consumer();
     let mut folder = consumer.into_folder();
     folder = folder.consume(22);
     folder = folder.consume(23);
@@ -29,7 +29,7 @@ fn produce_too_many_items() {
 fn produce_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 5);
-    let consumer = collect.as_consumer();
+    let consumer = collect.as_noop_consumer();
     let mut folder = consumer.into_folder();
     folder = folder.consume(22);
     folder = folder.consume(23);
@@ -43,7 +43,7 @@ fn left_produces_items_with_no_complete() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();
@@ -62,7 +62,7 @@ fn right_produces_items_with_no_complete() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();
@@ -80,7 +80,7 @@ fn produces_items_with_no_complete() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 2);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let mut folder = consumer.into_folder();
         folder = folder.consume(22);
         folder = folder.consume(23);
@@ -96,7 +96,7 @@ fn left_produces_too_many_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();
@@ -115,7 +115,7 @@ fn right_produces_too_many_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();
@@ -134,7 +134,7 @@ fn left_produces_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();
@@ -154,7 +154,7 @@ fn right_produces_fewer_items() {
     let mut v = vec![];
     let mut collect = Collect::new(&mut v, 4);
     {
-        let consumer = collect.as_consumer();
+        let consumer = collect.as_noop_consumer();
         let (left_consumer, right_consumer, _) = consumer.split_at(2);
         let mut left_folder = left_consumer.into_folder();
         let mut right_folder = right_consumer.into_folder();

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2021,7 +2021,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// }
     ///
     /// let negative_numbers =
-    ///     [4, -7, 18, 25, -9].par_iter().cloned().mapfold_collect_into_vec(
+    ///     [4, -7, 18, 25, -9].par_iter().cloned().map_collect_fold_reduce_into_vec_with(
     ///         &mut vec,
     ///         NegativeFolder(vec![]),
     ///         NegativeReducer
@@ -2030,7 +2030,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// assert_eq!(vec, [4, 0, 18, 25, 0]);
     /// assert_eq!(negative_numbers, [-7, -9]);
     /// ```
-    fn mapfold_collect_into_vec<F, R>(
+    fn map_collect_fold_reduce_into_vec_with<F, R>(
         self,
         target: &mut Vec<F::Output>,
         map_folder: F,
@@ -2040,7 +2040,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
         F: Clone + MapFolder<Self::Item> + Send,
         R: Clone + Reducer<F::Result> + Send,
     {
-        collect::mapfold_collect_into_vec(self, target, map_folder, reducer)
+        collect::map_collect_fold_reduce_into_vec_with(self, target, map_folder, reducer)
     }
 
     /// Unzips the results of the iterator into the specified

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -1,5 +1,6 @@
 use super::plumbing::*;
 
+#[derive(Clone)]
 pub struct NoopConsumer;
 
 impl NoopConsumer {
@@ -24,6 +25,20 @@ impl<T> Consumer<T> for NoopConsumer {
     fn full(&self) -> bool {
         false
     }
+}
+
+impl<T> MapFolder<T> for NoopConsumer
+where
+    T: Send,
+{
+    type Output = T;
+    type Result = ();
+
+    fn consume(self, item: T) -> (Self, T) {
+        (self, item)
+    }
+
+    fn complete(self) {}
 }
 
 impl<T> Folder<T> for NoopConsumer {
@@ -58,6 +73,7 @@ impl<T> UnindexedConsumer<T> for NoopConsumer {
     }
 }
 
+#[derive(Clone)]
 pub struct NoopReducer;
 
 impl Reducer<()> for NoopReducer {

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -1,3 +1,4 @@
+use super::collect::MapFolder;
 use super::plumbing::*;
 
 #[derive(Clone)]

--- a/src/iter/plumbing/mod.rs
+++ b/src/iter/plumbing/mod.rs
@@ -192,24 +192,6 @@ pub trait Folder<Item>: Sized {
     fn full(&self) -> bool;
 }
 
-/// The `MapFolder` trait represents a "map fold" operation, where the "map"
-/// part is encoded by the `consume` method taking `Self::Item` and returning
-/// `T`, and where the "fold" part is encoded by `map` taking `&mut self` and
-/// the `complete` method returning `Self::Result`.
-pub trait MapFolder<Item>: Sized {
-    /// The output returned when consuming an item.
-    type Output: Send;
-
-    /// The type of result that will ultimately be produced by the map folder.
-    type Result: Send;
-
-    /// Consume an item.
-    fn consume(self, item: Item) -> (Self, Self::Output);
-
-    /// Finish consuming items, produce final result.
-    fn complete(self) -> Self::Result;
-}
-
 /// The reducer is the final step of a `Consumer` -- after a consumer
 /// has been split into two parts, and each of those parts has been
 /// fully processed, we are left with two results. The reducer is then

--- a/src/iter/plumbing/mod.rs
+++ b/src/iter/plumbing/mod.rs
@@ -192,6 +192,24 @@ pub trait Folder<Item>: Sized {
     fn full(&self) -> bool;
 }
 
+/// The `MapFolder` trait represents a "map fold" operation, where the "map"
+/// part is encoded by the `consume` method taking `Self::Item` and returning
+/// `T`, and where the "fold" part is encoded by `map` taking `&mut self` and
+/// the `complete` method returning `Self::Result`.
+pub trait MapFolder<Item>: Sized {
+    /// The output returned when consuming an item.
+    type Output: Send;
+
+    /// The type of result that will ultimately be produced by the map folder.
+    type Result: Send;
+
+    /// Consume an item.
+    fn consume(self, item: Item) -> (Self, Self::Output);
+
+    /// Finish consuming items, produce final result.
+    fn complete(self) -> Self::Result;
+}
+
 /// The reducer is the final step of a `Consumer` -- after a consumer
 /// has been split into two parts, and each of those parts has been
 /// fully processed, we are left with two results. The reducer is then


### PR DESCRIPTION
*Nit: do bikeshed the name, I hate it anyway.*

This method introduces a neat way to collect some parallel iterator in a vec in an allocation-efficient way, while still being able to do some operations on the data being collected. It uses a new trait, `MapFolder<Item>`, which is a generalised closure for the classic [`mapfold`](http://erlang.org/doc/man/lists.html#mapfoldl-3) operation.

Given the very raison d'être of parallel iterators is to be able to do work by batches, the result of the various `MapFolder::complete` calls are passed to a `Reducer` and returned from `mapfold_collect_into_vec`.

# Why

Because, as usual, I need this as part of some Servo-related stuff. :) In [Victor](https://github.com/SimonSapin/victor), we build in parallel a vector of fragments from a vector of boxes:

https://github.com/SimonSapin/victor/blob/6ddce7345030ae4d25f846ca757d6b50f3f8aeac/victor/src/layout/mod.rs#L56-L59

Some CSS features (among which absolute positioning, in case you were curious) require us to make some of those fragments go up the fragment tree to where they should actually belong. To do this, we would like to be able map the boxes into fragments as usual, but also collect the absolutely positioned ones into a separate vec that we can then append to the parent's own list of absolutely positioned fragments, until we reach the final one. There are way fewer absolutely positioned boxes than normal ones so it's not a problem to concat them as we traverse the tree. This method allows us to achieve that this way:

```rust
#[derive(Clone)]
struct BoxMapFolder(Vec<AbsposFragment>);

impl<'a> MapFolder<&'a BlockLevelBox> for BoxMapFolder {
    type Output = Fragment;
    type Result = Vec<AbsposFragment>;

    fn consume(mut self, block_level_box: &'a BlockLevelBox) -> (Self, Self::Output) {
        let (fragment, mut absolutely_positioned_fragments) = block_level_box.layout();
        self.0.append(&mut absolutely_positioned_fragments);
        (self, fragment)
    }

    fn complete(self) -> Self::Result {
        self.0
    }
}

#[derive(Clone)]
struct BoxReducer;

impl Reducer<Vec<AbsposFragment>> for BoxReducer {
    fn reduce(
        self,
        mut left: Vec<AbsposFragment>,
        mut right: Vec<AbsposFragment>,
    ) -> Vec<AbsposFragment> {
        left.append(&mut right);
        left
    }
}

let mut child_fragments = vec![];
let absolutely_positioned_fragments = child_boxes
    .par_iter()
    .mapfold_collect_into_vec(
        &mut child_fragments,
        BoxMapFolder(vec![]),
        BoxReducer,
    );
```

# Unresolved questions

## Should this method really be relying on plumbing?

Probably not, I guess we should have a variety of different methods like `map_init`, `map_with`, `fold_with` etc, but as a proof of concept I didn't want to lose too much time on how the functionality should be exposed before I make the PR. Those methods will also require names, and I can't find any which doesn't annoy me.

## Should it be named that way?

Probably not.

## Is there a way to avoid the need for a new trait `MapFolder`?

I don't think so but I am certainly not sure of that.