### PR TITLE
Added A `par_chunk_by` method

### DIFF
--- a/src/slice/chunk_by.rs
+++ b/src/slice/chunk_by.rs
@@ -70,6 +70,15 @@ pub struct ChunkBy<'data, T, P> {
     slice: &'data [T],
 }
 
+impl<'data, T, P: Clone> Clone for ChunkBy<'data, T, P> {
+    fn clone(&self) -> Self {
+        ChunkBy {
+            pred: self.pred.clone(),
+            slice: self.slice,
+        }
+    }
+}
+
 impl<'data, T: fmt::Debug, P> fmt::Debug for ChunkBy<'data, T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChunkBy")

--- a/src/slice/chunk_by.rs
+++ b/src/slice/chunk_by.rs
@@ -65,20 +65,12 @@ where
 ///
 /// [`par_chunk_by`]: trait.ParallelSlice.html#method.par_chunk_by
 #[derive(Debug)]
-pub struct ChunkBy<'data, T, P>
-where
-    T: Sync,
-    P: Fn(&T, &T) -> bool + Send + Sync,
-{
+pub struct ChunkBy<'data, T, P> {
     pred: P,
     slice: &'data [T],
 }
 
-impl<'data, T, P> ChunkBy<'data, T, P>
-where
-    T: Sync,
-    P: Fn(&T, &T) -> bool + Send + Sync,
-{
+impl<'data, T, P> ChunkBy<'data, T, P> {
     pub(super) fn new(slice: &'data [T], pred: P) -> Self {
         Self { pred, slice }
     }
@@ -153,20 +145,12 @@ where
 ///
 /// [`par_chunk_by_mut`]: trait.ParallelSliceMut.html#method.par_chunk_by_mut
 #[derive(Debug)]
-pub struct ChunkByMut<'data, T, P>
-where
-    T: Send,
-    P: Fn(&T, &T) -> bool + Send + Sync,
-{
+pub struct ChunkByMut<'data, T, P> {
     pred: P,
     slice: &'data mut [T],
 }
 
-impl<'data, T, P> ChunkByMut<'data, T, P>
-where
-    T: Send,
-    P: Fn(&T, &T) -> bool + Send + Sync,
-{
+impl<'data, T, P> ChunkByMut<'data, T, P> {
     pub(super) fn new(slice: &'data mut [T], pred: P) -> Self {
         Self { pred, slice }
     }

--- a/src/slice/chunk_by.rs
+++ b/src/slice/chunk_by.rs
@@ -1,5 +1,6 @@
 use crate::iter::plumbing::*;
 use crate::iter::*;
+use std::fmt;
 
 fn find_index<T, P>(xs: &[T], pred: &P) -> Option<usize>
 where
@@ -64,10 +65,17 @@ where
 /// This struct is created by the [`par_chunk_by`] method on `&[T]`.
 ///
 /// [`par_chunk_by`]: trait.ParallelSlice.html#method.par_chunk_by
-#[derive(Debug)]
 pub struct ChunkBy<'data, T, P> {
     pred: P,
     slice: &'data [T],
+}
+
+impl<'data, T: fmt::Debug, P> fmt::Debug for ChunkBy<'data, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChunkBy")
+            .field("slice", &self.slice)
+            .finish()
+    }
 }
 
 impl<'data, T, P> ChunkBy<'data, T, P> {
@@ -144,10 +152,17 @@ where
 /// This struct is created by the [`par_chunk_by_mut`] method on `&mut [T]`.
 ///
 /// [`par_chunk_by_mut`]: trait.ParallelSliceMut.html#method.par_chunk_by_mut
-#[derive(Debug)]
 pub struct ChunkByMut<'data, T, P> {
     pred: P,
     slice: &'data mut [T],
+}
+
+impl<'data, T: fmt::Debug, P> fmt::Debug for ChunkByMut<'data, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChunkByMut")
+            .field("slice", &self.slice)
+            .finish()
+    }
 }
 
 impl<'data, T, P> ChunkByMut<'data, T, P> {

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -104,7 +104,7 @@ where
     }
 }
 
