### PR TITLE
Align doc comments to use indicative mood for functions

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -196,7 +196,7 @@ impl<S> ThreadPoolBuilder<S>
 where
     S: ThreadSpawn,
 {
-    /// Create a new `ThreadPool` initialized using this configuration.
+    /// Creates a new `ThreadPool` initialized using this configuration.
     pub fn build(self) -> Result<ThreadPool, ThreadPoolBuildError> {
         ThreadPool::build(self)
     }
@@ -226,7 +226,7 @@ where
 }
 
 impl ThreadPoolBuilder {
-    /// Create a scoped `ThreadPool` initialized using this configuration.
+    /// Creates a scoped `ThreadPool` initialized using this configuration.
     ///
     /// This is a convenience function for building a pool using [`crossbeam::scope`]
     /// to spawn threads in a [`spawn_handler`](#method.spawn_handler).
@@ -294,7 +294,7 @@ impl ThreadPoolBuilder {
 }
 
 impl<S> ThreadPoolBuilder<S> {
-    /// Set a custom function for spawning threads.
+    /// Sets a custom function for spawning threads.
     ///
     /// Note that the threads will not exit until after the pool is dropped. It
     /// is up to the caller to wait for thread termination if that is important
@@ -402,7 +402,7 @@ impl<S> ThreadPoolBuilder<S> {
         Some(f(index))
     }
 
-    /// Set a closure which takes a thread index and returns
+    /// Sets a closure which takes a thread index and returns
     /// the thread's name.
     pub fn thread_name<F>(mut self, closure: F) -> Self
     where
@@ -412,7 +412,7 @@ impl<S> ThreadPoolBuilder<S> {
         self
     }
 
-    /// Set the number of threads to be used in the rayon threadpool.
+    /// Sets the number of threads to be used in the rayon threadpool.
     ///
     /// If you specify a non-zero number of threads using this
     /// function, then the resulting thread-pools are guaranteed to
@@ -475,7 +475,7 @@ impl<S> ThreadPoolBuilder<S> {
         self.stack_size
     }
 
-    /// Set the stack size of the worker threads
+    /// Sets the stack size of the worker threads
     pub fn stack_size(mut self, stack_size: usize) -> Self {
         self.stack_size = Some(stack_size);
         self
@@ -524,7 +524,7 @@ impl<S> ThreadPoolBuilder<S> {
         self.start_handler.take()
     }
 
-    /// Set a callback to be invoked on thread start.
+    /// Sets a callback to be invoked on thread start.
     ///
     /// The closure is passed the index of the thread on which it is invoked.
     /// Note that this same closure may be invoked multiple times in parallel.
@@ -543,7 +543,7 @@ impl<S> ThreadPoolBuilder<S> {
         self.exit_handler.take()
     }
 
-    /// Set a callback to be invoked on thread exit.
+    /// Sets a callback to be invoked on thread exit.
     ///
     /// The closure is passed the index of the thread on which it is invoked.
     /// Note that this same closure may be invoked multiple times in parallel.

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -35,22 +35,22 @@ pub struct ThreadBuilder {
 }
 
 impl ThreadBuilder {
-    /// Get the index of this thread in the pool, within `0..num_threads`.
+    /// Gets the index of this thread in the pool, within `0..num_threads`.
     pub fn index(&self) -> usize {
         self.index
     }
 
-    /// Get the string that was specified by `ThreadPoolBuilder::name()`.
+    /// Gets the string that was specified by `ThreadPoolBuilder::name()`.
     pub fn name(&self) -> Option<&str> {
         self.name.as_ref().map(String::as_str)
     }
 
-    /// Get the value that was specified by `ThreadPoolBuilder::stack_size()`.
+    /// Gets the value that was specified by `ThreadPoolBuilder::stack_size()`.
     pub fn stack_size(&self) -> Option<usize> {
         self.stack_size
     }
 
-    /// Execute the main loop for this thread. This will not return until the
+    /// Executes the main loop for this thread. This will not return until the
     /// thread pool is dropped.
     pub fn run(self) {
         unsafe { main_loop(self.worker, self.registry, self.index) }
@@ -477,7 +477,7 @@ impl Registry {
         job.into_result()
     }
 
-    /// Increment the terminate counter. This increment should be
+    /// Increments the terminate counter. This increment should be
     /// balanced by a call to `terminate`, which will decrement. This
     /// is used when spawning asynchronous work, which needs to
     /// prevent the registry from terminating so long as it is active.

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -61,7 +61,7 @@ struct ScopeBase<'scope> {
     marker: PhantomData<Box<dyn FnOnce(&Scope<'scope>) + Send + Sync + 'scope>>,
 }
 
-/// Create a "fork-join" scope `s` and invokes the closure with a
+/// Creates a "fork-join" scope `s` and invokes the closure with a
 /// reference to `s`. This closure can then spawn asynchronous tasks
 /// into `s`. Those tasks may run asynchronously with respect to the
 /// closure; they may themselves spawn additional tasks into `s`. When
@@ -295,7 +295,7 @@ where
     })
 }
 
-/// Create a "fork-join" scope `s` with FIFO order, and invokes the
+/// Creates a "fork-join" scope `s` with FIFO order, and invokes the
 /// closure with a reference to `s`. This closure can then spawn
 /// asynchronous tasks into `s`. Those tasks may run asynchronously with
 /// respect to the closure; they may themselves spawn additional tasks
@@ -511,7 +511,7 @@ impl<'scope> ScopeFifo<'scope> {
 }
 
 impl<'scope> ScopeBase<'scope> {
-    /// Create the base of a new scope for the given worker thread
+    /// Creates the base of a new scope for the given worker thread
     fn new(owner_thread: &WorkerThread) -> Self {
         ScopeBase {
             owner_thread_index: owner_thread.index(),

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -66,7 +66,7 @@ where
     unsafe { spawn_in(func, &Registry::current()) }
 }
 
-/// Spawn an asynchronous job in `registry.`
+/// Spawns an asynchronous job in `registry.`
 ///
 /// Unsafe because `registry` must not yet have terminated.
 pub(super) unsafe fn spawn_in<F>(func: F, registry: &Arc<Registry>)
@@ -141,7 +141,7 @@ where
     unsafe { spawn_fifo_in(func, &Registry::current()) }
 }
 
-/// Spawn an asynchronous FIFO job in `registry.`
+/// Spawns an asynchronous FIFO job in `registry.`
 ///
 /// Unsafe because `registry` must not yet have terminated.
 pub(super) unsafe fn spawn_fifo_in<F>(func: F, registry: &Arc<Registry>)

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -67,7 +67,7 @@ fn sleeper_stop() {
     registry.wait_until_stopped();
 }
 
-/// Create a start/exit handler that increments an atomic counter.
+/// Creates a start/exit handler that increments an atomic counter.
 fn count_handler() -> (Arc<AtomicUsize>, impl Fn(usize)) {
     let count = Arc::new(AtomicUsize::new(0));
     (count.clone(), move |_| {

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -3,7 +3,7 @@
 // Note: these place `impl` bounds at the end, as token gobbling is the only way
 // I know how to consume an arbitrary list of constraints, with `$($args:tt)*`.
 
-/// Create a parallel iterator implementation which simply wraps an inner type
+/// Creates a parallel iterator implementation which simply wraps an inner type
 /// and delegates all methods inward.  The actual struct must already be
 /// declared with an `inner` field.
 ///
@@ -37,7 +37,7 @@ macro_rules! delegate_iterator {
     }
 }
 
-/// Create an indexed parallel iterator implementation which simply wraps an
+/// Creates an indexed parallel iterator implementation which simply wraps an
 /// inner type and delegates all methods inward.  The actual struct must already
 /// be declared with an `inner` field.
 macro_rules! delegate_indexed_iterator {

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -25,7 +25,7 @@ where
     A: ParallelIterator,
     B: ParallelIterator<Item = A::Item>,
 {
-    /// Create a new `Chain` iterator.
+    /// Creates a new `Chain` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         Chain { a, b }
     }

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -24,7 +24,7 @@ impl<I> Chunks<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `Chunks` iterator
+    /// Creates a new `Chunks` iterator
     pub(super) fn new(i: I, size: usize) -> Self {
         Chunks { i, size }
     }

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -19,7 +19,7 @@ impl<I> Cloned<I>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Cloned` iterator.
+    /// Creates a new `Cloned` iterator.
     pub(super) fn new(base: I) -> Self {
         Cloned { base }
     }

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -82,7 +82,7 @@ impl<'c, T: Send + 'c> Collect<'c, T> {
         }
     }
 
-    /// Create a consumer on a slice of our memory.
+    /// Creates a consumer on a slice of our memory.
     fn as_consumer(&mut self) -> CollectConsumer<'_, T> {
         // Reserve the new space.
         self.vec.reserve(self.len);
@@ -94,7 +94,7 @@ impl<'c, T: Send + 'c> Collect<'c, T> {
         CollectConsumer::new(&self.writes, slice)
     }
 
-    /// Update the final vector length.
+    /// Updates the final vector length.
     fn complete(self) {
         unsafe {
             // Here, we assert that `v` is fully initialized. This is
@@ -117,7 +117,7 @@ impl<'c, T: Send + 'c> Collect<'c, T> {
     }
 }
 
-/// Extend a vector with items from a parallel iterator.
+/// Extends a vector with items from a parallel iterator.
 impl<T> ParallelExtend<T> for Vec<T>
 where
     T: Send,

--- a/src/iter/copied.rs
+++ b/src/iter/copied.rs
@@ -19,7 +19,7 @@ impl<I> Copied<I>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Copied` iterator.
+    /// Creates a new `Copied` iterator.
     pub(super) fn new(base: I) -> Self {
         Copied { base }
     }

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -19,7 +19,7 @@ impl<I> Enumerate<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `Enumerate` iterator.
+    /// Creates a new `Enumerate` iterator.
     pub(super) fn new(base: I) -> Self {
         Enumerate { base }
     }

--- a/src/iter/extend.rs
+++ b/src/iter/extend.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
 use std::hash::{BuildHasher, Hash};
 
-/// Perform a generic `par_extend` by collecting to a `LinkedList<Vec<_>>` in
+/// Performs a generic `par_extend` by collecting to a `LinkedList<Vec<_>>` in
 /// parallel, then extending the collection sequentially.
 fn extend<C, I, F>(collection: &mut C, par_iter: I, reserve: F)
 where
@@ -49,7 +49,7 @@ fn list_append<T>(mut list1: LinkedList<T>, mut list2: LinkedList<T>) -> LinkedL
     list1
 }
 
-/// Compute the total length of a `LinkedList<Vec<_>>`.
+/// Computes the total length of a `LinkedList<Vec<_>>`.
 pub(super) fn len<T>(list: &LinkedList<Vec<T>>) -> usize {
     list.iter().map(Vec::len).sum()
 }
@@ -60,7 +60,7 @@ fn heap_reserve<T: Ord, U>(heap: &mut BinaryHeap<T>, list: &LinkedList<Vec<U>>) 
     heap.reserve(len(list));
 }
 
-/// Extend a binary heap with items from a parallel iterator.
+/// Extends a binary heap with items from a parallel iterator.
 impl<T> ParallelExtend<T> for BinaryHeap<T>
 where
     T: Ord + Send,
@@ -73,7 +73,7 @@ where
     }
 }
 
-/// Extend a binary heap with copied items from a parallel iterator.
+/// Extends a binary heap with copied items from a parallel iterator.
 impl<'a, T> ParallelExtend<&'a T> for BinaryHeap<T>
 where
     T: 'a + Copy + Ord + Send + Sync,
@@ -86,7 +86,7 @@ where
     }
 }
 
