### PR TITLE
Update to try_trait_v2 and stable ControlFlow

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 fn main() {
     let ac = autocfg::new();
     if ac.probe_expression("(0..10).step_by(2).rev()") {
-        autocfg::emit("step_by");
+        autocfg::emit("has_step_by_rev");
     }
     if ac.probe_expression("{ fn foo<const N: usize>() {} }") {
-        autocfg::emit("min_const_generics");
+        autocfg::emit("has_min_const_generics");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -6,4 +6,7 @@ fn main() {
     if ac.probe_expression("{ fn foo<const N: usize>() {} }") {
         autocfg::emit("has_min_const_generics");
     }
+    if ac.probe_path("std::ops::ControlFlow") {
+        autocfg::emit("has_control_flow");
+    }
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,4 +1,4 @@
-#![cfg(min_const_generics)]
+#![cfg(has_min_const_generics)]
 //! Parallel iterator types for [arrays] (`[T; N]`)
 //!
 //! You will rarely need to interact with this module directly unless you need

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -190,7 +190,7 @@ pub use self::{
 };
 
 mod step_by;
-#[cfg(step_by)]
+#[cfg(has_step_by_rev)]
 pub use self::step_by::StepBy;
 
 /// `IntoParallelIterator` implements the conversion to a [`ParallelIterator`].
@@ -2605,7 +2605,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// # Compatibility
     ///
     /// This method is only available on Rust 1.38 or greater.
-    #[cfg(step_by)]
+    #[cfg(has_step_by_rev)]
     fn step_by(self, step: usize) -> StepBy<Self> {
         StepBy::new(self, step)
     }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -457,10 +457,10 @@ pub trait ParallelIterator: Sized + Send {
     fn try_for_each<OP, R>(self, op: OP) -> R
     where
         OP: Fn(Self::Item) -> R + Sync + Send,
-        R: Try<Ok = ()> + Send,
+        R: Try<Output = ()> + Send,
     {
-        fn ok<R: Try<Ok = ()>>(_: (), _: ()) -> R {
-            R::from_ok(())
+        fn ok<R: Try<Output = ()>>(_: (), _: ()) -> R {
+            R::from_output(())
         }
 
         self.map(op).try_reduce(<()>::default, ok)
@@ -497,10 +497,10 @@ pub trait ParallelIterator: Sized + Send {
     where
         OP: Fn(&mut T, Self::Item) -> R + Sync + Send,
         T: Send + Clone,
-        R: Try<Ok = ()> + Send,
+        R: Try<Output = ()> + Send,
     {
-        fn ok<R: Try<Ok = ()>>(_: (), _: ()) -> R {
-            R::from_ok(())
+        fn ok<R: Try<Output = ()>>(_: (), _: ()) -> R {
+            R::from_output(())
         }
 
         self.map_with(init, op).try_reduce(<()>::default, ok)
@@ -539,10 +539,10 @@ pub trait ParallelIterator: Sized + Send {
     where
         OP: Fn(&mut T, Self::Item) -> R + Sync + Send,
         INIT: Fn() -> T + Sync + Send,
-        R: Try<Ok = ()> + Send,
+        R: Try<Output = ()> + Send,
     {
-        fn ok<R: Try<Ok = ()>>(_: (), _: ()) -> R {
-            R::from_ok(())
+        fn ok<R: Try<Output = ()>>(_: (), _: ()) -> R {
+            R::from_output(())
         }
 
         self.map_init(init, op).try_reduce(<()>::default, ok)
@@ -1065,7 +1065,7 @@ pub trait ParallelIterator: Sized + Send {
     where
         OP: Fn(T, T) -> Self::Item + Sync + Send,
         ID: Fn() -> T + Sync + Send,
-        Self::Item: Try<Ok = T>,
+        Self::Item: Try<Output = T>,
     {
         try_reduce::try_reduce(self, identity, op)
     }
@@ -1108,7 +1108,7 @@ pub trait ParallelIterator: Sized + Send {
     fn try_reduce_with<T, OP>(self, op: OP) -> Option<Self::Item>
     where
         OP: Fn(T, T) -> Self::Item + Sync + Send,
-        Self::Item: Try<Ok = T>,
+        Self::Item: Try<Output = T>,
     {
         try_reduce_with::try_reduce_with(self, op)
     }
@@ -1311,7 +1311,7 @@ pub trait ParallelIterator: Sized + Send {
     where
         F: Fn(T, Self::Item) -> R + Sync + Send,
         ID: Fn() -> T + Sync + Send,
-        R: Try<Ok = T> + Send,
+        R: Try<Output = T> + Send,
     {
         TryFold::new(self, identity, fold_op)
     }
@@ -1337,7 +1337,7 @@ pub trait ParallelIterator: Sized + Send {
     fn try_fold_with<F, T, R>(self, init: T, fold_op: F) -> TryFoldWith<Self, R, F>
     where
         F: Fn(T, Self::Item) -> R + Sync + Send,
-        R: Try<Ok = T> + Send,
+        R: Try<Output = T> + Send,
         T: Clone + Send,
     {
         TryFoldWith::new(self, init, fold_op)
@@ -3145,50 +3145,81 @@ pub trait ParallelDrainRange<Idx = usize> {
 /// We hide the `Try` trait in a private module, as it's only meant to be a
 /// stable clone of the standard library's `Try` trait, as yet unstable.
 mod private {
+    use std::convert::Infallible;
+
+    #[cfg(has_control_flow)]
+    pub(crate) use std::ops::ControlFlow;
+
+    #[cfg(not(has_control_flow))]
+    #[allow(missing_debug_implementations)]
+    pub enum ControlFlow<B, C = ()> {
+        Continue(C),
+        Break(B),
+    }
+
     /// Clone of `std::ops::Try`.
     ///
     /// Implementing this trait is not permitted outside of `rayon`.
     pub trait Try {
         private_decl! {}
 
-        type Ok;
-        type Error;
-        fn into_result(self) -> Result<Self::Ok, Self::Error>;
-        fn from_ok(v: Self::Ok) -> Self;
-        fn from_error(v: Self::Error) -> Self;
+        type Output;
+        type Residual;
+
+        fn from_output(output: Self::Output) -> Self;
+
+        fn from_residual(residual: Self::Residual) -> Self;
+
+        fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
     }
 
     impl<T> Try for Option<T> {
         private_impl! {}
 
-        type Ok = T;
-        type Error = ();
+        type Output = T;
+        type Residual = Option<Infallible>;
 
-        fn into_result(self) -> Result<T, ()> {
-            self.ok_or(())
+        fn from_output(output: Self::Output) -> Self {
+            Some(output)
         }
-        fn from_ok(v: T) -> Self {
-            Some(v)
+
+        fn from_residual(residual: Self::Residual) -> Self {
+            match residual {
+                None => None,
+                Some(_) => unreachable!(),
+            }
         }
-        fn from_error(_: ()) -> Self {
-            None
+
+        fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+            match self {
+                Some(c) => ControlFlow::Continue(c),
+                None => ControlFlow::Break(None),
+            }
         }
     }
 
     impl<T, E> Try for Result<T, E> {
         private_impl! {}
 
-        type Ok = T;
-        type Error = E;
+        type Output = T;
+        type Residual = Result<Infallible, E>;
 
-        fn into_result(self) -> Result<T, E> {
-            self
+        fn from_output(output: Self::Output) -> Self {
+            Ok(output)
         }
-        fn from_ok(v: T) -> Self {
-            Ok(v)
+
+        fn from_residual(residual: Self::Residual) -> Self {
+            match residual {
+                Err(e) => Err(e),
+                Ok(_) => unreachable!(),
+            }
         }
-        fn from_error(v: E) -> Self {
-            Err(v)
+
+        fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+            match self {
+                Ok(c) => ControlFlow::Continue(c),
+                Err(e) => ControlFlow::Break(Err(e)),
+            }
         }
     }
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -3173,6 +3173,32 @@ mod private {
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
     }
 
+    #[cfg(has_control_flow)]
+    impl<B, C> Try for ControlFlow<B, C> {
+        private_impl! {}
+
+        type Output = C;
+        type Residual = ControlFlow<B, Infallible>;
+
+        fn from_output(output: Self::Output) -> Self {
+            ControlFlow::Continue(output)
+        }
+
+        fn from_residual(residual: Self::Residual) -> Self {
+            match residual {
+                ControlFlow::Break(b) => ControlFlow::Break(b),
+                ControlFlow::Continue(_) => unreachable!(),
+            }
+        }
+
+        fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+            match self {
+                ControlFlow::Continue(c) => ControlFlow::Continue(c),
+                ControlFlow::Break(b) => ControlFlow::Break(ControlFlow::Break(b)),
+            }
+        }
+    }
+
     impl<T> Try for Option<T> {
         private_impl! {}
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -3158,6 +3158,8 @@ mod private {
         Break(B),
     }
 
+    use self::ControlFlow::{Break, Continue};
+
     /// Clone of `std::ops::Try`.
     ///
     /// Implementing this trait is not permitted outside of `rayon`.
@@ -3182,20 +3184,20 @@ mod private {
         type Residual = ControlFlow<B, Infallible>;
 
         fn from_output(output: Self::Output) -> Self {
-            ControlFlow::Continue(output)
+            Continue(output)
         }
 
         fn from_residual(residual: Self::Residual) -> Self {
             match residual {
-                ControlFlow::Break(b) => ControlFlow::Break(b),
-                ControlFlow::Continue(_) => unreachable!(),
+                Break(b) => Break(b),
+                Continue(_) => unreachable!(),
             }
         }
 
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
             match self {
-                ControlFlow::Continue(c) => ControlFlow::Continue(c),
-                ControlFlow::Break(b) => ControlFlow::Break(ControlFlow::Break(b)),
+                Continue(c) => Continue(c),
+                Break(b) => Break(Break(b)),
             }
         }
     }
@@ -3219,8 +3221,8 @@ mod private {
 
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
             match self {
-                Some(c) => ControlFlow::Continue(c),
-                None => ControlFlow::Break(None),
+                Some(c) => Continue(c),
+                None => Break(None),
             }
         }
     }
@@ -3244,8 +3246,8 @@ mod private {
 
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
             match self {
-                Ok(c) => ControlFlow::Continue(c),
-                Err(e) => ControlFlow::Break(Err(e)),
+                Ok(c) => Continue(c),
+                Err(e) => Break(Err(e)),
             }
         }
     }
@@ -3269,9 +3271,9 @@ mod private {
 
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
             match self {
-                Poll::Pending => ControlFlow::Continue(Poll::Pending),
-                Poll::Ready(Ok(c)) => ControlFlow::Continue(Poll::Ready(c)),
-                Poll::Ready(Err(e)) => ControlFlow::Break(Err(e)),
+                Poll::Pending => Continue(Poll::Pending),
+                Poll::Ready(Ok(c)) => Continue(Poll::Ready(c)),
+                Poll::Ready(Err(e)) => Break(Err(e)),
             }
         }
     }
@@ -3298,10 +3300,10 @@ mod private {
 
         fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
             match self {
-                Poll::Pending => ControlFlow::Continue(Poll::Pending),
-                Poll::Ready(None) => ControlFlow::Continue(Poll::Ready(None)),
-                Poll::Ready(Some(Ok(c))) => ControlFlow::Continue(Poll::Ready(Some(c))),
-                Poll::Ready(Some(Err(e))) => ControlFlow::Break(Err(e)),
+                Poll::Pending => Continue(Poll::Pending),
+                Poll::Ready(None) => Continue(Poll::Ready(None)),
+                Poll::Ready(Some(Ok(c))) => Continue(Poll::Ready(Some(c))),
+                Poll::Ready(Some(Err(e))) => Break(Err(e)),
             }
         }
     }

--- a/src/iter/step_by.rs
+++ b/src/iter/step_by.rs
@@ -1,4 +1,4 @@
-#![cfg(step_by)]
+#![cfg(has_step_by_rev)]
 use std::cmp::min;
 
 use super::plumbing::*;

--- a/src/iter/try_reduce.rs
+++ b/src/iter/try_reduce.rs
@@ -1,14 +1,16 @@
 use super::plumbing::*;
 use super::ParallelIterator;
+use super::Try;
 
-use super::private::Try;
+use super::private::ControlFlow::{self, Break, Continue};
+
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(super) fn try_reduce<PI, R, ID, T>(pi: PI, identity: ID, reduce_op: R) -> T
 where
     PI: ParallelIterator<Item = T>,
-    R: Fn(T::Ok, T::Ok) -> T + Sync,
-    ID: Fn() -> T::Ok + Sync,
+    R: Fn(T::Output, T::Output) -> T + Sync,
+    ID: Fn() -> T::Output + Sync,
     T: Try + Send,
 {
     let full = AtomicBool::new(false);
@@ -36,8 +38,8 @@ impl<'r, R, ID> Clone for TryReduceConsumer<'r, R, ID> {
 
 impl<'r, R, ID, T> Consumer<T> for TryReduceConsumer<'r, R, ID>
 where
-    R: Fn(T::Ok, T::Ok) -> T + Sync,
-    ID: Fn() -> T::Ok + Sync,
+    R: Fn(T::Output, T::Output) -> T + Sync,
+    ID: Fn() -> T::Output + Sync,
     T: Try + Send,
 {
     type Folder = TryReduceFolder<'r, R, T>;
@@ -51,7 +53,7 @@ where
     fn into_folder(self) -> Self::Folder {
         TryReduceFolder {
             reduce_op: self.reduce_op,
-            result: Ok((self.identity)()),
+            control: Continue((self.identity)()),
             full: self.full,
         }
     }
@@ -63,8 +65,8 @@ where
 
 impl<'r, R, ID, T> UnindexedConsumer<T> for TryReduceConsumer<'r, R, ID>
 where
-    R: Fn(T::Ok, T::Ok) -> T + Sync,
-    ID: Fn() -> T::Ok + Sync,
+    R: Fn(T::Output, T::Output) -> T + Sync,
+    ID: Fn() -> T::Output + Sync,
     T: Try + Send,
 {
     fn split_off_left(&self) -> Self {
@@ -78,52 +80,53 @@ where
 
 impl<'r, R, ID, T> Reducer<T> for TryReduceConsumer<'r, R, ID>
 where
-    R: Fn(T::Ok, T::Ok) -> T + Sync,
+    R: Fn(T::Output, T::Output) -> T + Sync,
     T: Try,
 {
     fn reduce(self, left: T, right: T) -> T {
-        match (left.into_result(), right.into_result()) {
-            (Ok(left), Ok(right)) => (self.reduce_op)(left, right),
-            (Err(e), _) | (_, Err(e)) => T::from_error(e),
+        match (left.branch(), right.branch()) {
+            (Continue(left), Continue(right)) => (self.reduce_op)(left, right),
+            (Break(r), _) | (_, Break(r)) => T::from_residual(r),
         }
     }
 }
 
 struct TryReduceFolder<'r, R, T: Try> {
     reduce_op: &'r R,
-    result: Result<T::Ok, T::Error>,
+    control: ControlFlow<T::Residual, T::Output>,
     full: &'r AtomicBool,
 }
 
 impl<'r, R, T> Folder<T> for TryReduceFolder<'r, R, T>
 where
-    R: Fn(T::Ok, T::Ok) -> T,
+    R: Fn(T::Output, T::Output) -> T,
     T: Try,
 {
     type Result = T;
 
     fn consume(mut self, item: T) -> Self {
         let reduce_op = self.reduce_op;
-        if let Ok(left) = self.result {
-            self.result = match item.into_result() {
-                Ok(right) => reduce_op(left, right).into_result(),
-                Err(error) => Err(error),
-            };
-        }
-        if self.result.is_err() {
-            self.full.store(true, Ordering::Relaxed)
+        self.control = match (self.control, item.branch()) {
+            (Continue(left), Continue(right)) => reduce_op(left, right).branch(),
+            (control @ Break(_), _) | (_, control @ Break(_)) => control,
+        };
+        if let Break(_) = self.control {
+            self.full.store(true, Ordering::Relaxed);
         }
         self
     }
 
     fn complete(self) -> T {
-        match self.result {
-            Ok(ok) => T::from_ok(ok),
-            Err(error) => T::from_error(error),
+        match self.control {
+            Continue(c) => T::from_output(c),
+            Break(r) => T::from_residual(r),
         }
     }
 
     fn full(&self) -> bool {
-        self.full.load(Ordering::Relaxed)
+        match self.control {
+            Break(_) => true,
+            _ => self.full.load(Ordering::Relaxed),
+        }
     }
 }


### PR DESCRIPTION
While `std::ops::Try` is still unstable, we can privately mirror recent changes to our own copy. Rust 1.55 _is_ stabilizing `enum ControlFlow` though, which also implements `Try` for the stable `?`-operator and `Iterator::try_*`, so we can support that as well. Finally, `std::task::Poll` was stabilized in 1.36, with `Try` implementations for `Poll<Result<T, E>>` and `Poll<Option<Result<T, E>>>`, so again we can mimic that.