### PR TITLE
Update dependencies for cargo audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.9.1", path = "rayon-core" }
-crossbeam-deque = "0.8.0"
+crossbeam-deque = "0.8"
 
 # This is a public dependency!
 [dependencies.either]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.9.1", path = "rayon-core" }
-crossbeam-deque = "0.8"
+crossbeam-deque = "0.8.1"
 
 # This is a public dependency!
 [dependencies.either]

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -7,10 +7,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "addr2line"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gimli 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimli 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -23,7 +23,7 @@ name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -31,11 +31,11 @@ name = "andrew"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,21 +58,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "addr2line 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "addr2line 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "object 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "object 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -109,7 +109,7 @@ name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -123,31 +123,16 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -156,12 +141,12 @@ name = "cocoa-foundation"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -171,7 +156,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -180,7 +165,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,10 +183,10 @@ name = "core-graphics"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,11 +194,11 @@ name = "core-graphics"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -221,10 +206,10 @@ name = "core-graphics-types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -235,8 +220,21 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -245,37 +243,45 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-epoch 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.4"
+name = "crossbeam-queue"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -296,10 +302,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,7 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -317,9 +323,9 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -355,7 +361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -393,32 +399,18 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -428,32 +420,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glium"
-version = "0.29.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "takeable-option 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glutin"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_egl_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_emscripten_sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -461,15 +453,15 @@ dependencies = [
  "glutin_glx_sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_wgl_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-egl 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-egl 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -514,10 +506,10 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -527,33 +519,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "khronos_api"
