### PR TITLE
Reusing LockLatch to reduce allocation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *~
 TAGS
 *.bk
+.idea

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -64,7 +64,7 @@ impl JobRef {
 /// executes it need not free any heap data, the cleanup occurs when
 /// the stack frame is later popped.  The function parameter indicates
 /// `true` if the job was stolen -- executed on a different thread.
-pub(super) struct StackJob<'a, L, F, R>
+pub(super) struct StackJob<'a, L: 'a, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -64,24 +64,24 @@ impl JobRef {
 /// executes it need not free any heap data, the cleanup occurs when
 /// the stack frame is later popped.  The function parameter indicates
 /// `true` if the job was stolen -- executed on a different thread.
-pub(super) struct StackJob<L, F, R>
+pub(super) struct StackJob<'a, L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,
     R: Send,
 {
-    pub(super) latch: L,
+    pub(super) latch: &'a mut L,
     func: UnsafeCell<Option<F>>,
     result: UnsafeCell<JobResult<R>>,
 }
 
-impl<L, F, R> StackJob<L, F, R>
+impl<'a, L, F, R> StackJob<'a, L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,
     R: Send,
 {
-    pub(super) fn new(func: F, latch: L) -> StackJob<L, F, R> {
+    pub(super) fn new(func: F, latch: &'a mut L) -> StackJob<'a, L, F, R> {
         StackJob {
             latch,
             func: UnsafeCell::new(Some(func)),
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<L, F, R> Job for StackJob<L, F, R>
+impl<'a, L, F, R> Job for StackJob<'a, L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -64,24 +64,24 @@ impl JobRef {
 /// executes it need not free any heap data, the cleanup occurs when
 /// the stack frame is later popped.  The function parameter indicates
 /// `true` if the job was stolen -- executed on a different thread.
-pub(super) struct StackJob<'a, L: 'a, F, R>
+pub(super) struct StackJob<L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,
     R: Send,
 {
-    pub(super) latch: &'a mut L,
+    pub(super) latch: L,
     func: UnsafeCell<Option<F>>,
     result: UnsafeCell<JobResult<R>>,
 }
 
-impl<'a, L, F, R> StackJob<'a, L, F, R>
+impl<L, F, R> StackJob<L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,
     R: Send,
 {
-    pub(super) fn new(func: F, latch: &'a mut L) -> StackJob<'a, L, F, R> {
+    pub(super) fn new(func: F, latch: L) -> StackJob<L, F, R> {
         StackJob {
             latch,
             func: UnsafeCell::new(Some(func)),
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<'a, L, F, R> Job for StackJob<'a, L, F, R>
+impl<L, F, R> Job for StackJob<L, F, R>
 where
     L: Latch + Sync,
     F: FnOnce(bool) -> R + Send,

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -120,12 +120,12 @@ where
             worker: worker_thread.index()
         });
 
-        let mut latch = SpinLatch::new();
+        let latch = SpinLatch::new();
 
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), &mut latch);
+        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), &latch);
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -125,7 +125,7 @@ where
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), &latch);
+        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), latch);
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 
@@ -164,7 +164,7 @@ where
                 log!(LostJob {
                     worker: worker_thread.index()
                 });
-                worker_thread.wait_until(job_b.latch);
+                worker_thread.wait_until(&job_b.latch);
                 debug_assert!(job_b.latch.probe());
                 break;
             }

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -120,13 +120,12 @@ where
             worker: worker_thread.index()
         });
 
+        let mut latch = SpinLatch::new();
+
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(
-            |migrated| oper_b(FnContext::new(migrated)),
-            SpinLatch::new(),
-        );
+        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), &mut latch);
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 
@@ -165,7 +164,7 @@ where
                 log!(LostJob {
                     worker: worker_thread.index()
                 });
-                worker_thread.wait_until(&job_b.latch);
+                worker_thread.wait_until(job_b.latch);
                 debug_assert!(job_b.latch.probe());
                 break;
             }

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -86,6 +86,11 @@ impl LockLatch {
         }
     }
 
+    /// Resets this lock latch so it can be reused again.
+    pub(super) fn reset(&mut self) {
+        *self.m.lock().unwrap() = false;
+    }
+
     /// Block until latch is set.
     pub(super) fn wait(&self) {
         let mut guard = self.m.lock().unwrap();

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -87,7 +87,7 @@ impl LockLatch {
     }
 
     /// Resets this lock latch so it can be reused again.
-    pub(super) fn reset(&mut self) {
+    pub(super) fn reset(&self) {
         *self.m.lock().unwrap() = false;
     }
 
@@ -189,5 +189,17 @@ impl<'a, L: Latch> Latch for TickleLatch<'a, L> {
     fn set(&self) {
         self.inner.set();
         self.sleep.tickle(usize::MAX);
+    }
+}
+
+impl<'a, L> LatchProbe for &'a L where L: LatchProbe {
+    fn probe(&self) -> bool {
+        unimplemented!()
+    }
+}
+
+impl<'a, L> Latch for &'a L where L: Latch {
+    fn set(&self) {
+        unimplemented!()
     }
 }

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -194,12 +194,12 @@ impl<'a, L: Latch> Latch for TickleLatch<'a, L> {
 
 impl<'a, L> LatchProbe for &'a L where L: LatchProbe {
     fn probe(&self) -> bool {
-        unimplemented!()
+        L::probe(&self)
     }
 }
 
 impl<'a, L> Latch for &'a L where L: Latch {
     fn set(&self) {
-        unimplemented!()
+        L::set(&self);
     }
 }

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -194,12 +194,12 @@ impl<'a, L: Latch> Latch for TickleLatch<'a, L> {
 
 impl<'a, L> LatchProbe for &'a L where L: LatchProbe {
     fn probe(&self) -> bool {
-        L::probe(&self)
+        L::probe(self)
     }
 }
 
 impl<'a, L> Latch for &'a L where L: Latch {
     fn set(&self) {
-        L::set(&self);
+        L::set(self);
     }
 }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -521,10 +521,10 @@ impl Registry {
                 assert!(injected && !worker_thread.is_null());
                 op(&*worker_thread, true)
             },
-            &latch,
+            latch,
         );
         self.inject(&[job.as_job_ref()]);
-        current_thread.wait_until(job.latch);
+        current_thread.wait_until(&job.latch);
         job.into_result()
     }
 


### PR DESCRIPTION
This addresses the first half of #666.

I kept the `LockLatch` and added a `reset()` method because that had overall fewer lines of code. If you want I can still change it to a separate `ReusableLockLatch` type.