-/// Extend a B-tree map with items from a parallel iterator.
+/// Extends a B-tree map with items from a parallel iterator.
 impl<K, V> ParallelExtend<(K, V)> for BTreeMap<K, V>
 where
     K: Ord + Send,
@@ -100,7 +100,7 @@ where
     }
 }
 
-/// Extend a B-tree map with copied items from a parallel iterator.
+/// Extends a B-tree map with copied items from a parallel iterator.
 impl<'a, K: 'a, V: 'a> ParallelExtend<(&'a K, &'a V)> for BTreeMap<K, V>
 where
     K: Copy + Ord + Send + Sync,
@@ -114,7 +114,7 @@ where
     }
 }
 
-/// Extend a B-tree set with items from a parallel iterator.
+/// Extends a B-tree set with items from a parallel iterator.
 impl<T> ParallelExtend<T> for BTreeSet<T>
 where
     T: Ord + Send,
@@ -127,7 +127,7 @@ where
     }
 }
 
-/// Extend a B-tree set with copied items from a parallel iterator.
+/// Extends a B-tree set with copied items from a parallel iterator.
 impl<'a, T> ParallelExtend<&'a T> for BTreeSet<T>
 where
     T: 'a + Copy + Ord + Send + Sync,
@@ -148,7 +148,7 @@ where
     map.reserve(len(list));
 }
 
