### PR TITLE
docs: fix "double wording"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ as:
 rayon = "1.0"
 ```
 
-and then add the following to to your `lib.rs`:
+and then add the following to your `lib.rs`:
 
 ```rust
 extern crate rayon;


### PR DESCRIPTION
"to to" -> "to"