### PR TITLE
Removed remaining allocations in ThreadPool::install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *~
 TAGS
 *.bk
+.idea

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -53,6 +53,7 @@ mod private;
 mod job;
 mod join;
 mod latch;
+mod queue;
 mod registry;
 mod scope;
 mod sleep;

--- a/rayon-core/src/queue.rs
+++ b/rayon-core/src/queue.rs
@@ -4,9 +4,9 @@ use crossbeam_queue::{ArrayQueue, PopError, SegQueue};
 ///
 /// This structure is useful if you want a possibly unbounded queue, and are willing to trade
 /// strict ordering for predictable allocations up to a certain point. In particular, if you
-/// load fewer than `cap` elements, this structure will not allocate.
+/// load fewer than `cap` elements, this structure will not allocate during `push()` or `pop()`.
 ///
-/// Also, up to a load of `cap` the structure will behave like a regular, but pre-allocated queue.
+/// Also, up to a load of `cap` the structure will behave like a regular, pre-allocated queue.
 /// Beyond that, the ordering of elements might be random until the load falls below `cap` again.
 pub(super) struct AlmostQueue<T> {
     unbounded: SegQueue<T>,

--- a/rayon-core/src/queue.rs
+++ b/rayon-core/src/queue.rs
@@ -1,45 +1,49 @@
 use crossbeam_queue::{ArrayQueue, PopError, SegQueue};
 
 /// A data exchange structure that tries to be a queue and almost succeeds.
-///
-/// This structure is useful if you want a possibly unbounded queue, and are willing to trade
-/// strict ordering for predictable allocations up to a certain point. In particular, if you
-/// load fewer than `cap` elements, this structure will not allocate during `push()` or `pop()`.
-///
-/// Also, up to a load of `cap` the structure will behave like a regular, pre-allocated queue.
-/// Beyond that, the ordering of elements might be random until the load falls below `cap` again.
-pub(super) struct AlmostQueue<T> {
+pub(crate) struct AlmostQueue<T> {
     unbounded: SegQueue<T>,
     bounded: ArrayQueue<T>,
 }
 
 impl<T> AlmostQueue<T> {
-    pub(super) fn new(cap: usize) -> Self {
+    pub(crate) fn new(cap: usize) -> Self {
         Self {
             unbounded: SegQueue::new(),
             bounded: ArrayQueue::new(cap),
         }
     }
-
-    pub(super) fn push(&self, t: T) {
-        if let Err(x) = self.bounded.push(t) {
-            // At this point we know we failed to insert into the bounded queue. In the meantime
-            // (between the Err and the next line) the bounded one might have become empty again,
-            // but we insert into the unbounded one anyway.
-            self.unbounded.push(x.0)
+    
+    pub(crate) fn push(&self, t: T) {
+        // If unbounded has any elements, it always takes over receiving elements.
+        if !self.unbounded.is_empty() {
+            // Once we entered here, bounded might have become empty again, and a newer element
+            // already be on the way to the bounded queue. That newer element would move to the
+            // bounded queue, and be handled before our element we just entered.
+            self.unbounded.push(t);
+        } else {
+            // If we enter here, unbounded might have become inhabited again with a newer element.
+            // In that case we would append our older element to the bounded queue. However, that
+            // would be fine, since we always process the bounded queue first.
+            if let Err(e) = self.bounded.push(t) {
+                // In this pathological case, we wanted to have inserted our older element
+                // into bounded, but couldn't because another element was stealing our slot.
+                // In that case we flow over to unbounded again, and our order might be out of
+                // place until all the elements in between have been processed.
+                self.unbounded.push(e.0);
+            }
         }
     }
-
-    pub(super) fn pop(&self) -> Result<T, PopError> {
-        // We have to query the bounded one first, since it might contain overflow elements even if
-        // the bounded one is empty.
-        let unbounded = self.unbounded.pop();
-
-        if unbounded.is_ok() {
-            unbounded
+    
+    pub(crate) fn pop(&self) -> Result<T, PopError> {
+        // We always pop the bounded first. It is filled first when the queue is empty,
+        // and might spuriously be filled if popping happens during pushing.
+        let x = self.bounded.pop();
+        
+        if x.is_ok() {
+            x
         } else {
-            // We only return bounded elements if we are sure there are no unbounded elements left.
-            self.bounded.pop()
+            self.unbounded.pop()
         }
     }
 }

--- a/rayon-core/src/queue.rs
+++ b/rayon-core/src/queue.rs
@@ -38,7 +38,7 @@ impl<T> AlmostQueue<T> {
         if unbounded.is_ok() {
             unbounded
         } else {
-            // We only return unbounded elements if we are sure there are no unbounded elements left.
+            // We only return bounded elements if we are sure there are no unbounded elements left.
             self.bounded.pop()
         }
     }

--- a/rayon-core/src/queue.rs
+++ b/rayon-core/src/queue.rs
@@ -1,0 +1,45 @@
+use crossbeam_queue::{ArrayQueue, PopError, SegQueue};
+
+/// A data exchange structure that tries to be a queue and almost succeeds.
+///
+/// This structure is useful if you want a possibly unbounded queue, and are willing to trade
+/// strict ordering for predictable allocations up to a certain point. In particular, if you
+/// load fewer than `cap` elements, this structure will not allocate.
+///
+/// Also, up to a load of `cap` the structure will behave like a regular, but pre-allocated queue.
+/// Beyond that, the ordering of elements might be random until the load falls below `cap` again.
+pub(super) struct AlmostQueue<T> {
+    unbounded: SegQueue<T>,
+    bounded: ArrayQueue<T>,
+}
+
+impl<T> AlmostQueue<T> {
+    pub(super) fn new(cap: usize) -> Self {
+        Self {
+            unbounded: SegQueue::new(),
+            bounded: ArrayQueue::new(cap),
+        }
+    }
+
+    pub(super) fn push(&self, t: T) {
+        if let Err(x) = self.bounded.push(t) {
+            // At this point we know we failed to insert into the bounded queue. In the meantime
+            // (between the Err and the next line) the bounded one might have become empty again,
+            // but we insert into the unbounded one anyway.
+            self.unbounded.push(x.0)
+        }
+    }
+
+    pub(super) fn pop(&self) -> Result<T, PopError> {
+        // We have to query the bounded one first, since it might contain overflow elements even if
+        // the bounded one is empty.
+        let unbounded = self.unbounded.pop();
+
+        if unbounded.is_ok() {
+            unbounded
+        } else {
+            // We only return unbounded elements if we are sure there are no unbounded elements left.
+            self.bounded.pop()
+        }
+    }
+}

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,5 +1,4 @@
 use crossbeam_deque::{self as deque, Pop, Steal, Stealer, Worker};
-use crossbeam_queue::SegQueue;
 #[cfg(rayon_unstable)]
 use internal::task::Task;
 #[cfg(rayon_unstable)]
@@ -7,6 +6,7 @@ use job::Job;
 use job::{JobFifo, JobRef, StackJob};
 use latch::{CountLatch, Latch, LatchProbe, LockLatch, SpinLatch, TickleLatch};
 use log::Event::*;
+use queue::AlmostQueue;
 use sleep::Sleep;
 use std::any::Any;
 use std::cell::Cell;
@@ -136,7 +136,7 @@ where
 pub(super) struct Registry {
     thread_infos: Vec<ThreadInfo>,
     sleep: Sleep,
-    injected_jobs: SegQueue<JobRef>,
+    injected_jobs: AlmostQueue<JobRef>,
     panic_handler: Option<Box<PanicHandler>>,
     start_handler: Option<Box<StartHandler>>,
     exit_handler: Option<Box<ExitHandler>>,
@@ -235,7 +235,7 @@ impl Registry {
         let registry = Arc::new(Registry {
             thread_infos: stealers.into_iter().map(ThreadInfo::new).collect(),
             sleep: Sleep::new(),
-            injected_jobs: SegQueue::new(),
+            injected_jobs: AlmostQueue::new(n_threads),
             terminate_latch: CountLatch::new(),
             panic_handler: builder.take_panic_handler(),
             start_handler: builder.take_start_handler(),


### PR DESCRIPTION
This removes the 2nd allocation source as discussed in #666, feedback welcome.