### PR TITLE
Note that collect_into_vec is in a different trait

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1864,10 +1864,15 @@ pub trait ParallelIterator: Sized + Send {
     /// Creates a fresh collection containing all the elements produced
     /// by this parallel iterator.
     ///
-    /// You may prefer to use `collect_into_vec()`, which allocates more
-    /// efficiently with precise knowledge of how many elements the
-    /// iterator contains, and even allows you to reuse an existing
-    /// vector's backing store rather than allocating a fresh vector.
+    /// You may prefer [`collect_into_vec()`] implemented on
+    /// [`IndexedParallelIterator`], if your underlying iterator also implements
+    /// it. [`collect_into_vec()`] allocates efficiently with precise knowledge
+    /// of how many elements the iterator contains, and even allows you to reuse
+    /// an existing vector's backing store rather than allocating a fresh vector.
+    ///
+    /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+    /// [`collect_into_vec()`]:
+    ///     trait.IndexedParallelIterator.html#method.collect_into_vec
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I couldn't find `collect_into_vec` until I noticed that it's not in `ParallelIterator`, but in `IndexedParallelIterator`.