@@ -566,13 +541,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -614,7 +584,7 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -632,16 +602,21 @@ name = "memmap2"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "miniz_oxide"
@@ -654,64 +629,55 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "mio-extras"
-version = "2.0.6"
+name = "mio-misc"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazycell 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ndk"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_enum 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ndk-glue"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -723,9 +689,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -734,24 +700,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -759,19 +715,28 @@ name = "nix"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimal-lexical 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -848,28 +813,28 @@ name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derivative 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_enum_derive 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro-crate 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-crate 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -882,12 +847,15 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -911,7 +879,7 @@ name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lock_api 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -922,9 +890,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -953,8 +921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -965,43 +942,43 @@ name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ppv-lite86 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1009,7 +986,7 @@ name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1017,7 +994,7 @@ name = "raw-window-handle"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1025,14 +1002,14 @@ name = "rayon"
 version = "1.5.1"
 dependencies = [
  "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.9.1",
- "serde 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1040,12 +1017,12 @@ name = "rayon-core"
 version = "1.9.1"
 dependencies = [
  "crossbeam-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,24 +1035,24 @@ dependencies = [
  "doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixedbitset 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glium 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glium 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.5.1",
  "regex 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1084,7 +1061,7 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1095,7 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1127,20 +1104,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1149,13 +1126,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
@@ -1168,16 +1140,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "andrew 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "calloop 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-cursor 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-protocols 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-cursor 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1192,10 +1164,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1207,20 +1179,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1228,7 +1200,7 @@ name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1263,73 +1235,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wayland-client"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-commons"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xcursor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xcursor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-egl"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.28.5"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,22 +1311,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1376,41 +1338,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winit"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-video-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "instant 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk-glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-misc 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk-glue 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1419,17 +1373,17 @@ version = "2.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "xcursor"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1439,28 +1393,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ab_glyph_rasterizer 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
-"checksum addr2line 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03345e98af8f3d786b6d9f656ccfa6ac316d954e92bc4841f0bba20789d5fb5a"
+"checksum addr2line 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 "checksum adler 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 "checksum aho-corasick 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 "checksum andrew 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c4afb09dd642feec8408e33f92f3ffc4052946f6b20f32fb99c1f58cd4fa7cf"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum approx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 "checksum autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-"checksum backtrace 0.3.59 (registry+https://github.com/rust-lang/crates.io-index)" = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum backtrace 0.3.61 (registry+https://github.com/rust-lang/crates.io-index)" = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+"checksum bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum calloop 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0b036167e76041694579972c28cf4877b4f92da222560ddb49008937b6a6727c"
-"checksum cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+"checksum cc 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)" = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 "checksum cgl 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 "checksum cgmath 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
-"checksum cocoa 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
 "checksum cocoa 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
 "checksum cocoa-foundation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
@@ -1471,10 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-graphics 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)" = "269f35f69b542b80e736a20a89a05215c0ce80c2c03c514abb2e318b78379d86"
 "checksum core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 "checksum core-video-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+"checksum crossbeam 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 "checksum crossbeam-channel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-"checksum crossbeam-deque 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-"checksum crossbeam-epoch 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
-"checksum crossbeam-utils 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+"checksum crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+"checksum crossbeam-epoch 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+"checksum crossbeam-queue 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+"checksum crossbeam-utils 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 "checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 "checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
@@ -1490,49 +1445,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum getrandom 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
-"checksum gimli 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+"checksum getrandom 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+"checksum gimli 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 "checksum gl_generator 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-"checksum glium 0.29.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a58e115545ab8ce2238630c06a60f30a835271e3aff861db08d81561643d7a9"
-"checksum glutin 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ae1cbb9176b9151c4ce03f012e3cd1c6c18c4be79edeaeb3d99f5d8085c5fa3"
+"checksum glium 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6dfaf64eee4e23d1d5429945816ab083cb94b44e00c3c5f9f9aebfd09ec63df"
+"checksum glutin 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "762d6cd2e1b855d99668ebe591cc9058659d85ac39a9a2078000eb122ddba8f0"
 "checksum glutin_egl_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2abb6aa55523480c4adc5a56bbaa249992e2dddb2fc63dc96e04a3355364c211"
 "checksum glutin_emscripten_sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1"
 "checksum glutin_gles2_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e8094e708b730a7c8a1954f4f8a31880af00eb8a1c5b5bf85d28a0a3c6d69103"
 "checksum glutin_glx_sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "7e393c8fc02b807459410429150e9c4faffdb312d59b8c038566173c81991351"
 "checksum glutin_wgl_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
-"checksum hermit-abi 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+"checksum hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-"checksum instant 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum instant 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum lazycell 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-"checksum libc 0.2.94 (registry+https://github.com/rust-lang/crates.io-index)" = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+"checksum libc 0.2.100 (registry+https://github.com/rust-lang/crates.io-index)" = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 "checksum libloading 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 "checksum libloading 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 "checksum lock_api 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 "checksum log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum memchr 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+"checksum memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 "checksum memmap2 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
-"checksum memoffset 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+"checksum memoffset 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+"checksum minimal-lexical 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6595bb28ed34f43c3fe088e48f6cfb2e033cab45f25a5384d5fdf564fbc8c4b2"
 "checksum miniz_oxide 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-"checksum mio 0.6.23 (registry+https://github.com/rust-lang/crates.io-index)" = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-"checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-"checksum miow 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-"checksum ndk 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5eb167c1febed0a496639034d0c76b3b74263636045db5489eee52143c246e73"
-"checksum ndk-glue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdf399b8b7a39c6fb153c4ec32c72fd5fe789df24a647f229c239aa7adb15241"
+"checksum mio 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+"checksum mio-misc 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf05411bb159cdb5801bb10002afb66cb4572be656044315e363460ce69dc2"
+"checksum miow 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+"checksum ndk 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
+"checksum ndk-glue 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 "checksum ndk-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05d1c6307dc424d0f65b9b06e94f88248e6305726b14729fd67a5e47b2dc481d"
 "checksum ndk-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
-"checksum net2 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 "checksum nix 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 "checksum nix 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
-"checksum nom 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+"checksum nom 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+"checksum ntapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 "checksum num 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 "checksum num-bigint 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
 "checksum num-complex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
@@ -1541,11 +1492,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 "checksum num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-"checksum num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
-"checksum num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+"checksum num_enum 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+"checksum num_enum_derive 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 "checksum objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-"checksum object 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
-"checksum once_cell 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+"checksum object 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+"checksum once_cell 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owned_ttf_parser 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f923fb806c46266c02ab4a5b239735c144bdeda724a50ed058e5226f594cde3"
 "checksum parking_lot 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
@@ -1554,56 +1505,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 "checksum ppv-lite86 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 "checksum proc-macro-crate 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-"checksum proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+"checksum proc-macro-crate 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+"checksum proc-macro2 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 "checksum quote 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
-"checksum rand 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-"checksum rand_chacha 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-"checksum rand_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-"checksum rand_hc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+"checksum rand 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+"checksum rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+"checksum rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+"checksum rand_hc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 "checksum rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 "checksum raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211"
-"checksum redox_syscall 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+"checksum redox_syscall 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 "checksum regex 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 "checksum regex-syntax 0.6.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-"checksum rustc-demangle 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
+"checksum rustc-demangle 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 "checksum rusttype 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dc7c727aded0be18c5b80c1640eae0ac8e396abf6fa8477d96cb37d18ee5ec59"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum serde 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
-"checksum serde_derive 1.0.126 (registry+https://github.com/rust-lang/crates.io-index)" = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+"checksum serde 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)" = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+"checksum serde_derive 1.0.129 (registry+https://github.com/rust-lang/crates.io-index)" = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-"checksum slab 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 "checksum smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 "checksum smithay-client-toolkit 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4750c76fd5d3ac95fa3ed80fe667d6a3d8590a960e5b575b98eea93339a80b80"
 "checksum strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-"checksum syn 1.0.72 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+"checksum syn 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 "checksum takeable-option 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
-"checksum thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
-"checksum thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+"checksum thiserror 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+"checksum thiserror-impl 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 "checksum toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 "checksum ttf-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e5d7cd7ab3e47dda6e56542f4bbf3824c15234958c6e1bd6aaa347e93499fdc"
 "checksum unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 "checksum version_check 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 "checksum walkdir 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 "checksum wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-"checksum wayland-client 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "06ca44d86554b85cf449f1557edc6cc7da935cc748c8e4bf1c507cbd43bae02c"
-"checksum wayland-commons 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8bd75ae380325dbcff2707f0cd9869827ea1d2d6d534cff076858d3f0460fd5a"
-"checksum wayland-cursor 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b37e5455ec72f5de555ec39b5c3704036ac07c2ecd50d0bffe02d5fe2d4e65ab"
-"checksum wayland-egl 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9461a67930ec16da7a4fd8b50e9ffa23f4417240b43ec84008bd1b2c94421c94"
-"checksum wayland-protocols 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95df3317872bcf9eec096c864b69aa4769a1d5d6291a5b513f8ba0af0efbd52c"
-"checksum wayland-scanner 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "389d680d7bd67512dc9c37f39560224327038deb0f0e8d33f870900441b68720"
-"checksum wayland-sys 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2907bd297eef464a95ba9349ea771611771aa285b932526c633dc94d5400a8e2"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum wayland-client 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e3ab332350e502f159382201394a78e3cc12d0f04db863429260164ea40e0355"
+"checksum wayland-commons 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a21817947c7011bbd0a27e11b17b337bfd022e8544b071a2641232047966fbda"
+"checksum wayland-cursor 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "be610084edd1586d45e7bdd275fe345c7c1873598caa464c4fb835dee70fa65a"
+"checksum wayland-egl 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "99ba1ab1e18756b23982d36f08856d521d7df45015f404a2d7c4f0b2d2f66956"
+"checksum wayland-protocols 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "286620ea4d803bacf61fa087a4242ee316693099ee5a140796aaba02b29f861f"
+"checksum wayland-scanner 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ce923eb2deb61de332d1f356ec7b6bf37094dc5573952e1c8936db03b54c03f1"
+"checksum wayland-sys 0.28.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d841fca9aed7febf9bed2e9796c49bf58d4152ceda8ac949ebe00868d8f0feb8"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum winit 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79610794594d5e86be473ef7763f604f2159cbac8c94debd00df8fb41e86c2f8"
 "checksum x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
-"checksum xcursor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
+"checksum xcursor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
-"checksum xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+"checksum xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["concurrency"]
 [dependencies]
 num_cpus = "1.2"
 lazy_static = "1"
-crossbeam-channel = "0.5.0"
-crossbeam-deque = "0.8.0"
-crossbeam-utils = "0.8.0"
+crossbeam-channel = "0.5"
+crossbeam-deque = "0.8"
+crossbeam-utils = "0.8"
 
 [dev-dependencies]
 rand = "0.8"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -18,9 +18,9 @@ categories = ["concurrency"]
 [dependencies]
 num_cpus = "1.2"
 lazy_static = "1"
-crossbeam-channel = "0.5"
-crossbeam-deque = "0.8"
-crossbeam-utils = "0.8"
+crossbeam-channel = "0.5.0"
+crossbeam-deque = "0.8.1"
+crossbeam-utils = "0.8.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -10,7 +10,7 @@ rayon = { path = "../" }
 cgmath = "0.18"
 docopt = "1"
 fixedbitset = "0.4"
-glium = "0.29"
+glium = "0.30"
 lazy_static = "1"
 rand = "0.8"
 rand_xorshift = "0.3"


### PR DESCRIPTION
Updates crossbeam and glium for cargo audit purposes. crossbeam had security vulnerability in 0.8.0 so am giving some range availability in which version to pick, ideally this makes updates like this pr needed less frequently