### PR TITLE
Attribute invalid input assertions to callers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,11 @@ on:
 jobs:
 
   check:
-    name: Check (1.36.0)
+    name: Check (1.46.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.36.0
+      - uses: dtolnay/rust-toolchain@1.46.0
       - run: cp ci/compat-Cargo.lock ./Cargo.lock
       - run: cargo check --verbose --locked
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,11 +8,11 @@ env:
 jobs:
 
   check:
-    name: Check (1.36.0)
+    name: Check (1.46.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.36.0
+      - uses: dtolnay/rust-toolchain@1.46.0
       - run: cp ci/compat-Cargo.lock ./Cargo.lock
       - run: cargo check --verbose --locked
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Rayon crate](https://img.shields.io/crates/v/rayon.svg)](https://crates.io/crates/rayon)
 [![Rayon documentation](https://docs.rs/rayon/badge.svg)](https://docs.rs/rayon)
-![minimum rustc 1.36](https://img.shields.io/badge/rustc-1.36+-red.svg)
+![minimum rustc 1.46](https://img.shields.io/badge/rustc-1.46+-red.svg)
 [![build status](https://github.com/rayon-rs/rayon/workflows/master/badge.svg)](https://github.com/rayon-rs/rayon/actions)
 [![Join the chat at https://gitter.im/rayon-rs/Lobby](https://badges.gitter.im/rayon-rs/Lobby.svg)](https://gitter.im/rayon-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -84,7 +84,7 @@ just add:
 use rayon::prelude::*;
 ```
 
-Rayon currently requires `rustc 1.36.0` or greater.
+Rayon currently requires `rustc 1.46.0` or greater.
 
 ### Usage with WebAssembly
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-  "Check (1.36.0)",
+  "Check (1.46.0)",
   "Test (ubuntu-latest, stable)",
   "Test (ubuntu-latest, stable-i686)",
   "Test (ubuntu-latest, beta)",

--- a/rayon-core/README.md
+++ b/rayon-core/README.md
@@ -8,4 +8,4 @@ Please see [Rayon Docs] for details about using Rayon.
 
 [Rayon Docs]: https://docs.rs/rayon/
 
-Rayon-core currently requires `rustc 1.36.0` or greater.
+Rayon-core currently requires `rustc 1.46.0` or greater.

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2348,7 +2348,11 @@ pub trait IndexedParallelIterator: ParallelIterator {
         Z::Iter: IndexedParallelIterator,
     {
         let zip_op_iter = zip_op.into_par_iter();
-        assert_eq!(self.len(), zip_op_iter.len(), "iterators must have the same length");
+        assert_eq!(
+            self.len(),
+            zip_op_iter.len(),
+            "iterators must have the same length"
+        );
         ZipEq::new(self, zip_op_iter)
     }
 

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2341,13 +2341,14 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// // we should never get here
     /// assert_eq!(1, zipped.len());
     /// ```
+    #[track_caller]
     fn zip_eq<Z>(self, zip_op: Z) -> ZipEq<Self, Z::Iter>
     where
         Z: IntoParallelIterator,
         Z::Iter: IndexedParallelIterator,
     {
         let zip_op_iter = zip_op.into_par_iter();
-        assert_eq!(self.len(), zip_op_iter.len());
+        assert_eq!(self.len(), zip_op_iter.len(), "iterators must have the same length");
         ZipEq::new(self, zip_op_iter)
     }
 

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -85,6 +85,7 @@ pub trait ParallelSlice<T: Sync> {
     /// let chunks: Vec<_> = [1, 2, 3, 4, 5].par_chunks(2).collect();
     /// assert_eq!(chunks, vec![&[1, 2][..], &[3, 4], &[5]]);
     /// ```
+    #[track_caller]
     fn par_chunks(&self, chunk_size: usize) -> Chunks<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         Chunks::new(chunk_size, self.as_parallel_slice())
@@ -104,6 +105,7 @@ pub trait ParallelSlice<T: Sync> {
     /// let chunks: Vec<_> = [1, 2, 3, 4, 5].par_chunks_exact(2).collect();
     /// assert_eq!(chunks, vec![&[1, 2][..], &[3, 4]]);
     /// ```
+    #[track_caller]
     fn par_chunks_exact(&self, chunk_size: usize) -> ChunksExact<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         ChunksExact::new(chunk_size, self.as_parallel_slice())
@@ -123,6 +125,7 @@ pub trait ParallelSlice<T: Sync> {
     /// let chunks: Vec<_> = [1, 2, 3, 4, 5].par_rchunks(2).collect();
     /// assert_eq!(chunks, vec![&[4, 5][..], &[2, 3], &[1]]);
     /// ```
+    #[track_caller]
     fn par_rchunks(&self, chunk_size: usize) -> RChunks<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         RChunks::new(chunk_size, self.as_parallel_slice())
@@ -142,6 +145,7 @@ pub trait ParallelSlice<T: Sync> {
     /// let chunks: Vec<_> = [1, 2, 3, 4, 5].par_rchunks_exact(2).collect();
     /// assert_eq!(chunks, vec![&[4, 5][..], &[2, 3]]);
     /// ```
+    #[track_caller]
     fn par_rchunks_exact(&self, chunk_size: usize) -> RChunksExact<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         RChunksExact::new(chunk_size, self.as_parallel_slice())
@@ -199,6 +203,7 @@ pub trait ParallelSliceMut<T: Send> {
     ///      .for_each(|slice| slice.reverse());
     /// assert_eq!(array, [2, 1, 4, 3, 5]);
     /// ```
+    #[track_caller]
     fn par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         ChunksMut::new(chunk_size, self.as_parallel_slice_mut())
@@ -220,6 +225,7 @@ pub trait ParallelSliceMut<T: Send> {
     ///      .for_each(|slice| slice.reverse());
     /// assert_eq!(array, [3, 2, 1, 4, 5]);
     /// ```
+    #[track_caller]
     fn par_chunks_exact_mut(&mut self, chunk_size: usize) -> ChunksExactMut<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         ChunksExactMut::new(chunk_size, self.as_parallel_slice_mut())
@@ -241,6 +247,7 @@ pub trait ParallelSliceMut<T: Send> {
     ///      .for_each(|slice| slice.reverse());
     /// assert_eq!(array, [1, 3, 2, 5, 4]);
     /// ```
+    #[track_caller]
     fn par_rchunks_mut(&mut self, chunk_size: usize) -> RChunksMut<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         RChunksMut::new(chunk_size, self.as_parallel_slice_mut())
@@ -262,6 +269,7 @@ pub trait ParallelSliceMut<T: Send> {
     ///      .for_each(|slice| slice.reverse());
     /// assert_eq!(array, [1, 2, 5, 4, 3]);
     /// ```
+    #[track_caller]
     fn par_rchunks_exact_mut(&mut self, chunk_size: usize) -> RChunksExactMut<'_, T> {
         assert!(chunk_size != 0, "chunk_size must not be zero");
         RChunksExactMut::new(chunk_size, self.as_parallel_slice_mut())


### PR DESCRIPTION
`#[track_caller]` makes assert location point to the caller of the function. This helps users find which of their calls provided the invalid inputs.