### PR TITLE
Rename autocfg probe method to _foo to avoid dead code warning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ fn main() {
     if ac.probe_expression("(0..10).step_by(2).rev()") {
         autocfg::emit("has_step_by_rev");
     }
-    if ac.probe_expression("{ fn foo<const N: usize>() {} }") {
+    if ac.probe_expression("{ fn _foo<const N: usize>() {} }") {
         autocfg::emit("has_min_const_generics");
     }
     if ac.probe_path("std::ops::ControlFlow") {


### PR DESCRIPTION
If rayon is built in a configuration with warnings as error (e.g., `RUSTFLAGS=-Dwarnings`), then the probe will fail even though the compiler does have the necessary const generic support.