### PR TITLE
Fix tiny typo in licensing section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,5 @@ See [the Rayon FAQ][faq].
 
 Rayon is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0). See [LICENSE-APACHE](LICENSE-APACHE) and
-[LICENSE-MIT](LICENSE-MIT) for details. Opening a pull requests is
+[LICENSE-MIT](LICENSE-MIT) for details. Opening a pull request is
 assumed to signal agreement with these licensing terms.


### PR DESCRIPTION
Right now it says: 
_"Opening a pull requests is assumed to signal agreement with these licensing terms."_ 

It should probably instead say one of the two below:

- _"Opening a pull REQUEST is assumed to signal agreement with these licensing terms."_
- _"The opening of pull requests is assumed to signal agreement with these licensing terms."_