### PR TITLE
Update crossbeam to avoid multi version dependency

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -18,8 +18,8 @@ categories = ["concurrency"]
 num_cpus = "1.2"
 lazy_static = "1"
 crossbeam-deque = "0.7"
-crossbeam-queue = "0.1.2"
-crossbeam-utils = "0.6.5"
+crossbeam-queue = "0.2"
+crossbeam-utils = "0.7"
 
 [dev-dependencies]
 rand = "0.6"


### PR DESCRIPTION
Just did a `cargo update` on my project today morning and noticed that with the release of **crossbeam-epoch 0.8.0**, rayon starts to depend on 2 versions of **crossbeam-utils**.

Before:
```
 rayon-core v1.6.0
 ├── crossbeam-deque v0.7.2
 │   ├── crossbeam-epoch v0.8.0
 │   │   └── crossbeam-utils v0.7.0 <-- latest
 │   └── crossbeam-utils v0.7.0     <-- latest
 ├── crossbeam-queue v0.1.2
 │   └── crossbeam-utils v0.6.6     <-- outdated
 └── crossbeam-utils v0.6.6         <-- outdated
```

Here Rust will compile 2 versions of the same dependency.

After:
```
rayon-core v1.6.0
├── crossbeam-deque v0.7.2
│   ├── crossbeam-epoch v0.8.0
│   │   └── crossbeam-utils v0.7.0 <-- latest
│   └── crossbeam-utils v0.7.0     <-- latest
├── crossbeam-queue v0.2.0
│   └── crossbeam-utils v0.7.0     <-- latest
└── crossbeam-utils v0.7.0         <-- latest
```

Here all references are up to date and Rust will only compile one version of `crossbeam-utils`.