-/// Extend a hash map with items from a parallel iterator.
+/// Extends a hash map with items from a parallel iterator.
 impl<K, V, S> ParallelExtend<(K, V)> for HashMap<K, V, S>
 where
     K: Eq + Hash + Send,
@@ -164,7 +164,7 @@ where
     }
 }
 
-/// Extend a hash map with copied items from a parallel iterator.
+/// Extends a hash map with copied items from a parallel iterator.
 impl<'a, K: 'a, V: 'a, S> ParallelExtend<(&'a K, &'a V)> for HashMap<K, V, S>
 where
     K: Copy + Eq + Hash + Send + Sync,
@@ -187,7 +187,7 @@ where
     set.reserve(len(list));
 }
 
-/// Extend a hash set with items from a parallel iterator.
+/// Extends a hash set with items from a parallel iterator.
 impl<T, S> ParallelExtend<T> for HashSet<T, S>
 where
     T: Eq + Hash + Send,
@@ -201,7 +201,7 @@ where
     }
 }
 
-/// Extend a hash set with copied items from a parallel iterator.
+/// Extends a hash set with copied items from a parallel iterator.
 impl<'a, T, S> ParallelExtend<&'a T> for HashSet<T, S>
 where
     T: 'a + Copy + Eq + Hash + Send + Sync,
