### PR TITLE
Use in_place_scope to spawn skipped items

### DIFF
--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -79,9 +79,16 @@ where
             where
                 P: Producer<Item = T>,
             {
-                let (before_skip, after_skip) = base.split_at(self.n);
-                bridge_producer_consumer(self.n, before_skip, NoopConsumer);
-                self.callback.callback(after_skip)
+                crate::in_place_scope(|scope| {
+                    let Self { callback, n } = self;
+                    let (before_skip, after_skip) = base.split_at(n);
+
+                    // Run the skipped part separately for side effects.
+                    // We'll still get any panics propagated back by the scope.
+                    scope.spawn(move |_| bridge_producer_consumer(n, before_skip, NoopConsumer));
+
+                    callback.callback(after_skip)
+                })
             }
         }
     }


### PR DESCRIPTION
`Skip` still executes the skipped part of the iterator with a no-op
consumer in case there are side effects, as a point of compatibility
with sequential `Skip`. However, the `Producer` is not necessarily
`'static`, and `ProducerCallback::Output` doesn't require `Send`, so we
didn't have a way to run the no-op in parallel with the normal callback.

Now with `in_place_scope`, we can `spawn` the no-op consumer while we
run the callback directly. The scope will still wait for that no-op to
complete before returning, propagating panics if necessary.