### PR TITLE
feat: Simplify `leak` by using `Box::leak`

### DIFF
--- a/rayon-core/src/util.rs
+++ b/rayon-core/src/util.rs
@@ -1,10 +1,3 @@
-use std::mem;
-
 pub(super) fn leak<T>(v: T) -> &'static T {
-    unsafe {
-        let b = Box::new(v);
-        let p: *const T = &*b;
-        mem::forget(b); // leak our reference, so that `b` is never freed
-        &*p
-    }
+    Box::leak(Box::new(v))
 }


### PR DESCRIPTION
Thanks for the great project!

I thing `leak` can be rewritten by using `Box::leak`.

Bonus: It removes one `unsafe` block.