@@ -220,7 +220,7 @@ fn list_push_back<T>(mut list: LinkedList<T>, elem: T) -> LinkedList<T> {
     list
 }
 
-/// Extend a linked list with items from a parallel iterator.
+/// Extends a linked list with items from a parallel iterator.
 impl<T> ParallelExtend<T> for LinkedList<T>
 where
     T: Send,
@@ -237,7 +237,7 @@ where
     }
 }
 
-/// Extend a linked list with copied items from a parallel iterator.
+/// Extends a linked list with copied items from a parallel iterator.
 impl<'a, T> ParallelExtend<&'a T> for LinkedList<T>
 where
     T: 'a + Copy + Send + Sync,
@@ -255,7 +255,7 @@ fn string_push(mut string: String, ch: char) -> String {
     string
 }
 
-/// Extend a string with characters from a parallel iterator.
+/// Extends a string with characters from a parallel iterator.
 impl ParallelExtend<char> for String {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -274,7 +274,7 @@ impl ParallelExtend<char> for String {
     }
 }
 
-/// Extend a string with copied characters from a parallel iterator.
+/// Extends a string with copied characters from a parallel iterator.
 impl<'a> ParallelExtend<&'a char> for String {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -289,7 +289,7 @@ fn string_reserve<T: AsRef<str>>(string: &mut String, list: &LinkedList<Vec<T>>)
     string.reserve(len);
 }
 
-/// Extend a string with string slices from a parallel iterator.
+/// Extends a string with string slices from a parallel iterator.
 impl<'a> ParallelExtend<&'a str> for String {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -299,7 +299,7 @@ impl<'a> ParallelExtend<&'a str> for String {
     }
 }
 
-/// Extend a string with strings from a parallel iterator.
+/// Extends a string with strings from a parallel iterator.
 impl ParallelExtend<String> for String {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -309,7 +309,7 @@ impl ParallelExtend<String> for String {
     }
 }
 
-/// Extend a string with string slices from a parallel iterator.
+/// Extends a string with string slices from a parallel iterator.
 impl<'a> ParallelExtend<Cow<'a, str>> for String {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -323,7 +323,7 @@ fn deque_reserve<T, U>(deque: &mut VecDeque<T>, list: &LinkedList<Vec<U>>) {
     deque.reserve(len(list));
 }
 
-/// Extend a deque with items from a parallel iterator.
+/// Extends a deque with items from a parallel iterator.
 impl<T> ParallelExtend<T> for VecDeque<T>
 where
     T: Send,
@@ -336,7 +336,7 @@ where
     }
 }
 
-/// Extend a deque with copied items from a parallel iterator.
+/// Extends a deque with copied items from a parallel iterator.
 impl<'a, T> ParallelExtend<&'a T> for VecDeque<T>
 where
     T: 'a + Copy + Send + Sync,
@@ -352,7 +352,7 @@ where
 // See the `collect` module for the `Vec<T>` implementation.
 // impl<T> ParallelExtend<T> for Vec<T>
 
