### PR TITLE
Add mini-section on Wasm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ use rayon::prelude::*;
 
 Rayon currently requires `rustc 1.36.0` or greater.
 
+### Usage with WebAssembly
+
+Rayon can work on the Web via WebAssembly, but requires an adapter
+and some project configuration to account for differences between
+WebAssembly threads and threads on the other platforms.
+
+Check out [wasm-bindgen-rayon](https://github.com/GoogleChromeLabs/wasm-bindgen-rayon)
+docs for more details.
+
 ## Contribution
 
 Rayon is an open source project! If you'd like to contribute to Rayon, check out [the list of "help wanted" issues](https://github.com/rayon-rs/rayon/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). These are all (or should be) issues that are suitable for getting started, and they generally include a detailed set of instructions for what to do. Please ask questions if anything is unclear! Also, check out the [Guide to Development](https://github.com/rayon-rs/rayon/wiki/Guide-to-Development) page on the wiki. Note that all code submitted in PRs to Rayon is assumed to [be licensed under Rayon's dual MIT/Apache2 licensing](https://github.com/rayon-rs/rayon/blob/master/README.md#license).


### PR DESCRIPTION
I wasn't sure at first if you'd be interested in linking to the adapter from Rayon docs, but seeing more and more projects using this integration already, figured it might be useful.

Feel free to close if you think otherwise.