### PR TITLE
Replace `docopt` with `clap`

### DIFF
--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -8,17 +8,13 @@ publish = false
 [dependencies]
 rayon = { path = "../" }
 cgmath = "0.18"
-docopt = "1"
+clap = { version = "3.2.3", features = ["derive"] }
 fixedbitset = "0.4"
 glium = "0.31"
 lazy_static = "1"
 rand = "0.8"
 rand_xorshift = "0.3"
 regex = "1"
-
-[dependencies.serde]
-version = "1.0.85"
-features = ["derive"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/rayon-demo/src/mergesort/mod.rs
+++ b/rayon-demo/src/mergesort/mod.rs
@@ -1,33 +1,15 @@
+use clap::{Parser, Subcommand};
 use rand::distributions::Standard;
 use rand::Rng;
+use std::cmp::max;
+use std::time::Instant;
 
-const USAGE: &str = "
-Usage: mergesort bench [--size N]
-       mergesort --help
-
+const ABOUT: &str = "
 Parallel mergesort: regular sorting with a parallel merge step.
 O(n log n) time; O(n) extra space; critical path is O(log^3 n)
 
 Algorithm described in: https://software.intel.com/en-us/articles/a-parallel-stable-sort-using-c11-for-tbb-cilk-plus-and-openmp
-
-Commands:
-    bench              Run the benchmark in different modes and print the timings.
-
-Options:
-    --size N           Number of 32-bit words to sort [default: 250000000] (1GB)
-    -h, --help         Show this message.
 ";
-
-#[derive(serde::Deserialize)]
-pub struct Args {
-    cmd_bench: bool,
-    flag_size: usize,
-}
-
-use docopt::Docopt;
-
-use std::cmp::max;
-use std::time::Instant;
 
 pub fn merge_sort<T: Ord + Send + Copy>(v: &mut [T]) {
     let n = v.len();
@@ -235,16 +217,33 @@ fn timed_sort<F: FnOnce(&mut [u32])>(n: usize, f: F, name: &str) -> u64 {
     nanos
 }
 
-pub fn main(args: &[String]) {
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|d| d.argv(args).deserialize())
-        .unwrap_or_else(|e| e.exit());
+#[derive(Subcommand)]
+enum Commands {
+    /// Run the benchmark in different modes and print the timings
+    Bench,
+}
 
-    if args.cmd_bench {
-        let seq = timed_sort(args.flag_size, seq_merge_sort, "seq");
-        let par = timed_sort(args.flag_size, merge_sort, "par");
-        let speedup = seq as f64 / par as f64;
-        println!("speedup: {:.2}x", speedup);
+#[derive(Parser)]
+#[clap(about = ABOUT)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Number of 32-bit words to sort
+    #[clap(long, default_value_t = 250000000)]
+    size: usize,
+}
+
+pub fn main(args: &[String]) {
+    let args: Args = Parser::parse_from(args);
+
+    match args.command {
+        Commands::Bench => {
+            let seq = timed_sort(args.size, seq_merge_sort, "seq");
+            let par = timed_sort(args.size, merge_sort, "par");
+            let speedup = seq as f64 / par as f64;
+            println!("speedup: {:.2}x", speedup);
+        }
     }
 }
 

--- a/rayon-demo/src/noop/mod.rs
+++ b/rayon-demo/src/noop/mod.rs
@@ -1,36 +1,31 @@
-const USAGE: &str = "
-Usage: noop [--sleep N] [--iters N]
-
-Noop loop to measure CPU usage. See rayon-rs/rayon#642.
-
-Options:
-    --sleep N       How long to sleep (in millis) between doing a spawn. [default: 10]
-    --iters N        Total time to execution (in millis). [default: 100]
-";
-
 use crate::cpu_time;
-use docopt::Docopt;
+use clap::Parser;
 
-#[derive(serde::Deserialize)]
+#[derive(Parser)]
+#[clap(
+    author,
+    version,
+    about = "Noop loop to measure CPU usage. See rayon-rs/rayon#642."
+)]
 pub struct Args {
-    flag_sleep: u64,
-    flag_iters: u64,
+    /// How long to sleep (in millis) between doing a spawn.
+    #[clap(long, default_value_t = 10)]
+    sleep: u64,
+
+    /// Total time to execution (in millis).
+    #[clap(long, default_value_t = 100)]
+    iters: u64,
 }
 
 pub fn main(args: &[String]) {
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|d| d.argv(args).deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let args: Args = Parser::parse_from(args);
 
     let m = cpu_time::measure_cpu(|| {
-        for _ in 1..args.flag_iters {
-            std::thread::sleep(std::time::Duration::from_millis(args.flag_sleep));
+        for _ in 1..args.iters {
+            std::thread::sleep(std::time::Duration::from_millis(args.sleep));
             rayon::spawn(move || {});
         }
     });
-    println!(
-        "noop --iters={} --sleep={}",
-        args.flag_iters, args.flag_sleep
-    );
+    println!("noop --iters={} --sleep={}", args.iters, args.sleep);
     cpu_time::print_time(m);
 }


### PR DESCRIPTION
This PR replaces `docopt` with `clap`.

Something similar was worked on in #737, but now `clap` includes the the derive macros that `structopt` had.

This also makes it possible to remove the `serde` dependency.