-/// Extend a vector with copied items from a parallel iterator.
+/// Extends a vector with copied items from a parallel iterator.
 impl<'a, T> ParallelExtend<&'a T> for Vec<T>
 where
     T: 'a + Copy + Send + Sync,

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -25,7 +25,7 @@ impl<I, P> Filter<I, P>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Filter` iterator.
+    /// Creates a new `Filter` iterator.
     pub(super) fn new(base: I, filter_op: P) -> Self {
         Filter { base, filter_op }
     }

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -24,7 +24,7 @@ impl<I: ParallelIterator + Debug, P> Debug for FilterMap<I, P> {
 }
 
 impl<I: ParallelIterator, P> FilterMap<I, P> {
-    /// Create a new `FilterMap` iterator.
+    /// Creates a new `FilterMap` iterator.
     pub(super) fn new(base: I, filter_op: P) -> Self {
         FilterMap { base, filter_op }
     }

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -22,7 +22,7 @@ impl<I: ParallelIterator + Debug, F> Debug for FlatMap<I, F> {
 }
 
 impl<I: ParallelIterator, F> FlatMap<I, F> {
-    /// Create a new `FlatMap` iterator.
+    /// Creates a new `FlatMap` iterator.
     pub(super) fn new(base: I, map_op: F) -> Self {
         FlatMap { base, map_op }
     }

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -18,7 +18,7 @@ where
     I: ParallelIterator<Item = PI>,
     PI: IntoParallelIterator + Send,
 {
-    /// Create a new `Flatten` iterator.
+    /// Creates a new `Flatten` iterator.
     pub(super) fn new(base: I) -> Self {
         Flatten { base }
     }

--- a/src/iter/from_par_iter.rs
+++ b/src/iter/from_par_iter.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
 use std::hash::{BuildHasher, Hash};
 
-/// Create an empty default collection and extend it.
+/// Creates an empty default collection and extends it.
 fn collect_extended<C, I>(par_iter: I) -> C
 where
     I: IntoParallelIterator,
@@ -18,7 +18,7 @@ where
     collection
 }
 
-/// Collect items from a parallel iterator into a vector.
+/// Collects items from a parallel iterator into a vector.
 impl<T> FromParallelIterator<T> for Vec<T>
 where
     T: Send,
@@ -31,7 +31,7 @@ where
     }
 }
 
-/// Collect items from a parallel iterator into a vecdeque.
+/// Collects items from a parallel iterator into a vecdeque.
 impl<T> FromParallelIterator<T> for VecDeque<T>
 where
     T: Send,
@@ -44,7 +44,7 @@ where
     }
 }
 
-/// Collect items from a parallel iterator into a binaryheap.
+/// Collects items from a parallel iterator into a binaryheap.
 /// The heap-ordering is calculated serially after all items are collected.
 impl<T> FromParallelIterator<T> for BinaryHeap<T>
 where
@@ -58,7 +58,7 @@ where
     }
 }
 
-/// Collect items from a parallel iterator into a freshly allocated
+/// Collects items from a parallel iterator into a freshly allocated
 /// linked list.
 impl<T> FromParallelIterator<T> for LinkedList<T>
 where
@@ -72,7 +72,7 @@ where
     }
 }
 
-/// Collect (key, value) pairs from a parallel iterator into a
+/// Collects (key, value) pairs from a parallel iterator into a
 /// hashmap. If multiple pairs correspond to the same key, then the
 /// ones produced earlier in the parallel iterator will be
 /// overwritten, just as with a sequential iterator.
@@ -90,7 +90,7 @@ where
     }
 }
 
-/// Collect (key, value) pairs from a parallel iterator into a
+/// Collects (key, value) pairs from a parallel iterator into a
 /// btreemap. If multiple pairs correspond to the same key, then the
 /// ones produced earlier in the parallel iterator will be
 /// overwritten, just as with a sequential iterator.
@@ -107,7 +107,7 @@ where
     }
 }
 
-/// Collect values from a parallel iterator into a hashset.
+/// Collects values from a parallel iterator into a hashset.
 impl<V, S> FromParallelIterator<V> for HashSet<V, S>
 where
     V: Eq + Hash + Send,
@@ -121,7 +121,7 @@ where
     }
 }
 
-/// Collect values from a parallel iterator into a btreeset.
+/// Collects values from a parallel iterator into a btreeset.
 impl<V> FromParallelIterator<V> for BTreeSet<V>
 where
     V: Send + Ord,
@@ -134,7 +134,7 @@ where
     }
 }
 
-/// Collect characters from a parallel iterator into a string.
+/// Collects characters from a parallel iterator into a string.
 impl FromParallelIterator<char> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -144,7 +144,7 @@ impl FromParallelIterator<char> for String {
     }
 }
 
-/// Collect characters from a parallel iterator into a string.
+/// Collects characters from a parallel iterator into a string.
 impl<'a> FromParallelIterator<&'a char> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -154,7 +154,7 @@ impl<'a> FromParallelIterator<&'a char> for String {
     }
 }
 
-/// Collect string slices from a parallel iterator into a string.
+/// Collects string slices from a parallel iterator into a string.
 impl<'a> FromParallelIterator<&'a str> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -164,7 +164,7 @@ impl<'a> FromParallelIterator<&'a str> for String {
     }
 }
 
-/// Collect strings from a parallel iterator into one large string.
+/// Collects strings from a parallel iterator into one large string.
 impl FromParallelIterator<String> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -174,7 +174,7 @@ impl FromParallelIterator<String> for String {
     }
 }
 
-/// Collect string slices from a parallel iterator into a string.
+/// Collects string slices from a parallel iterator into a string.
 impl<'a> FromParallelIterator<Cow<'a, str>> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -184,7 +184,7 @@ impl<'a> FromParallelIterator<Cow<'a, str>> for String {
     }
 }
 
-/// Collect an arbitrary `Cow` collection.
+/// Collects an arbitrary `Cow` collection.
 ///
 /// Note, the standard library only has `FromIterator` for `Cow<'a, str>` and
 /// `Cow<'a, [T]>`, because no one thought to add a blanket implementation

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -28,7 +28,7 @@ impl<I, F> Inspect<I, F>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Inspect` iterator.
+    /// Creates a new `Inspect` iterator.
     pub(super) fn new(base: I, inspect_op: F) -> Self {
         Inspect { base, inspect_op }
     }

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -25,7 +25,7 @@ where
     I: IndexedParallelIterator,
     J: IndexedParallelIterator<Item = I::Item>,
 {
-    /// Create a new `Interleave` iterator
+    /// Creates a new `Interleave` iterator
     pub(super) fn new(i: I, j: J) -> Self {
         Interleave { i, j }
     }

--- a/src/iter/interleave_shortest.rs
+++ b/src/iter/interleave_shortest.rs
@@ -25,7 +25,7 @@ where
     I: IndexedParallelIterator,
     J: IndexedParallelIterator<Item = I::Item>,
 {
-    /// Create a new `InterleaveShortest` iterator
+    /// Creates a new `InterleaveShortest` iterator
     pub(super) fn new(i: I, j: J) -> Self {
         InterleaveShortest {
             interleave: if i.len() <= j.len() {

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -25,7 +25,7 @@ where
     I: ParallelIterator,
     I::Item: Clone,
 {
-    /// Create a new `Intersperse` iterator
+    /// Creates a new `Intersperse` iterator
     pub(super) fn new(base: I, item: I::Item) -> Self {
         Intersperse { base, item }
     }

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -18,7 +18,7 @@ impl<I> MinLen<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `MinLen` iterator.
+    /// Creates a new `MinLen` iterator.
     pub(super) fn new(base: I, min: usize) -> Self {
         MinLen { base, min }
     }
@@ -152,7 +152,7 @@ impl<I> MaxLen<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `MaxLen` iterator.
+    /// Creates a new `MaxLen` iterator.
     pub(super) fn new(base: I, max: usize) -> Self {
         MaxLen { base, max }
     }

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -27,7 +27,7 @@ impl<I, F> Map<I, F>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Map` iterator.
+    /// Creates a new `Map` iterator.
     pub(super) fn new(base: I, map_op: F) -> Self {
         Map { base, map_op }
     }

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -30,7 +30,7 @@ impl<I, T, F> MapWith<I, T, F>
 where
     I: ParallelIterator,
 {
-    /// Create a new `MapWith` iterator.
+    /// Creates a new `MapWith` iterator.
     pub(super) fn new(base: I, item: T, map_op: F) -> Self {
         MapWith { base, item, map_op }
     }
@@ -359,7 +359,7 @@ impl<I, INIT, F> MapInit<I, INIT, F>
 where
     I: ParallelIterator,
 {
-    /// Create a new `MapInit` iterator.
+    /// Creates a new `MapInit` iterator.
     pub(super) fn new(base: I, init: INIT, map_op: F) -> Self {
         MapInit { base, init, map_op }
     }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1201,7 +1201,7 @@ pub trait ParallelIterator: Sized + Send {
         FoldWith::new(self, init, fold_op)
     }
 
-    /// Perform a fallible parallel fold.
+    /// Performs a fallible parallel fold.
     ///
     /// This is a variation of [`fold()`] for operations which can fail with
     /// `Option::None` or `Result::Err`.  The first such failure stops
@@ -1235,7 +1235,7 @@ pub trait ParallelIterator: Sized + Send {
         TryFold::new(self, identity, fold_op)
     }
 
-    /// Perform a fallible parallel fold with a cloneable `init` value.
+    /// Performs a fallible parallel fold with a cloneable `init` value.
     ///
     /// This combines the `init` semantics of [`fold_with()`] and the failure
     /// semantics of [`try_fold()`].
@@ -1861,7 +1861,7 @@ pub trait ParallelIterator: Sized + Send {
         PanicFuse::new(self)
     }
 
-    /// Create a fresh collection containing all the element produced
+    /// Creates a fresh collection containing all the elements produced
     /// by this parallel iterator.
     ///
     /// You may prefer to use `collect_into_vec()`, which allocates more
@@ -2135,7 +2135,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
         collect::unzip_into_vecs(self, left, right);
     }
 
-    /// Iterate over tuples `(A, B)`, where the items `A` are from
+    /// Iterates over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.
     /// Like the `zip` method on ordinary iterators, if the two
     /// iterators are of unequal length, you only get the items they
@@ -2190,7 +2190,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
         ZipEq::new(self, zip_op_iter)
     }
 
