### PR TITLE
Question: Concatenate list of indexed parallel iterators

### DIFF
--- a/src/iter/concat.rs
+++ b/src/iter/concat.rs
@@ -1,0 +1,178 @@
+use super::{
+    plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer},
+    IndexedParallelIterator, ParallelIterator,
+};
+
+/// TODO
+pub fn concat<I>(iters: Vec<I>) -> Concat<I>
+where
+    I: IndexedParallelIterator,
+{
+    Concat(iters)
+}
+
+/// TODO
+#[derive(Debug)]
+pub struct Concat<I>(Vec<I>);
+
+impl<I> ParallelIterator for Concat<I>
+where
+    I: IndexedParallelIterator,
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl<I> IndexedParallelIterator for Concat<I>
+where
+    I: IndexedParallelIterator,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.0.iter().map(IndexedParallelIterator::len).sum()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        struct Collector<P1> {
+            len: usize,
+            prods: Vec<(usize, P1)>,
+        }
+
+        impl<'a, T, P1> ProducerCallback<T> for &'a mut Collector<P1>
+        where
+            P1: Producer<Item = T>,
+        {
+            type Output = ();
+
+            fn callback<P2>(self, producer: P2) -> Self::Output
+            where
+                P2: Producer<Item = T>,
+            {
+                // TODO: unify P1 and P2
+                self.prods.push((self.len, producer));
+            }
+        }
+
+        let mut collector = Collector {
+            len: 0,
+            prods: Vec::new(),
+        };
+
+        for iter in self.0 {
+            collector.len += iter.len();
+
+            iter.with_producer(&mut collector);
+        }
+
+        callback.callback(Concat(collector.prods))
+    }
+}
+
+impl<P> Producer for Concat<(usize, P)>
+where
+    P: Producer,
+{
+    type Item = P::Item;
+    type IntoIter = Concat<P::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Concat(
+            self.0
+                .into_iter()
+                .map(|(_len, prod)| prod.into_iter())
+                .collect(),
+        )
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        // TODO: binary search
+        if let Some(pos) = self.0.iter().position(|(len, _prod)| *len > index) {
+            let mut lhs = self.0;
+            let mut rhs = lhs.split_off(pos);
+
+            let lhs_len = lhs.last().map_or(0, |(len, _prod)| *len);
+
+            let (rhs_len, rhs_prod) = rhs.remove(0); // TODO: deque
+
+            let (lhs_prod, rhs_prod) = rhs_prod.split_at(index - lhs_len);
+
+            lhs.push((index, lhs_prod));
+            rhs.insert(0, (rhs_len - index, rhs_prod)); // TODO: deque
+
+            (Concat(lhs), Concat(rhs))
+        } else {
+            (self, Concat(Vec::new()))
+        }
+    }
+}
+
+impl<I> Iterator for Concat<I>
+where
+    I: Iterator + DoubleEndedIterator + ExactSizeIterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let first = self.0.first_mut()?;
+
+            match first.next() {
+                Some(item) => return Some(item),
+                None => {
+                    self.0.remove(0); // TODO: deque
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<I> DoubleEndedIterator for Concat<I>
+where
+    I: Iterator + DoubleEndedIterator + ExactSizeIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let last = self.0.last_mut()?;
+
+            match last.next_back() {
+                Some(item) => return Some(item),
+                None => {
+                    self.0.pop();
+                }
+            }
+        }
+    }
+}
+
+impl<I> ExactSizeIterator for Concat<I>
+where
+    I: Iterator + DoubleEndedIterator + ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        self.0.iter().map(ExactSizeIterator::len).sum()
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -106,6 +106,7 @@ mod chain;
 mod chunks;
 mod cloned;
 mod collect;
+mod concat;
 mod copied;
 mod empty;
 mod enumerate;
@@ -155,6 +156,7 @@ pub use self::{
     chain::Chain,
     chunks::Chunks,
     cloned::Cloned,
+    concat::{concat, Concat},
     copied::Copied,
     empty::{empty, Empty},
     enumerate::Enumerate,


### PR DESCRIPTION
This is admittedly more of a question than a pull request but I thought that it might be easiest to answer this with the code at hand. I have [a situation](https://github.com/adamreichold/rs-ecs/pull/17) in which I basically want to concatenate a
```rust
Vec<I> where I: IndexedParallelIterator
```
into a single indexed parallel iterator with the same semantics as if I would `.into_iter().flatten()` the vector.

I tried to implement this by looking at the existing `Chain` adapter which however handles a fixed number of inner iterators with possibly heterogeneous types instead of a unknown number of iterators with homogeneous types.

I am currently stuck at trying to collect the producers created by the inner iterators into a vector. This does not seem to work as it seems possible that each invocation of
```
<I as IndexParallelIterator>::with_producer
```
will call the given callback with a different producer type.

Leaving aside the overhead, boxing does not seem possible due to `Producer` not being object safe. I did consider defining a simpler `DynProducer` trait that would be, but I think this would end with
```rust
trait IntoIter<T>: Iterator<Item = T> + DoubleEndedIterator + ExactSizeIterator;
type IntoIter = Box<dyn IntoIter<Self::Item>>;
```
which feels prohibitively expensive.

I also considered building a producer out of a list of iterators each recording a list of split positions and only turn this into producers and split those when e.g. `Producer::into_iter` is actually called. But does seem to imply at least sharing (and hence synchronizing) the original list between tasks if a split happens to saddle the boundary between two of original iterators. Also, I am not sure if this would avoid the issue of different producer types eventually.

Does anybody know whether this is possible at all and if so how?