### PR TITLE
increase version of num_cpus to support RustHermit

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["concurrency"]
 
 # Some dependencies may not be their latest version, in order to support older rustc.
 [dependencies]
-num_cpus = "1.2"
+num_cpus = "1.11"
 lazy_static = "1"
 crossbeam-deque = "0.7"
 crossbeam-queue = "0.1.2"


### PR DESCRIPTION
We are developing the unikernel RustyHermit ([https://github.com/hermitcore/libhermit-rs](https://github.com/hermitcore/libhermit-rs)), where the kernel is written in Rust and is already part of the Rust Standard Library. With this pull request, we want to increate the version number of num_cpus, which already supports RustyHermit. 