-    /// Interleave elements of this iterator and the other given
+    /// Interleaves elements of this iterator and the other given
     /// iterator. Alternately yields elements from this iterator and
     /// the given iterator, until both are exhausted. If one iterator
     /// is exhausted before the other, the last elements are provided
@@ -2212,7 +2212,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
         Interleave::new(self, other.into_par_iter())
     }
 
-    /// Interleave elements of this iterator and the other given
+    /// Interleaves elements of this iterator and the other given
     /// iterator, until one is exhausted.
     ///
     /// # Examples
@@ -2231,7 +2231,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
         InterleaveShortest::new(self, other.into_par_iter())
     }
 
-    /// Split an iterator up into fixed-size chunks.
+    /// Splits an iterator up into fixed-size chunks.
     ///
     /// Returns an iterator that returns `Vec`s of the given number of elements.
     /// If the number of elements in the iterator is not divisible by `chunk_size`,

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -40,7 +40,7 @@ impl<I> PanicFuse<I>
 where
     I: ParallelIterator,
 {
-    /// Create a new `PanicFuse` iterator.
+    /// Creates a new `PanicFuse` iterator.
     pub(super) fn new(base: I) -> PanicFuse<I> {
         PanicFuse { base }
     }

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -44,7 +44,7 @@ use crate::iter::ParallelIterator;
 /// assert_eq!(&*output, &["one!", "three!", "two!"]);
 /// ```
 pub trait ParallelBridge: Sized {
-    /// Create a bridge from this type to a `ParallelIterator`.
+    /// Creates a bridge from this type to a `ParallelIterator`.
     fn par_bridge(self) -> IterBridge<Self>;
 }
 

--- a/src/iter/plumbing/mod.rs
+++ b/src/iter/plumbing/mod.rs
@@ -300,7 +300,7 @@ struct LengthSplitter {
 }
 
 impl LengthSplitter {
-    /// Create a new splitter based on lengths.
+    /// Creates a new splitter based on lengths.
     ///
     /// The `min` is a hard lower bound.  We'll never split below that, but
     /// of course an iterator might start out smaller already.

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -31,7 +31,7 @@ impl<T> Repeat<T>
 where
     T: Clone + Send,
 {
-    /// Take only `n` repeats of the element, similar to the general
+    /// Takes only `n` repeats of the element, similar to the general
     /// [`take()`](trait.IndexedParallelIterator.html#method.take).
     ///
     /// The resulting `RepeatN` is an `IndexedParallelIterator`, allowing
@@ -40,7 +40,7 @@ where
         repeatn(self.element, n)
     }
 
-    /// Iterate tuples repeating the element with items from another
+    /// Iterates tuples, repeating the element with items from another
     /// iterator, similar to the general
     /// [`zip()`](trait.IndexedParallelIterator.html#method.zip).
     pub fn zip<Z>(self, zip_op: Z) -> Zip<RepeatN<T>, Z::Iter>

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -17,7 +17,7 @@ impl<I> Rev<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `Rev` iterator.
+    /// Creates a new `Rev` iterator.
     pub(super) fn new(base: I) -> Self {
         Rev { base }
     }

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -19,7 +19,7 @@ impl<I> Skip<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `Skip` iterator.
+    /// Creates a new `Skip` iterator.
     pub(super) fn new(base: I, n: usize) -> Self {
         let n = min(base.len(), n);
         Skip { base, n }

--- a/src/iter/step_by.rs
+++ b/src/iter/step_by.rs
@@ -23,7 +23,7 @@ impl<I> StepBy<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `StepBy` iterator.
+    /// Creates a new `StepBy` iterator.
     pub(super) fn new(base: I, step: usize) -> Self {
         StepBy { base, step }
     }

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -18,7 +18,7 @@ impl<I> Take<I>
 where
     I: IndexedParallelIterator,
 {
-    /// Create a new `Take` iterator.
+    /// Creates a new `Take` iterator.
     pub(super) fn new(base: I, n: usize) -> Self {
         let n = min(base.len(), n);
         Take { base, n }

--- a/src/iter/unzip.rs
+++ b/src/iter/unzip.rs
@@ -11,7 +11,7 @@ trait UnzipOp<T>: Sync + Send {
     /// The type of item expected by the right consumer.
     type Right: Send;
 
-    /// Consume one item and feed it to one or both of the underlying folders.
+    /// Consumes one item and feeds it to one or both of the underlying folders.
     fn consume<FA, FB>(&self, item: T, left: FA, right: FB) -> (FA, FB)
     where
         FA: Folder<Self::Left>,
@@ -25,7 +25,7 @@ trait UnzipOp<T>: Sync + Send {
     }
 }
 
-/// Run an unzip-like operation into default `ParallelExtend` collections.
+/// Runs an unzip-like operation into default `ParallelExtend` collections.
 fn execute<I, OP, FromA, FromB>(pi: I, op: OP) -> (FromA, FromB)
 where
     I: ParallelIterator,
@@ -39,7 +39,7 @@ where
     (a, b)
 }
 
-/// Run an unzip-like operation into `ParallelExtend` collections.
+/// Runs an unzip-like operation into `ParallelExtend` collections.
 fn execute_into<I, OP, FromA, FromB>(a: &mut FromA, b: &mut FromB, pi: I, op: OP)
 where
     I: ParallelIterator,
@@ -69,7 +69,7 @@ where
     execute(pi, Unzip)
 }
 
-/// Unzip an `IndexedParallelIterator` into two arbitrary `Consumer`s.
+/// Unzips an `IndexedParallelIterator` into two arbitrary `Consumer`s.
 ///
 /// This is called by `super::collect::unzip_into_vecs`.
 pub(super) fn unzip_indexed<I, A, B, CA, CB>(pi: I, left: CA, right: CB) -> (CA::Result, CB::Result)

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -27,7 +27,7 @@ impl<I, F> Update<I, F>
 where
     I: ParallelIterator,
 {
-    /// Create a new `Update` iterator.
+    /// Creates a new `Update` iterator.
     pub(super) fn new(base: I, update_op: F) -> Self {
         Update { base, update_op }
     }

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -19,7 +19,7 @@ impl<I> WhileSome<I>
 where
     I: ParallelIterator,
 {
-    /// Create a new `WhileSome` iterator.
+    /// Creates a new `WhileSome` iterator.
     pub(super) fn new(base: I) -> Self {
         WhileSome { base }
     }

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -21,7 +21,7 @@ where
     A: IndexedParallelIterator,
     B: IndexedParallelIterator,
 {
-    /// Create a new `Zip` iterator.
+    /// Creates a new `Zip` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         Zip { a, b }
     }

--- a/src/iter/zip_eq.rs
+++ b/src/iter/zip_eq.rs
@@ -20,7 +20,7 @@ where
     A: IndexedParallelIterator,
     B: IndexedParallelIterator,
 {
-    /// Create a new `ZipEq` iterator.
+    /// Creates a new `ZipEq` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         ZipEq {
             zip: super::Zip::new(a, b),


### PR DESCRIPTION
I'll admit it feels a bit pedantic.

Looking at some of the biggies from `std::`, the indicative mood appears to dominate, even for simple `set`ters, `get`ters and `new`s. It also finds ample use within rayon, so this PR is not a total inversion of the present state, as glancing at the diff may suggest!

I've left a few functions such as `registry::wait_until` and `::steal` in imperative mood as I felt uncertain about changing them.