### PR TITLE
Change wording, less "High level for low level"

### DIFF
--- a/src/iter/plumbing/mod.rs
+++ b/src/iter/plumbing/mod.rs
@@ -1,6 +1,6 @@
 //! Traits and functions used to implement parallel iteration.  These are
 //! low-level details -- users of parallel iterators should not need to
-//! interact with them directly.  See [the `plumbing` README][r] for a high-level overview.
+//! interact with them directly.  See [the `plumbing` README][r] for a general overview.
 //!
 //! [r]: https://github.com/rayon-rs/rayon/blob/master/src/iter/plumbing/README.md
 


### PR DESCRIPTION
This patch changes the wording of the documentation, because right now it is "There's a highlevel overview over the low level stuff", which is ridiculous.

Rather use "general overview" for less funny wording.