### PR TITLE
Fix typos

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -560,7 +560,7 @@ impl<S> ThreadPoolBuilder<S> {
     /// to true, however, workers will prefer to execute in a
     /// *breadth-first* fashion -- that is, they will search for jobs at
     /// the *bottom* of their local deque. (At present, workers *always*
-    /// steal from the bottom of other worker's deques, regardless of
+    /// steal from the bottom of other workers' deques, regardless of
     /// the setting of this flag.)
     ///
     /// If you think of the tasks as a tree, where a parent task

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -159,7 +159,7 @@ impl Sleep {
         debug_assert!(!*is_blocked);
 
         // Our latch was signalled. We should wake back up fully as we
-        // wil have some stuff to do.
+        // will have some stuff to do.
         if !latch.fall_asleep() {
             self.logger.log(|| ThreadSleepInterruptedByLatch {
                 worker: worker_index,

--- a/src/slice/mergesort.rs
+++ b/src/slice/mergesort.rs
@@ -570,7 +570,7 @@ unsafe fn recurse<T, F>(
 
     // After recursive calls finish we'll have to merge chunks `(start, mid)` and `(mid, end)` from
     // `src` into `dest`. If the current invocation has to store the result into `buf`, we'll
-    // merge chunks from `v` into `buf`, and viceversa.
+    // merge chunks from `v` into `buf`, and vice versa.
     //
     // Recursive calls flip `into_buf` at each level of recursion. More concretely, `par_merge`
     // merges chunks from `buf` into `v` at the first level, from `v` into `buf` at the second


### PR DESCRIPTION
Found via `codespell -L crate,fromt,deques`