### PR TITLE
Link to GitHub Actions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Rayon crate](https://img.shields.io/crates/v/rayon.svg)](https://crates.io/crates/rayon)
 [![Rayon documentation](https://docs.rs/rayon/badge.svg)](https://docs.rs/rayon)
 ![minimum rustc 1.36](https://img.shields.io/badge/rustc-1.36+-red.svg)
-![build status](https://github.com/rayon-rs/rayon/workflows/master/badge.svg)
+[![build status](https://github.com/rayon-rs/rayon/workflows/master/badge.svg)](https://github.com/rayon-rs/rayon/actions)
 [![Join the chat at https://gitter.im/rayon-rs/Lobby](https://badges.gitter.im/rayon-rs/Lobby.svg)](https://gitter.im/rayon-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Rayon is a data-parallelism library for Rust. It is extremely


### PR DESCRIPTION
This is probably more useful than just showing the badge and matches the behavior of the previous CI badges.