### PR TITLE
Revert "Use a single termination latch for the registry"

### DIFF
--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -292,11 +292,10 @@ impl CountLatch {
         }
     }
 
-    /// Increments the latch counter by one and returns the previous value.
     #[inline]
-    pub(super) fn increment(&self) -> usize {
+    pub(super) fn increment(&self) {
         debug_assert!(!self.core_latch.probe());
-        self.counter.fetch_add(1, Ordering::Relaxed)
+        self.counter.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Decrements the latch counter by one. If this is the final
@@ -345,12 +344,10 @@ impl CountLockLatch {
         }
     }
 
-    /// Increments the latch counter by one and returns the previous value.
     #[inline]
-    pub(super) fn increment(&self) -> usize {
+    pub(super) fn increment(&self) {
         let old_counter = self.counter.fetch_add(1, Ordering::Relaxed);
         debug_assert!(old_counter != 0);
-        old_counter
     }
 
     pub(super) fn wait(&self) {

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -699,8 +699,7 @@ impl ScopeLatch {
         }
     }
 
-    /// Increments the latch counter by one and returns the previous value.
-    fn increment(&self) -> usize {
+    fn increment(&self) {
         match self {
             ScopeLatch::Stealing { latch, .. } => latch.increment(),
             ScopeLatch::Blocking { latch } => latch.increment(),


### PR DESCRIPTION
This reverts commit 1dfd5d90e562b2aac0673b1cb611eafdd783701d.

This was a mistake -- multiple threads can't wait on the same latch,
because the inner `CoreLatch` tracks thread-specific sleep state.
