### PR TITLE
Update crossbeam-deque to 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
   fast_finish: true
   include:
     # NB: To help with CI delays, each `pull_request` is only tested on Linux,
-    # with 1.26 for compatibility and stable+rayon_unstable for broad test
+    # with 1.28 for compatibility and stable+rayon_unstable for broad test
     # coverage.  The bors bot counts as a `push` type, which will run it all.
 
-    - rust: 1.26.0
+    - rust: 1.28.0
       os: linux
       #if: everything!
       script: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rayon"
 # Reminder to update html_rool_url in lib.rs when updating version
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Simple work-stealing parallelism for Rust"
@@ -18,7 +18,7 @@ members = ["rayon-demo", "rayon-core", "rayon-futures"]
 exclude = ["ci"]
 
 [dependencies]
-rayon-core = { version = "1.5.0", path = "rayon-core" }
+rayon-core = { version = "1.6.0", path = "rayon-core" }
 crossbeam-deque = "0.7"
 
 # This is a public dependency!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.5.0", path = "rayon-core" }
-crossbeam-deque = "0.6.3"
+crossbeam-deque = "0.7"
 
 # This is a public dependency!
 [dependencies.either]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ just add:
 use rayon::prelude::*;
 ```
 
-Rayon currently requires `rustc 1.26.0` or greater.
+Rayon currently requires `rustc 1.28.0` or greater.
 
 ## Contribution
 

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["concurrency"]
 [dependencies]
 num_cpus = "1.2"
 lazy_static = "1"
-crossbeam-deque = "0.6.3"
+crossbeam-deque = "0.7"
 crossbeam-queue = "0.1.2"
 crossbeam-utils = "0.6.5"
 

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-core"
-version = "1.5.0" # reminder to update html_root_url attribute
+version = "1.6.0" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon"

--- a/rayon-core/README.md
+++ b/rayon-core/README.md
@@ -8,4 +8,4 @@ Please see [Rayon Docs] for details about using Rayon.
 
 [Rayon Docs]: https://docs.rs/rayon/
 
-Rayon-core currently requires `rustc 1.26.0` or greater.
+Rayon-core currently requires `rustc 1.28.0` or greater.

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -19,7 +19,7 @@
 //! conflicting requirements will need to be resolved before the build will
 //! succeed.
 
-#![doc(html_root_url = "https://docs.rs/rayon-core/1.5")]
+#![doc(html_root_url = "https://docs.rs/rayon-core/1.6")]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unreachable_pub)]

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,4 +1,4 @@
-use crossbeam_deque::{self as deque, Steal, Stealer, Worker};
+use crossbeam_deque::{Steal, Stealer, Worker};
 use crossbeam_queue::SegQueue;
 #[cfg(rayon_unstable)]
 use internal::task::Task;
@@ -225,9 +225,9 @@ impl Registry {
         let (workers, stealers): (Vec<_>, Vec<_>) = (0..n_threads)
             .map(|_| {
                 let worker = if breadth_first {
-                    deque::Worker::new_fifo()
+                    Worker::new_fifo()
                 } else {
-                    deque::Worker::new_lifo()
+                    Worker::new_lifo()
                 };
 
                 let stealer = worker.stealer();

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,4 +1,4 @@
-use crossbeam_deque::{self as deque, Pop, Steal, Stealer, Worker};
+use crossbeam_deque::{self as deque, Steal, Stealer, Worker};
 use crossbeam_queue::SegQueue;
 #[cfg(rayon_unstable)]
 use internal::task::Task;
@@ -224,11 +224,14 @@ impl Registry {
 
         let (workers, stealers): (Vec<_>, Vec<_>) = (0..n_threads)
             .map(|_| {
-                if breadth_first {
-                    deque::fifo()
+                let worker = if breadth_first {
+                    deque::Worker::new_fifo()
                 } else {
-                    deque::lifo()
-                }
+                    deque::Worker::new_lifo()
+                };
+
+                let stealer = worker.stealer();
+                (worker, stealer)
             })
             .unzip();
 
@@ -674,13 +677,7 @@ impl WorkerThread {
     /// bottom.
     #[inline]
     pub(super) unsafe fn take_local_job(&self) -> Option<JobRef> {
-        loop {
-            match self.worker.pop() {
-                Pop::Empty => return None,
-                Pop::Data(d) => return Some(d),
-                Pop::Retry => {}
-            }
-        }
+        self.worker.pop()
     }
 
     /// Wait until the latch is set. Try to keep busy by popping and
@@ -763,7 +760,7 @@ impl WorkerThread {
                 loop {
                     match victim.stealer.steal() {
                         Steal::Empty => return None,
-                        Steal::Data(d) => {
+                        Steal::Success(d) => {
                             log!(StoleWork {
                                 worker: self.index,
                                 victim: victim_index

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,4 +1,4 @@
-use crossbeam_deque::{self as deque, Steal, Stealer, Worker};
+use crossbeam_deque::{Steal, Stealer, Worker};
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, TryLockError};
@@ -79,7 +79,7 @@ where
         C: UnindexedConsumer<Self::Item>,
     {
         let split_count = AtomicUsize::new(current_num_threads());
-        let worker = deque::Worker::new_fifo();
+        let worker = Worker::new_fifo();
         let stealer = worker.stealer();
         let done = AtomicBool::new(false);
         let iter = Mutex::new((self.iter, worker));

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -79,7 +79,8 @@ where
         C: UnindexedConsumer<Self::Item>,
     {
         let split_count = AtomicUsize::new(current_num_threads());
-        let (worker, stealer) = deque::fifo();
+        let worker = deque::Worker::new_fifo();
+        let stealer = worker.stealer();
         let done = AtomicBool::new(false);
         let iter = Mutex::new((self.iter, worker));
 
@@ -149,7 +150,7 @@ where
     {
         loop {
             match self.items.steal() {
-                Steal::Data(it) => {
+                Steal::Success(it) => {
                     folder = folder.consume(it);
                     if folder.full() {
                         return folder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/rayon/1.1")]
+#![doc(html_root_url = "https://docs.rs/rayon/1.2")]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unreachable_pub)]


### PR DESCRIPTION
The only substantive change is to 'take_local_job'.
'Worker::pop` now returns a plain 'Option<T>', so there's
no need to loop anymore