-// Mutable 
+// Mutable
 
 struct GroupByMutProducer<'data, 'p, T, P> {
     pred: &'p P,

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -7,37 +7,13 @@ where
 {
     let n = xs.len() / 2;
 
-    for (start, end) in (0..).scan(true, |cont, i| {
-        if *cont {
-            let offset = 2 * i;
-            let start = n.saturating_sub(offset);
-            let end = n + offset;
-            Some(
-                if !(1..xs.len()).contains(&start) || !(2..xs.len()).contains(&end) {
-                    *cont = false;
-                    (0, xs.len())
-                } else {
-                    (start, end)
-                },
-            )
-        } else {
-            None
-        }
-    }) {
-        match xs[start..end]
-            .windows(2)
-            .enumerate()
-            .find_map(|(i, win)| {
-                if pred(&win[0], &win[1]) {
-                    None
-                } else {
-                    Some(i)
-                }
-            })
-            .map(|i| start + i)
-        {
-            Some(i) => return Some(i),
-            None => {}
+    for m in (1..((n / 2) + 1)).map(|x| 2 * x) {
+        let start = n.saturating_sub(m);
+        let end = std::cmp::min(n + m, xs.len());
+        for i in start..(end - 1) {
+            if !pred(&xs[i], &xs[i + 1]) {
+                return Some(start + i);
+            }
         }
     }
     None
@@ -58,7 +34,7 @@ where
     fn split(self) -> (Self, Option<Self>) {
         match find_index(self.slice, self.pred) {
             Some(i) => {
-                let (ys, zs) = self.slice.split_at(i + 1);
+                let (ys, zs) = self.slice.split_at(i);
                 (
                     Self {
                         pred: self.pred,
@@ -120,6 +96,94 @@ where
     {
         bridge_unindexed(
             GroupByProducer {
+                pred: &self.pred,
+                slice: self.slice,
+            },
+            consumer,
+        )
+    }
+}
+
+// Mutable 
+
+struct GroupByMutProducer<'data, 'p, T, P> {
+    pred: &'p P,
+    slice: &'data mut [T],
+}
+
+impl<'data, 'p, T, P> UnindexedProducer for GroupByMutProducer<'data, 'p, T, P>
+where
+    T: Send,
+    P: Fn(&T, &T) -> bool + Send + Sync,
+{
+    type Item = &'data mut [T];
+
+    fn split(self) -> (Self, Option<Self>) {
+        match find_index(self.slice, self.pred) {
+            Some(i) => {
+                let (ys, zs) = self.slice.split_at_mut(i);
+                (
+                    Self {
+                        pred: self.pred,
+                        slice: ys,
+                    },
+                    Some(Self {
+                        pred: self.pred,
+                        slice: zs,
+                    }),
+                )
+            }
+            None => (self, None),
+        }
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+    where
+        F: Folder<Self::Item>,
+    {
+        folder.consume_iter(self.slice.chunk_by_mut(self.pred))
+    }
+}
+
+/// Parallel iterator over slice in (non-overlapping) mutable chunks
+/// separated by a predicate.
+///
+/// This struct is created by the [`group_by_mut`] method on `&[T]`.
+///
+/// [`group_by_mut`]: trait.ParallelSlice.html#method.par_group_by_mut
+#[derive(Debug)]
+pub struct GroupByMut<'data, T, F>
+where
+    T: Send,
+    F: Fn(&T, &T) -> bool + Send + Sync,
+{
+    pred: F,
+    slice: &'data mut [T],
+}
+
+impl<'data, T, F> GroupByMut<'data, T, F>
+where
+    T: Send,
+    F: Fn(&T, &T) -> bool + Send + Sync,
+{
+    pub(super) fn new(slice: &'data mut [T], pred: F) -> Self {
+        Self { pred, slice }
+    }
+}
+
+impl<'data, T, F> ParallelIterator for GroupByMut<'data, T, F>
+where
+    T: Send,
+    F: Fn(&T, &T) -> bool + Send + Sync,
+{
+    type Item = &'data mut [T];
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge_unindexed(
+            GroupByMutProducer {
                 pred: &self.pred,
                 slice: self.slice,
             },

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -1,4 +1,3 @@
-
 use crate::iter::plumbing::*;
 use crate::iter::*;
 
@@ -17,13 +16,11 @@ where
                 if !(1..xs.len()).contains(&start) || !(2..xs.len()).contains(&end) {
                     *cont = false;
                     (0, xs.len())
-                }
-                else {
+                } else {
                     (start, end)
                 },
             )
-        }
-        else {
+        } else {
             None
         }
     }) {
@@ -33,8 +30,7 @@ where
             .find_map(|(i, win)| {
                 if pred(&win[0], &win[1]) {
                     None
-                }
-                else {
+                } else {
                     Some(i)
                 }
             })
@@ -47,8 +43,7 @@ where
     None
 }
 
-struct GroupByProducer<'data, 'p, T, P>
-{
+struct GroupByProducer<'data, 'p, T, P> {
     pred: &'p P,
     slice: &'data [T],
 }
@@ -60,13 +55,20 @@ where
 {
     type Item = &'data [T];
 
-    fn split(self) -> (Self, Option<Self>)
-    {
+    fn split(self) -> (Self, Option<Self>) {
         match find_index(self.slice, self.pred) {
             Some(i) => {
                 let (ys, zs) = self.slice.split_at(i + 1);
-                (Self { pred: self.pred, slice: ys },
-                Some(Self { pred: self.pred, slice: zs }))
+                (
+                    Self {
+                        pred: self.pred,
+                        slice: ys,
+                    },
+                    Some(Self {
+                        pred: self.pred,
+                        slice: zs,
+                    }),
+                )
             }
             None => (self, None),
         }
@@ -89,23 +91,21 @@ where
 pub struct GroupBy<'data, T, F>
 where
     T: Sync,
-    F: Fn(&T, &T) -> bool + Send + Sync
+    F: Fn(&T, &T) -> bool + Send + Sync,
 {
     pred: F,
     slice: &'data [T],
 }
 
-impl<'data, T, F> GroupBy<'data, T, F> 
+impl<'data, T, F> GroupBy<'data, T, F>
 where
     T: Sync,
-    F: Fn(&T, &T) -> bool + Send + Sync
+    F: Fn(&T, &T) -> bool + Send + Sync,
 {
-    pub(super) fn new(slice: &'data [T], pred: F) -> Self
-    {
+    pub(super) fn new(slice: &'data [T], pred: F) -> Self {
         Self { pred, slice }
     }
 }
-
 
 impl<'data, T, F> ParallelIterator for GroupBy<'data, T, F>
 where
@@ -118,7 +118,12 @@ where
     where
         C: UnindexedConsumer<Self::Item>,
     {
-        bridge_unindexed(GroupByProducer { pred: &self.pred, slice: self.slice }, consumer)
+        bridge_unindexed(
+            GroupByProducer {
+                pred: &self.pred,
+                slice: self.slice,
+            },
+            consumer,
+        )
     }
 }
-        

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -150,7 +150,7 @@ where
 ///
 /// This struct is created by the [`group_by_mut`] method on `&[T]`.
 ///
-/// [`group_by_mut`]: trait.ParallelSlice.html#method.par_group_by_mut
+/// [`group_by_mut`]: trait.ParallelSliceMut.html#method.par_group_by_mut
 #[derive(Debug)]
 pub struct GroupByMut<'data, T, F>
 where

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -1,0 +1,124 @@
+
+use crate::iter::plumbing::*;
+use crate::iter::*;
+
+fn find_index<T, F>(xs: &[T], pred: &F) -> Option<usize>
+where
+    F: Fn(&T, &T) -> bool,
+{
+    let n = xs.len() / 2;
+
+    for (start, end) in (0..).scan(true, |cont, i| {
+        if *cont {
+            let offset = 2 * i;
+            let start = n.saturating_sub(offset);
+            let end = n + offset;
+            Some(
+                if !(1..xs.len()).contains(&start) || !(2..xs.len()).contains(&end) {
+                    *cont = false;
+                    (0, xs.len())
+                }
+                else {
+                    (start, end)
+                },
+            )
+        }
+        else {
+            None
+        }
+    }) {
+        match xs[start..end]
+            .windows(2)
+            .enumerate()
+            .find_map(|(i, win)| {
+                if pred(&win[0], &win[1]) {
+                    None
+                }
+                else {
+                    Some(i)
+                }
+            })
+            .map(|i| start + i)
+        {
+            Some(i) => return Some(i),
+            None => {}
+        }
+    }
+    None
+}
+
+struct GroupByProducer<'data, 'p, T, P>
+{
+    pred: &'p P,
+    slice: &'data [T],
+}
+
+impl<'data, 'p, T, P> UnindexedProducer for GroupByProducer<'data, 'p, T, P>
+where
+    T: Sync,
+    P: Fn(&T, &T) -> bool + Send + Sync,
+{
+    type Item = &'data [T];
+
+    fn split(self) -> (Self, Option<Self>)
+    {
+        match find_index(self.slice, self.pred) {
+            Some(i) => {
+                let (ys, zs) = self.slice.split_at(i + 1);
+                (Self { pred: self.pred, slice: ys },
+                Some(Self { pred: self.pred, slice: zs }))
+            }
+            None => (self, None),
+        }
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+    where
+        F: Folder<Self::Item>,
+    {
+        folder.consume_iter(self.slice.chunk_by(self.pred))
+    }
+}
+
+/// Parallel iterator over slice in (non-overlapping) chunks separated by a predicate.
+///
+/// This struct is created by the [`group_by`] method on `&[T]`.
+///
+/// [`group_by`]: trait.ParallelSlice.html#method.par_group_by
+#[derive(Debug)]
+pub struct GroupBy<'data, T, F>
+where
+    T: Sync,
+    F: Fn(&T, &T) -> bool + Send + Sync
+{
+    pred: F,
+    slice: &'data [T],
+}
+
+impl<'data, T, F> GroupBy<'data, T, F> 
+where
+    T: Sync,
+    F: Fn(&T, &T) -> bool + Send + Sync
+{
+    pub(super) fn new(slice: &'data [T], pred: F) -> Self
+    {
+        Self { pred, slice }
+    }
+}
+
+
+impl<'data, T, F> ParallelIterator for GroupBy<'data, T, F>
+where
+    T: Sync,
+    F: Fn(&T, &T) -> bool + Send + Sync,
+{
+    type Item = &'data [T];
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge_unindexed(GroupByProducer { pred: &self.pred, slice: self.slice }, consumer)
+    }
+}
+        

--- a/src/slice/group_by.rs
+++ b/src/slice/group_by.rs
@@ -5,15 +5,16 @@ fn find_index<T, F>(xs: &[T], pred: &F) -> Option<usize>
 where
     F: Fn(&T, &T) -> bool,
 {
-    let n = xs.len() / 2;
+    let n = (xs.len() / 2).saturating_sub(1);
 
     for m in (1..((n / 2) + 1)).map(|x| 2 * x) {
         let start = n.saturating_sub(m);
         let end = std::cmp::min(n + m, xs.len());
-        for i in start..(end - 1) {
-            if !pred(&xs[i], &xs[i + 1]) {
-                return Some(start + i);
-            }
+        let fsts = &xs[start..end];
+        let (_, snds) = fsts.split_first()?;
+        match fsts.iter().zip(snds).position(|(x , y)| !pred(x, y)) {
+            None => (),
+            Some(i) => return Some(start + i + 1),
         }
     }
     None

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -6,10 +6,10 @@
 //! [std::slice]: https://doc.rust-lang.org/stable/std/slice/
 
 mod chunks;
+mod group_by;
 mod mergesort;
 mod quicksort;
 mod rchunks;
-mod group_by;
 
 mod test;
 
@@ -24,8 +24,8 @@ use std::fmt::{self, Debug};
 use std::mem;
 
 pub use self::chunks::{Chunks, ChunksExact, ChunksExactMut, ChunksMut};
-pub use self::rchunks::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 pub use self::group_by::GroupBy;
+pub use self::rchunks::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 
 /// Parallel extensions for slices.
 pub trait ParallelSlice<T: Sync> {

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -109,6 +109,7 @@ fn clone_str() {
 fn clone_vec() {
     let v: Vec<_> = (0..1000).collect();
     check(v.par_iter());
+    check(v.par_chunk_by(i32::eq));
     check(v.par_chunks(42));
     check(v.par_chunks_exact(42));
     check(v.par_rchunks(42));

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -121,6 +121,8 @@ fn debug_vec() {
     let mut v: Vec<_> = (0..10).collect();
     check(v.par_iter());
     check(v.par_iter_mut());
+    check(v.par_chunk_by(i32::eq));
+    check(v.par_chunk_by_mut(i32::eq));
     check(v.par_chunks(42));
     check(v.par_chunks_exact(42));
     check(v.par_chunks_mut(42));


### PR DESCRIPTION
Hello, I found this method useful in my code and thought it could be used here. However it relies on #![feature(slice_group_by)] unstable feature of the rust std library and you would probably want to wait for that method to be stabilized anyways so as to stay consistent with whatever naming they choose. This pull request is here for when that happens. Also if any one has any comments on the code I'd really appreciate hearing them.