### PR TITLE
Fix a use-after-free race in SpinLatch::set, and release 1.9.3

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# Release rayon-core 1.9.3 (2022-05-13)
+
+- Fixed a use-after-free race in job notification.
+
 # Release rayon 1.5.2 / rayon-core 1.9.2 (2022-04-13)
 
 - The new `ParallelSlice::par_rchunks()` and `par_rchunks_exact()` iterate

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -18,7 +18,7 @@ name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -31,7 +31,7 @@ name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -41,15 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "addr2line 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
- "miniz_oxide 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "object 0.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "object 0.28.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -73,7 +73,7 @@ name = "calloop"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -97,7 +97,7 @@ name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ dependencies = [
  "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -134,7 +134,7 @@ dependencies = [
  "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -144,7 +144,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ dependencies = [
  "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -186,7 +186,7 @@ dependencies = [
  "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ dependencies = [
  "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -274,10 +274,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -287,7 +287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -315,7 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -358,7 +358,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -373,7 +373,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -382,7 +382,7 @@ name = "glium"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,7 +408,7 @@ dependencies = [
  "glutin_wgl_sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -463,7 +463,7 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -507,7 +507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -541,12 +541,12 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -554,7 +554,7 @@ name = "memmap2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -572,32 +572,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ntapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows-sys 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -609,24 +598,24 @@ dependencies = [
  "jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ndk-context"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ndk-glue"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk-context 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk-context 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-macro 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -638,9 +627,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -656,7 +645,7 @@ dependencies = [
  "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -665,16 +654,8 @@ name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "minimal-lexical 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -683,11 +664,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -696,35 +677,35 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -734,13 +715,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,7 +733,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -769,9 +750,9 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -784,10 +765,10 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -820,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "instant 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -846,16 +827,16 @@ name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -863,7 +844,7 @@ name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -871,7 +852,7 @@ name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -920,18 +901,18 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.9.2",
- "serde 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.9.3",
+ "serde 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "crossbeam-channel 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,13 +929,13 @@ dependencies = [
  "fixedbitset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glium 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.5.2",
  "regex 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -972,7 +953,7 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -998,20 +979,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1020,7 +1001,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1037,7 +1018,7 @@ dependencies = [
  "calloop 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,12 +1034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1068,33 +1049,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror-impl 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1123,10 +1104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bumpalo 3.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1144,9 +1125,9 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1163,7 +1144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-commons 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1217,7 +1198,7 @@ name = "wayland-scanner"
 version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1261,6 +1242,43 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_i686_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "windows_x86_64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winit"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,11 +1291,11 @@ dependencies = [
  "dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "instant 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndk-glue 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ndk-glue 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1298,7 +1316,7 @@ version = "2.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1322,7 +1340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
 "checksum approx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 "checksum autocfg 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-"checksum backtrace 0.3.64 (registry+https://github.com/rust-lang/crates.io-index)" = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+"checksum backtrace 0.3.65 (registry+https://github.com/rust-lang/crates.io-index)" = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 "checksum bitflags 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 "checksum bumpalo 3.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
@@ -1377,38 +1395,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum js-sys 0.3.57 (registry+https://github.com/rust-lang/crates.io-index)" = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 "checksum khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.123 (registry+https://github.com/rust-lang/crates.io-index)" = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+"checksum libc 0.2.125 (registry+https://github.com/rust-lang/crates.io-index)" = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 "checksum libloading 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 "checksum lock_api 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-"checksum log 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+"checksum log 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+"checksum memchr 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 "checksum memmap2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
 "checksum memoffset 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 "checksum minimal-lexical 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-"checksum miniz_oxide 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-"checksum mio 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
-"checksum miow 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+"checksum miniz_oxide 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+"checksum mio 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 "checksum ndk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
-"checksum ndk-context 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e3c5cc68637e21fe8f077f6a1c9e0b9ca495bb74895226b476310f613325884"
-"checksum ndk-glue 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1c68f70683c5fc9a747a383744206cd371741b2f0b31781ab6770487ec572e2"
+"checksum ndk-context 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+"checksum ndk-glue 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
 "checksum ndk-macro 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
 "checksum ndk-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
 "checksum nix 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 "checksum nom 7.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-"checksum ntapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 "checksum num 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 "checksum num-bigint 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-"checksum num-complex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
-"checksum num-integer 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-"checksum num-iter 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+"checksum num-complex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+"checksum num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)" = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+"checksum num-iter 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 "checksum num-rational 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
-"checksum num-traits 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+"checksum num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 "checksum num_cpus 1.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 "checksum num_enum 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 "checksum num_enum_derive 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 "checksum objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-"checksum object 0.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+"checksum object 0.28.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 "checksum once_cell 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum parking_lot 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
@@ -1417,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 "checksum ppv-lite86 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 "checksum proc-macro-crate 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-"checksum proc-macro2 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+"checksum proc-macro2 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
 "checksum quote 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 "checksum rand 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 "checksum rand_chacha 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -1430,18 +1446,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-"checksum serde 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)" = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
-"checksum serde_derive 1.0.136 (registry+https://github.com/rust-lang/crates.io-index)" = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+"checksum serde 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)" = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+"checksum serde_derive 1.0.137 (registry+https://github.com/rust-lang/crates.io-index)" = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 "checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 "checksum smallvec 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 "checksum smithay-client-toolkit 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
 "checksum strsim 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-"checksum syn 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+"checksum syn 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)" = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 "checksum takeable-option 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
-"checksum thiserror 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
-"checksum thiserror-impl 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
-"checksum toml 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-"checksum unicode-xid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+"checksum thiserror 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+"checksum thiserror-impl 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+"checksum toml 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+"checksum unicode-xid 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 "checksum wasi 0.10.2+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 "checksum wasi 0.11.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 "checksum wasm-bindgen 0.2.80 (registry+https://github.com/rust-lang/crates.io-index)" = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
@@ -1460,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum windows-sys 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+"checksum windows_aarch64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+"checksum windows_i686_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+"checksum windows_i686_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+"checksum windows_x86_64_gnu 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+"checksum windows_x86_64_msvc 0.36.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 "checksum winit 0.26.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 "checksum x11-dl 2.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
 "checksum xcursor 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-core"
-version = "1.9.2" # reminder to update html_root_url attribute
+version = "1.9.3" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon"

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -189,19 +189,21 @@ impl<'r> Latch for SpinLatch<'r> {
     fn set(&self) {
         let cross_registry;
 
-        let registry = if self.cross {
+        let registry: &Registry = if self.cross {
             // Ensure the registry stays alive while we notify it.
             // Otherwise, it would be possible that we set the spin
             // latch and the other thread sees it and exits, causing
             // the registry to be deallocated, all before we get a
             // chance to invoke `registry.notify_worker_latch_is_set`.
             cross_registry = Arc::clone(self.registry);
-            &cross_registry
+            &*cross_registry
         } else {
             // If this is not a "cross-registry" spin-latch, then the
             // thread which is performing `set` is itself ensuring
-            // that the registry stays alive.
-            self.registry
+            // that the registry stays alive. However, that doesn't
+            // include this *particular* `Arc` handle if the waiting
+            // thread then exits, so we must completely dereference it.
+            &**self.registry
         };
         let target_worker_index = self.target_worker_index;
 

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -92,7 +92,7 @@ where
     registry.increment_terminate_count();
 
     Box::new(HeapJob::new({
-        let registry = registry.clone();
+        let registry = Arc::clone(registry);
         move || {
             match unwind::halt_unwinding(func) {
                 Ok(()) => {}

--- a/rayon-core/src/test.rs
+++ b/rayon-core/src/test.rs
@@ -22,8 +22,8 @@ fn start_callback_called() {
     // Wait for all the threads in the pool plus the one running tests.
     let barrier = Arc::new(Barrier::new(n_threads + 1));
 
-    let b = barrier.clone();
-    let nc = n_called.clone();
+    let b = Arc::clone(&barrier);
+    let nc = Arc::clone(&n_called);
     let start_handler = move |_| {
         nc.fetch_add(1, Ordering::SeqCst);
         b.wait();
@@ -48,8 +48,8 @@ fn exit_callback_called() {
     // Wait for all the threads in the pool plus the one running tests.
     let barrier = Arc::new(Barrier::new(n_threads + 1));
 
-    let b = barrier.clone();
-    let nc = n_called.clone();
+    let b = Arc::clone(&barrier);
+    let nc = Arc::clone(&n_called);
     let exit_handler = move |_| {
         nc.fetch_add(1, Ordering::SeqCst);
         b.wait();
@@ -85,9 +85,9 @@ fn handler_panics_handled_correctly() {
         panic!("ensure panic handler is called when exiting");
     };
 
-    let sb = start_barrier.clone();
-    let eb = exit_barrier.clone();
-    let nc = n_called.clone();
+    let sb = Arc::clone(&start_barrier);
+    let eb = Arc::clone(&exit_barrier);
+    let nc = Arc::clone(&n_called);
     let panic_handler = move |_| {
         let val = nc.fetch_add(1, Ordering::SeqCst);
         if val < n_threads {

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -28,7 +28,7 @@ fn workers_stop() {
             // do some work on these threads
             join_a_lot(22);
 
-            thread_pool.registry.clone()
+            Arc::clone(&thread_pool.registry)
         });
         assert_eq!(registry.num_threads(), 22);
     }
@@ -53,7 +53,7 @@ fn sleeper_stop() {
     {
         // once we exit this block, thread-pool will be dropped
         let thread_pool = ThreadPoolBuilder::new().num_threads(22).build().unwrap();
-        registry = thread_pool.registry.clone();
+        registry = Arc::clone(&thread_pool.registry);
 
         // Give time for at least some of the thread pool to fall asleep.
         thread::sleep(time::Duration::from_secs(1));
@@ -67,7 +67,7 @@ fn sleeper_stop() {
 /// Creates a start/exit handler that increments an atomic counter.
 fn count_handler() -> (Arc<AtomicUsize>, impl Fn(usize)) {
     let count = Arc::new(AtomicUsize::new(0));
-    (count.clone(), move |_| {
+    (Arc::clone(&count), move |_| {
         count.fetch_add(1, Ordering::SeqCst);
     })
 }


### PR DESCRIPTION
`SpinLatch<'r>` borrows `&'r Arc<Registry>` from the `WorkerThread` where it is created. When we `set`, we're careful to make sure that the `Registry` remains alive while we do the inner `set` and then `notify_worker_latch_is_set`. We knew from past bugs that the `SpinLatch` could be invalidated between set and notify, but the `&Arc` could also be invalidated if the target thread sees the set *and exits* (dropping its `WorkerThread`) before the notification. That's a fairly long race, but preemption could make that happen.

The inner `Registry` will still be alive, since the current thread is part of that pool, so we can hold that reference directly.

Fixes #913
Fixes #929