### PR TITLE
Move doctest to the rayon-demo library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ docopt = "1"
 lazy_static = "1"
 rand = "0.7"
 rand_xorshift = "0.2"
-doc-comment = "0.3"
 
 [dev-dependencies.serde]
 version = "1.0.85"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -918,7 +918,6 @@ version = "1.3.0"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,6 +947,7 @@ name = "rayon-demo"
 version = "0.0.0"
 dependencies = [
  "cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glium 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -27,4 +27,5 @@ libc = "0.2"
 winapi = { version = "0.3", features = ["processthreadsapi"] }
 
 [dev-dependencies]
+doc-comment = "0.3"
 num = "0.2"

--- a/rayon-demo/src/lib.rs
+++ b/rayon-demo/src/lib.rs
@@ -1,0 +1,3 @@
+// Make sure the examples in the main README actually compile.
+#[cfg(doctest)]
+doc_comment::doctest!("../../README.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,6 @@
 //!
 //! [faq]: https://github.com/rayon-rs/rayon/blob/master/FAQ.md
 
-#[cfg(doctest)]
-doc_comment::doctest!("../README.md");
-
 #[macro_use]
 mod delegate;
 


### PR DESCRIPTION
We've used `doc_comment::doctest!` to push the README through rustdoc
testing, but its `#[cfg(doctest)]` only works on 1.40+, and causes a
hard error on 1.38 and 1.39. Now we move this into rayon-demo so it
doesn't hurt compatibility of the main library.