### PR TITLE
Convert delegate doctest to unit tests

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -8,15 +8,6 @@
 /// declared with an `inner` field.
 ///
 /// The implementation of `IntoParallelIterator` should be added separately.
-///
-/// # Example
-///
-/// ```
-/// delegate_iterator!{
-///     MyIntoIter<T, U> => (T, U),
-///     impl<T: Ord + Send, U: Send>
-/// }
-/// ```
 macro_rules! delegate_iterator {
     ($iter:ty => $item:ty ,
      impl $( $args:tt )*
@@ -67,4 +58,52 @@ macro_rules! delegate_indexed_iterator {
             }
         }
     }
+}
+
+#[test]
+fn unindexed_example() {
+    use crate::collections::btree_map::IntoIter;
+    use crate::iter::plumbing::*;
+    use crate::prelude::*;
+
+    use std::collections::BTreeMap;
+
+    struct MyIntoIter<T: Ord + Send, U: Send> {
+        inner: IntoIter<T, U>,
+    }
+
+    delegate_iterator! {
+        MyIntoIter<T, U> => (T, U),
+        impl<T: Ord + Send, U: Send>
+    }
+
+    let map = BTreeMap::from([(1, 'a'), (2, 'b'), (3, 'c')]);
+    let iter = MyIntoIter {
+        inner: map.into_par_iter(),
+    };
+    let vec: Vec<_> = iter.map(|(k, _)| k).collect();
+    assert_eq!(vec, &[1, 2, 3]);
+}
+
+#[test]
+fn indexed_example() {
+    use crate::iter::plumbing::*;
+    use crate::prelude::*;
+    use crate::vec::IntoIter;
+
+    struct MyIntoIter<T: Send> {
+        inner: IntoIter<T>,
+    }
+
+    delegate_indexed_iterator! {
+        MyIntoIter<T> => T,
+        impl<T: Send>
+    }
+
+    let iter = MyIntoIter {
+        inner: vec![1, 2, 3].into_par_iter(),
+    };
+    let mut vec = vec![];
+    iter.collect_into_vec(&mut vec);
+    assert_eq!(vec, &[1, 2, 3]);
 }


### PR DESCRIPTION
The documented example wasn't functional, and this broke on nightly since rust-lang/rust#96630.

We can't actually doctest a nonexported macro, but a unit test will do.