### PR TITLE
Add par_sort_by_cached_key

### DIFF
--- a/rayon-demo/src/sort.rs
+++ b/rayon-demo/src/sort.rs
@@ -79,6 +79,17 @@ macro_rules! sort {
     };
 }
 
+macro_rules! sort_keys {
+    ($f:ident, $name:ident, $gen:expr, $len:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let v = $gen($len);
+            b.iter(|| v.clone().$f(ToString::to_string));
+            b.bytes = $len * mem::size_of_val(&$gen(1)[0]) as u64;
+        }
+    };
+}
+
 macro_rules! sort_strings {
     ($f:ident, $name:ident, $gen:expr, $len:expr) => {
         #[bench]
@@ -136,6 +147,13 @@ sort!(par_sort, par_sort_random, gen_random, 50_000);
 sort!(par_sort, par_sort_big, gen_big_random, 50_000);
 sort_strings!(par_sort, par_sort_strings, gen_strings, 50_000);
 sort_expensive!(par_sort_by, par_sort_expensive, gen_random, 50_000);
+sort_keys!(par_sort_by_key, par_sort_by_key, gen_random, 50_000);
+sort_keys!(
+    par_sort_by_cached_key,
+    par_sort_by_cached_key,
+    gen_random,
+    50_000
+);
 
 sort!(
     par_sort_unstable,
@@ -182,6 +200,12 @@ sort_strings!(
 sort_expensive!(
     par_sort_unstable_by,
     par_sort_unstable_expensive,
+    gen_random,
+    50_000
+);
+sort_keys!(
+    par_sort_unstable_by_key,
+    par_sort_unstable_by_key,
     gen_random,
     50_000
 );

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -268,7 +268,7 @@ pub trait ParallelSliceMut<T: Send> {
 
     /// Sorts the slice in parallel.
     ///
-    /// This sort is stable (i.e. does not reorder equal elements) and `O(n log n)` worst-case.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*n* \* log(*n*)) worst-case.
     ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
@@ -308,7 +308,25 @@ pub trait ParallelSliceMut<T: Send> {
 
     /// Sorts the slice in parallel with a comparator function.
     ///
-    /// This sort is stable (i.e. does not reorder equal elements) and `O(n log n)` worst-case.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*n* \* log(*n*)) worst-case.
+    ///
+    /// The comparator function must define a total ordering for the elements in the slice. If
+    /// the ordering is not total, the order of the elements is unspecified. An order is a
+    /// total order if it is (for all `a`, `b` and `c`):
+    ///
+    /// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
+    /// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+    ///
+    /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
+    /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    ///
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.par_sort_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
+    /// ```
     ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
@@ -353,7 +371,8 @@ pub trait ParallelSliceMut<T: Send> {
 
     /// Sorts the slice in parallel with a key extraction function.
     ///
-    /// This sort is stable (i.e. does not reorder equal elements) and `O(n log n)` worst-case.
+    /// This sort is stable (i.e., does not reorder equal elements) and *O*(*m* \* *n* \* log(*n*))
+    /// worst-case, where the key function is *O*(*m*).
     ///
     /// When applicable, unstable sorting is preferred because it is generally faster than stable
     /// sorting and it doesn't allocate auxiliary memory.
@@ -384,27 +403,28 @@ pub trait ParallelSliceMut<T: Send> {
     /// v.par_sort_by_key(|k| k.abs());
     /// assert_eq!(v, [1, 2, -3, 4, -5]);
     /// ```
-    fn par_sort_by_key<B, F>(&mut self, f: F)
+    fn par_sort_by_key<K, F>(&mut self, f: F)
     where
-        B: Ord,
-        F: Fn(&T) -> B + Sync,
+        K: Ord,
+        F: Fn(&T) -> K + Sync,
     {
         par_mergesort(self.as_parallel_slice_mut(), |a, b| f(a).lt(&f(b)));
     }
 
-    /// Sorts the slice in parallel, but may not preserve the order of equal elements.
+    /// Sorts the slice in parallel, but might not preserve the order of equal elements.
     ///
-    /// This sort is unstable (i.e. may reorder equal elements), in-place (i.e. does not allocate),
-    /// and `O(n log n)` worst-case.
+    /// This sort is unstable (i.e., may reorder equal elements), in-place
+    /// (i.e., does not allocate), and *O*(*n* \* log(*n*)) worst-case.
     ///
     /// # Current implementation
     ///
-    /// The current algorithm is based on Orson Peters' [pattern-defeating quicksort][pdqsort],
-    /// which is a quicksort variant designed to be very fast on certain kinds of patterns,
-    /// sometimes achieving linear time. It is randomized but deterministic, and falls back to
-    /// heapsort on degenerate inputs.
+    /// The current algorithm is based on [pattern-defeating quicksort][pdqsort] by Orson Peters,
+    /// which combines the fast average case of randomized quicksort with the fast worst case of
+    /// heapsort, while achieving linear time on slices with certain patterns. It uses some
+    /// randomization to avoid degenerate cases, but with a fixed seed to always provide
+    /// deterministic behavior.
     ///
-    /// It is generally faster than stable sorting, except in a few special cases, e.g. when the
+    /// It is typically faster than stable sorting, except in a few special cases, e.g., when the
     /// slice consists of several concatenated sorted sequences.
     ///
     /// All quicksorts work in two stages: partitioning into two halves followed by recursive
@@ -430,20 +450,39 @@ pub trait ParallelSliceMut<T: Send> {
         par_quicksort(self.as_parallel_slice_mut(), T::lt);
     }
 
-    /// Sorts the slice in parallel with a comparator function, but may not preserve the order of
+    /// Sorts the slice in parallel with a comparator function, but might not preserve the order of
     /// equal elements.
     ///
-    /// This sort is unstable (i.e. may reorder equal elements), in-place (i.e. does not allocate),
-    /// and `O(n log n)` worst-case.
+    /// This sort is unstable (i.e., may reorder equal elements), in-place
+    /// (i.e., does not allocate), and *O*(*n* \* log(*n*)) worst-case.
+    ///
+    /// The comparator function must define a total ordering for the elements in the slice. If
+    /// the ordering is not total, the order of the elements is unspecified. An order is a
+    /// total order if it is (for all `a`, `b` and `c`):
+    ///
+    /// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
+    /// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+    ///
+    /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
+    /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    ///
+    /// let mut floats = [5f64, 4.0, 1.0, 3.0, 2.0];
+    /// floats.par_sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+    /// assert_eq!(floats, [1.0, 2.0, 3.0, 4.0, 5.0]);
+    /// ```
     ///
     /// # Current implementation
     ///
-    /// The current algorithm is based on Orson Peters' [pattern-defeating quicksort][pdqsort],
-    /// which is a quicksort variant designed to be very fast on certain kinds of patterns,
-    /// sometimes achieving linear time. It is randomized but deterministic, and falls back to
-    /// heapsort on degenerate inputs.
+    /// The current algorithm is based on [pattern-defeating quicksort][pdqsort] by Orson Peters,
+    /// which combines the fast average case of randomized quicksort with the fast worst case of
+    /// heapsort, while achieving linear time on slices with certain patterns. It uses some
+    /// randomization to avoid degenerate cases, but with a fixed seed to always provide
+    /// deterministic behavior.
     ///
-    /// It is generally faster than stable sorting, except in a few special cases, e.g. when the
+    /// It is typically faster than stable sorting, except in a few special cases, e.g., when the
     /// slice consists of several concatenated sorted sequences.
     ///
     /// All quicksorts work in two stages: partitioning into two halves followed by recursive
@@ -474,20 +513,22 @@ pub trait ParallelSliceMut<T: Send> {
         });
     }
 
-    /// Sorts the slice in parallel with a key extraction function, but may not preserve the order
+    /// Sorts the slice in parallel with a key extraction function, but might not preserve the order
     /// of equal elements.
     ///
-    /// This sort is unstable (i.e. may reorder equal elements), in-place (i.e. does not allocate),
-    /// and `O(n log n)` worst-case.
+    /// This sort is unstable (i.e., may reorder equal elements), in-place
+    /// (i.e., does not allocate), and *O*(m \* *n* \* log(*n*)) worst-case,
+    /// where the key function is *O*(*m*).
     ///
     /// # Current implementation
     ///
-    /// The current algorithm is based on Orson Peters' [pattern-defeating quicksort][pdqsort],
-    /// which is a quicksort variant designed to be very fast on certain kinds of patterns,
-    /// sometimes achieving linear time. It is randomized but deterministic, and falls back to
-    /// heapsort on degenerate inputs.
+    /// The current algorithm is based on [pattern-defeating quicksort][pdqsort] by Orson Peters,
+    /// which combines the fast average case of randomized quicksort with the fast worst case of
+    /// heapsort, while achieving linear time on slices with certain patterns. It uses some
+    /// randomization to avoid degenerate cases, but with a fixed seed to always provide
+    /// deterministic behavior.
     ///
-    /// It is generally faster than stable sorting, except in a few special cases, e.g. when the
+    /// It is typically faster than stable sorting, except in a few special cases, e.g., when the
     /// slice consists of several concatenated sorted sequences.
     ///
     /// All quicksorts work in two stages: partitioning into two halves followed by recursive
@@ -506,10 +547,10 @@ pub trait ParallelSliceMut<T: Send> {
     /// v.par_sort_unstable_by_key(|k| k.abs());
     /// assert_eq!(v, [1, 2, -3, 4, -5]);
     /// ```
-    fn par_sort_unstable_by_key<B, F>(&mut self, f: F)
+    fn par_sort_unstable_by_key<K, F>(&mut self, f: F)
     where
-        B: Ord,
-        F: Fn(&T) -> B + Sync,
+        K: Ord,
+        F: Fn(&T) -> K + Sync,
     {
         par_quicksort(self.as_parallel_slice_mut(), |a, b| f(a).lt(&f(b)));
     }


### PR DESCRIPTION
This is a port of the standard library's `slice::sort_by_cached_key` as `ParallelSliceMut::par_sort_by_cached_key`. We can do the initial key-caching indexed `collect` in parallel, and then use `par_sort_unstable` on that, but the final rearrangement on the original slice is still sequential.

The new benchmarks test integers with a `to_string` key, and it looks great on my Ryzen 7 5800X:

```
test sort::par_sort_by_cached_key   ... bench:   3,464,639 ns/iter (+/- 253,378) = 115 MB/s
test sort::par_sort_by_key          ... bench:   6,865,096 ns/iter (+/- 204,145) = 58 MB/s
test sort::par_sort_unstable_by_key ... bench:  13,346,235 ns/iter (+/- 1,966,048) = 29 MB/s
```

While I was in the neighborhood, I also updated documentation changes in the other sorting methods that were ported from the standard library.