### PR TITLE
Reduce Windows CI to just stable Rust

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,35 +7,10 @@ environment:
       CHANNEL: stable
       RUSTFLAGS: --cfg rayon_unstable
 
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: beta
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: beta
-      RUSTFLAGS: --cfg rayon_unstable
-
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: nightly
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: nightly
-      RUSTFLAGS: --cfg rayon_unstable
-
-
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
-      RUSTFLAGS: --cfg rayon_unstable
-
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: beta
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: beta
-      RUSTFLAGS: --cfg rayon_unstable
-
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: nightly
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: nightly
       RUSTFLAGS: --cfg rayon_unstable
 
 install:


### PR DESCRIPTION
CI for #711 ran into a broken beta windows-gnu toolchain, which is frustrating, but in general I already feel that it's overkill to test so much on Windows. The Linux builds on Travis CI already test a breadth of compiler versions, and it does so in parallel, whereas Appveyor runs serially. We can just test Windows stable to be sure the platform works at all, and leave it at that.