### PR TITLE
refactoring: have latches tickle registries directly

### DIFF
--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -138,7 +138,7 @@ where
         // Create virtual wrapper for task b; this all has to be
         // done here so that the stack frame can keep it all live
         // long enough.
-        let job_b = StackJob::new(call_b(oper_b), SpinLatch::new());
+        let job_b = StackJob::new(call_b(oper_b), SpinLatch::new(worker_thread.registry()));
         let job_b_ref = job_b.as_job_ref();
         worker_thread.push(job_b_ref);
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -559,8 +559,7 @@ impl Registry {
     /// dropped. The worker threads will gradually terminate, once any
     /// extant work is completed.
     pub(super) fn terminate(&self) {
-        self.terminate_latch.set();
-        self.sleep.tickle(usize::MAX);
+        self.terminate_latch.set_and_tickle(self);
     }
 
     /// Invoked by a latch associated with this registry when it is set.

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -737,12 +737,6 @@ impl WorkerThread {
 
     pub(super) unsafe fn execute(&self, job: JobRef) {
         job.execute();
-
-        // Subtle: executing this job will have `set()` some of its
-        // latches.  This may mean that a sleepy (or sleeping) worker
-        // can now make progress. So we have to tickle them to let
-        // them know.
-        self.registry.sleep.tickle(self.index);
     }
 
     /// Try to steal a single job and return it.

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -5,7 +5,7 @@
 //! [`join()`]: ../join/join.fn.html
 
 use job::{HeapJob, JobFifo};
-use latch::{CountLatch, Latch};
+use latch::{CountLatch};
 use log::Event::*;
 use registry::{in_worker, Registry, WorkerThread};
 use std::any::Any;
@@ -591,14 +591,14 @@ impl<'scope> ScopeBase<'scope> {
             });
         }
 
-        self.job_completed_latch.set();
+        self.job_completed_latch.set_and_tickle(&self.registry);
     }
 
     unsafe fn job_completed_ok(&self) {
         log!(JobCompletedOk {
             owner_thread: self.owner_thread_index
         });
-        self.job_completed_latch.set();
+        self.job_completed_latch.set_and_tickle(&self.registry);
     }
 
     unsafe fn steal_till_jobs_complete(&self, owner_thread: &WorkerThread) {


### PR DESCRIPTION
As a start to improving our sleep system, this PR does a refactoring to how tickle works. We used to tickle the registry after each job executed: the idea was that executing a job would set some latch, and we needed to wake up any threads that might be blocked, waiting on that latch. However, this was a bit overapproximated: for example, the latch might've been a `LockLatch`, which indicates a thread from outside the pool, in which case there is no need to tickle threads at all. 

In this PR, the latches themselves track the registry that they must tickle when they are set. In the case of a `Countdown` latch, they are given it from the outside; this is because countdown latches are sometimes owned by the registry itself, so it would be impossible for them to have a reference to the registry.

I'd like to work towards a scenario where we know not only the *registry* that must be awoken but the exact helper thread. This could avoid needless wakeups. But this refactoring is as far as I got for now.