### PR TITLE
Reduce the genericity of many closures

### DIFF
--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -109,10 +109,14 @@ where
     R: Send,
 {
     unsafe fn execute(this: *const Self) {
+        fn call<R>(func: impl FnOnce(bool) -> R) -> impl FnOnce() -> R {
+            move || func(true)
+        }
+
         let this = &*this;
         let abort = unwind::AbortIfPanic;
         let func = (*this.func.get()).take().unwrap();
-        (*this.result.get()) = match unwind::halt_unwinding(|| func(true)) {
+        (*this.result.get()) = match unwind::halt_unwinding(call(func)) {
             Ok(x) => JobResult::Ok(x),
             Err(x) => JobResult::Panic(x),
         };

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -98,7 +98,12 @@ where
     RA: Send,
     RB: Send,
 {
-    join_context(|_| oper_a(), |_| oper_b())
+    #[inline]
+    fn call<R>(f: impl FnOnce() -> R) -> impl FnOnce(FnContext) -> R {
+        move |_| f()
+    }
+
+    join_context(call(oper_a), call(oper_b))
 }
 
 /// Identical to `join`, except that the closures have a parameter
@@ -115,22 +120,30 @@ where
     RA: Send,
     RB: Send,
 {
+    #[inline]
+    fn call_a<R>(f: impl FnOnce(FnContext) -> R, injected: bool) -> impl FnOnce() -> R {
+        move || f(FnContext::new(injected))
+    }
+
+    #[inline]
+    fn call_b<R>(f: impl FnOnce(FnContext) -> R) -> impl FnOnce(bool) -> R {
+        move |migrated| f(FnContext::new(migrated))
+    }
+
     registry::in_worker(|worker_thread, injected| unsafe {
         log!(Join {
             worker: worker_thread.index()
         });
 
-        let latch = SpinLatch::new();
-
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(|migrated| oper_b(FnContext::new(migrated)), latch);
+        let job_b = StackJob::new(call_b(oper_b), SpinLatch::new());
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 
         // Execute task a; hopefully b gets stolen in the meantime.
-        let status_a = unwind::halt_unwinding(move || oper_a(FnContext::new(injected)));
+        let status_a = unwind::halt_unwinding(call_a(oper_a, injected));
         let result_a = match status_a {
             Ok(v) => v,
             Err(err) => join_recover_from_panic(worker_thread, &job_b.latch, err),

--- a/src/iter/copied.rs
+++ b/src/iter/copied.rs
@@ -102,11 +102,11 @@ where
     T: 'a + Copy,
 {
     type Item = T;
-    type IntoIter = iter::Map<P::IntoIter, fn(&T) -> T>;
+    type IntoIter = iter::Cloned<P::IntoIter>;
 
     fn into_iter(self) -> Self::IntoIter {
         // FIXME: use `Iterator::copied()` when Rust 1.36 is our minimum.
-        self.base.into_iter().map(|&x| x)
+        self.base.into_iter().cloned()
     }
 
     fn min_len(&self) -> usize {
@@ -211,7 +211,7 @@ where
         I: IntoIterator<Item = &'a T>,
     {
         // FIXME: use `Iterator::copied()` when Rust 1.36 is our minimum.
-        self.base = self.base.consume_iter(iter.into_iter().map(|&x| x));
+        self.base = self.base.consume_iter(iter.into_iter().cloned());
         self
     }
 

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -87,10 +87,14 @@ where
     where
         I: IntoIterator<Item = T>,
     {
+        fn not_full<T>(found: &AtomicBool) -> impl Fn(&T) -> bool + '_ {
+            move |_| !found.load(Ordering::Relaxed)
+        }
+
         self.item = iter
             .into_iter()
             // stop iterating if another thread has found something
-            .take_while(|_| !self.full())
+            .take_while(not_full(&self.found))
             .find(self.find_op);
         if self.item.is_some() {
             self.found.store(true, Ordering::Relaxed)

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -35,6 +35,10 @@ where
     where
         C: UnindexedConsumer<Self::Item>,
     {
-        self.base.flat_map(|x| x).drive_unindexed(consumer)
+        fn id<T>(x: T) -> T {
+            x
+        }
+
+        self.base.flat_map(id).drive_unindexed(consumer)
     }
 }

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -147,11 +147,18 @@ where
     where
         I: IntoIterator<Item = T>,
     {
+        fn not_full<C, ID, T>(base: &C) -> impl Fn(&T) -> bool + '_
+        where
+            C: Folder<ID>,
+        {
+            move |_| !base.full()
+        }
+
         let base = self.base;
         let item = iter
             .into_iter()
             // stop iterating if another thread has finished
-            .take_while(|_| !base.full())
+            .take_while(not_full(&base))
             .fold(self.item, self.fold_op);
 
         FoldFolder {

--- a/src/iter/for_each.rs
+++ b/src/iter/for_each.rs
@@ -52,7 +52,7 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        iter.into_iter().fold((), |_, item| (self.op)(item));
+        iter.into_iter().for_each(self.op);
         self
     }
 

--- a/src/iter/from_par_iter.rs
+++ b/src/iter/from_par_iter.rs
@@ -1,3 +1,4 @@
+use super::noop::NoopConsumer;
 use super::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
 
 use std::borrow::Cow;
@@ -222,6 +223,6 @@ impl FromParallelIterator<()> for () {
     where
         I: IntoParallelIterator<Item = ()>,
     {
-        par_iter.into_par_iter().for_each(|()| {})
+        par_iter.into_par_iter().drive_unindexed(NoopConsumer)
     }
 }

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -205,10 +205,13 @@ where
     /// should yield the next element, otherwise, if `j` should yield
     /// the next element, set a = index/2 and b = (index/2)+1
     fn split_at(self, index: usize) -> (Self, Self) {
+        #[inline]
+        fn odd_offset(flag: bool) -> usize {
+            (!flag) as usize
+        }
+
         let even = index % 2 == 0;
         let idx = index >> 1;
-
-        let odd_offset = |flag| if flag { 0 } else { 1 };
 
         // desired split
         let (i_idx, j_idx) = (

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -310,10 +310,15 @@ where
     where
         I: IntoIterator<Item = T>,
     {
+        fn with<'f, T, U, R>(
+            item: &'f mut U,
+            map_op: impl Fn(&mut U, T) -> R + 'f,
+        ) -> impl FnMut(T) -> R + 'f {
+            move |x| map_op(item, x)
+        }
+
         {
-            let map_op = self.map_op;
-            let item = &mut self.item;
-            let mapped_iter = iter.into_iter().map(|x| map_op(item, x));
+            let mapped_iter = iter.into_iter().map(with(&mut self.item, self.map_op));
             self.base = self.base.consume_iter(mapped_iter);
         }
         self

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -2,12 +2,6 @@ use super::plumbing::*;
 
 pub(super) struct NoopConsumer;
 
-impl NoopConsumer {
-    pub(super) fn new() -> Self {
-        NoopConsumer
-    }
-}
-
 impl<T> Consumer<T> for NoopConsumer {
     type Folder = NoopConsumer;
     type Reducer = NoopReducer;
@@ -37,7 +31,7 @@ impl<T> Folder<T> for NoopConsumer {
     where
         I: IntoIterator<Item = T>,
     {
-        iter.into_iter().fold((), |_, _| ());
+        iter.into_iter().for_each(drop);
         self
     }
 

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -306,9 +306,13 @@ where
     where
         I: IntoIterator<Item = T>,
     {
+        fn cool<'a, T>(fuse: &'a Fuse) -> impl Fn(&T) -> bool + 'a {
+            move |_| !fuse.panicked()
+        }
+
         self.base = {
             let fuse = &self.fuse;
-            let iter = iter.into_iter().take_while(move |_| !fuse.panicked());
+            let iter = iter.into_iter().take_while(cool(fuse));
             self.base.consume_iter(iter)
         };
         self

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -80,7 +80,7 @@ where
                 P: Producer<Item = T>,
             {
                 let (before_skip, after_skip) = base.split_at(self.n);
-                bridge_producer_consumer(self.n, before_skip, NoopConsumer::new());
+                bridge_producer_consumer(self.n, before_skip, NoopConsumer);
                 self.callback.callback(after_skip)
             }
         }

--- a/src/iter/try_fold.rs
+++ b/src/iter/try_fold.rs
@@ -141,10 +141,12 @@ where
 {
     type Result = C::Result;
 
-    fn consume(self, item: T) -> Self {
+    fn consume(mut self, item: T) -> Self {
         let fold_op = self.fold_op;
-        let result = self.result.and_then(|acc| fold_op(acc, item).into_result());
-        TryFoldFolder { result, ..self }
+        if let Ok(acc) = self.result {
+            self.result = fold_op(acc, item).into_result();
+        }
+        self
     }
 
     fn complete(self) -> C::Result {

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -223,6 +223,13 @@ struct UpdateFolder<'f, C, F: 'f> {
     update_op: &'f F,
 }
 
+fn apply<T>(update_op: impl Fn(&mut T)) -> impl Fn(T) -> T {
+    move |mut item| {
+        update_op(&mut item);
+        item
+    }
+}
+
 impl<'f, T, C, F> Folder<T> for UpdateFolder<'f, C, F>
 where
     C: Folder<T>,
@@ -244,10 +251,9 @@ where
         I: IntoIterator<Item = T>,
     {
         let update_op = self.update_op;
-        self.base = self.base.consume_iter(iter.into_iter().map(|mut item| {
-            update_op(&mut item);
-            item
-        }));
+        self.base = self
+            .base
+            .consume_iter(iter.into_iter().map(apply(update_op)));
         self
     }
 
@@ -271,7 +277,7 @@ struct UpdateSeq<I, F> {
 impl<I, F> Iterator for UpdateSeq<I, F>
 where
     I: Iterator,
-    F: FnMut(&mut I::Item),
+    F: Fn(&mut I::Item),
 {
     type Item = I::Item;
 
@@ -285,15 +291,11 @@ where
         self.base.size_hint()
     }
 
-    fn fold<Acc, G>(self, init: Acc, mut g: G) -> Acc
+    fn fold<Acc, G>(self, init: Acc, g: G) -> Acc
     where
         G: FnMut(Acc, Self::Item) -> Acc,
     {
-        let mut f = self.update_op;
-        self.base.fold(init, move |acc, mut v| {
-            f(&mut v);
-            g(acc, v)
-        })
+        self.base.map(apply(self.update_op)).fold(init, g)
     }
 
     // if possible, re-use inner iterator specializations in collect
@@ -301,27 +303,21 @@ where
     where
         C: ::std::iter::FromIterator<Self::Item>,
     {
-        let mut f = self.update_op;
-        self.base
-            .map(move |mut v| {
-                f(&mut v);
-                v
-            })
-            .collect()
+        self.base.map(apply(self.update_op)).collect()
     }
 }
 
 impl<I, F> ExactSizeIterator for UpdateSeq<I, F>
 where
     I: ExactSizeIterator,
-    F: FnMut(&mut I::Item),
+    F: Fn(&mut I::Item),
 {
 }
 
 impl<I, F> DoubleEndedIterator for UpdateSeq<I, F>
 where
     I: DoubleEndedIterator,
-    F: FnMut(&mut I::Item),
+    F: Fn(&mut I::Item),
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let mut v = self.base.next_back()?;

--- a/src/option.rs
+++ b/src/option.rs
@@ -180,14 +180,18 @@ where
     where
         I: IntoParallelIterator<Item = Option<T>>,
     {
-        let found_none = AtomicBool::new(false);
-        let collection = par_iter
-            .into_par_iter()
-            .inspect(|item| {
+        fn check<T>(found_none: &AtomicBool) -> impl Fn(&Option<T>) + '_ {
+            move |item| {
                 if item.is_none() {
                     found_none.store(true, Ordering::Relaxed);
                 }
-            })
+            }
+        }
+
+        let found_none = AtomicBool::new(false);
+        let collection = par_iter
+            .into_par_iter()
+            .inspect(check(&found_none))
             .while_some()
             .collect();
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -156,11 +156,16 @@ macro_rules! unindexed_range_impl {
             where
                 C: UnindexedConsumer<Self::Item>,
             {
+                #[inline]
+                fn offset(start: $t) -> impl Fn(usize) -> $t {
+                    move |i| start.wrapping_add(i as $t)
+                }
+
                 if let Some(len) = self.opt_len() {
                     // Drive this in indexed mode for better `collect`.
                     (0..len)
                         .into_par_iter()
-                        .map(|i| self.range.start.wrapping_add(i as $t))
+                        .map(offset(self.range.start))
                         .drive(consumer)
                 } else {
                     bridge_unindexed(IterProducer { range: self.range }, consumer)

--- a/src/result.rs
+++ b/src/result.rs
@@ -100,23 +100,27 @@ where
     where
         I: IntoParallelIterator<Item = Result<T, E>>,
     {
-        let saved_error = Mutex::new(None);
-        let collection = par_iter
-            .into_par_iter()
-            .map(|item| match item {
+        fn ok<T, E>(saved: &Mutex<Option<E>>) -> impl Fn(Result<T, E>) -> Option<T> + '_ {
+            move |item| match item {
                 Ok(item) => Some(item),
                 Err(error) => {
                     // We don't need a blocking `lock()`, as anybody
                     // else holding the lock will also be writing
                     // `Some(error)`, and then ours is irrelevant.
-                    if let Ok(mut guard) = saved_error.try_lock() {
+                    if let Ok(mut guard) = saved.try_lock() {
                         if guard.is_none() {
                             *guard = Some(error);
                         }
                     }
                     None
                 }
-            })
+            }
+        }
+
+        let saved_error = Mutex::new(None);
+        let collection = par_iter
+            .into_par_iter()
+            .map(ok(&saved_error))
             .while_some()
             .collect();
 

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -186,7 +186,7 @@ pub trait ParallelSliceMut<T: Send> {
     where
         T: Ord,
     {
-        par_mergesort(self.as_parallel_slice_mut(), |a, b| a.lt(b));
+        par_mergesort(self.as_parallel_slice_mut(), T::lt);
     }
 
     /// Sorts the slice in parallel with a comparator function.
@@ -310,7 +310,7 @@ pub trait ParallelSliceMut<T: Send> {
     where
         T: Ord,
     {
-        par_quicksort(self.as_parallel_slice_mut(), |a, b| a.lt(b));
+        par_quicksort(self.as_parallel_slice_mut(), T::lt);
     }
 
     /// Sorts the slice in parallel with a comparator function, but may not preserve the order of

--- a/src/split_producer.rs
+++ b/src/split_producer.rs
@@ -84,11 +84,10 @@ where
     fn split(self) -> (Self, Option<Self>) {
         // Look forward for the separator, and failing that look backward.
         let mid = self.data.midpoint(self.tail);
-        let index = self
-            .data
-            .find(self.separator, mid, self.tail)
-            .map(|i| mid + i)
-            .or_else(|| self.data.rfind(self.separator, mid));
+        let index = match self.data.find(self.separator, mid, self.tail) {
+            Some(i) => Some(mid + i),
+            None => self.data.rfind(self.separator, mid),
+        };
 
         if let Some(index) = index {
             let len = self.data.length();

--- a/tests/issue671-unzip.rs
+++ b/tests/issue671-unzip.rs
@@ -1,0 +1,19 @@
+#![type_length_limit = "10000"]
+
+extern crate rayon;
+
+use rayon::prelude::*;
+
+#[test]
+fn type_length_limit() {
+    let input = vec![1, 2, 3, 4, 5];
+    let (indexes, (squares, cubes)): (Vec<_>, (Vec<_>, Vec<_>)) = input
+        .par_iter()
+        .map(|x| (x * x, x * x * x))
+        .enumerate()
+        .unzip();
+
+    drop(indexes);
+    drop(squares);
+    drop(cubes);
+}

--- a/tests/issue671.rs
+++ b/tests/issue671.rs
@@ -1,3 +1,5 @@
+#![type_length_limit = "500000"]
+
 extern crate rayon;
 
 use rayon::prelude::*;

--- a/tests/issue671.rs
+++ b/tests/issue671.rs
@@ -1,0 +1,16 @@
+extern crate rayon;
+
+use rayon::prelude::*;
+
+#[test]
+fn type_length_limit() {
+    let _ = Vec::<Result<(), ()>>::new()
+        .into_par_iter()
+        .map(|x| x)
+        .map(|x| x)
+        .map(|x| x)
+        .map(|x| x)
+        .map(|x| x)
+        .map(|x| x)
+        .collect::<Result<(), ()>>();
+}


### PR DESCRIPTION
The `take_while` closure only needs to be generic in `T`, along with a
captured `&AtomicBool`. When we write the closure directly, it carries
all the type baggage of `WhileSomeFolder<'f, C>::consumer_iter<I>`,
where the monomorphized type may explode. Instead, we can move this
closure to a standalone function for reduced genericity.