### PR TITLE
par_bridge: use naive locking of the Iterator

### DIFF
--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,9 +1,9 @@
 use std::sync::Mutex;
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use crate::current_num_threads;
 use crate::iter::plumbing::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};
 use crate::iter::ParallelIterator;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Conversion trait to convert an `Iterator` to a `ParallelIterator`.
 ///
@@ -155,8 +155,7 @@ where
                     self.done.store(true, Ordering::SeqCst);
                     return folder;
                 }
-            }
-            else {
+            } else {
                 // any panics from other threads will have been caught by the pool,
                 // and will be re-thrown when joined - just exit
                 self.done.store(true, Ordering::SeqCst);

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -148,6 +148,9 @@ where
                 if let Some(it) = iter.next() {
                     drop(iter);
                     folder = folder.consume(it);
+                    if folder.full() {
+                        return folder;
+                    }
                 } else {
                     self.done.store(true, Ordering::SeqCst);
                     return folder;

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,9 +1,9 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use crate::current_num_threads;
 use crate::iter::plumbing::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};
 use crate::iter::ParallelIterator;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Conversion trait to convert an `Iterator` to a `ParallelIterator`.
 ///
@@ -118,7 +118,7 @@ where
         let mut count = self.split_count.load(Ordering::SeqCst);
 
         loop {
-            // Check if the iterator is exhausted *and* we've consumed every item from it.
+            // Check if the iterator is exhausted
             let done = self.done.load(Ordering::SeqCst);
             match count.checked_sub(1) {
                 Some(new_count) if !done => {

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -78,7 +78,7 @@ where
         let split_count = AtomicUsize::new(current_num_threads());
 
         let done = AtomicBool::new(false);
-        let iter = Mutex::new(self.iter);
+        let iter = Mutex::new(self.iter.fuse());
 
         bridge_unindexed(
             IterParallelProducer {
@@ -94,7 +94,7 @@ where
 struct IterParallelProducer<'a, Iter: Iterator> {
     split_count: &'a AtomicUsize,
     done: &'a AtomicBool,
-    iter: &'a Mutex<Iter>,
+    iter: &'a Mutex<std::iter::Fuse<Iter>>,
 }
 
 // manual clone because T doesn't need to be Clone, but the derive assumes it should be


### PR DESCRIPTION
Fix issue #795

instead of using crossbeam_deque, just lock the Iterator and get the next item, naively. The original code would spin until more data became available, which would cause par_bridge to not be useful in cases where the source Iterator did slow IO or was computationally costly in itself.

This causes there to be virtually no change in runtime in many cases, but in cases where there are a lot CPUs and even slightly slower IO, significantly less runtime.

In pretty much every case, total CPU time was much lower.

I ran the below test program on a 1.5GiB file from a fast SSD and on a machine with 64 cores and mean runtime went from 44s to 30s. In fact, according to hyperfine, average runtime with this patch was lower than _minimum_ runtime without (25s and 41s, respectively). But more importantly, total CPU time was almost 10x less with this patch.

I'm not sure what realistic usage patterns could be worse with this patch and therefor I'd love to hear other opinions.

I wrote a basic test program:

```
use std::io::{BufReader,BufRead};
use rayon::prelude::*;
use std::sync::atomic::{Ordering,AtomicUsize};
use std::os::unix::io::FromRawFd;

fn main() {
  let counter = AtomicUsize::new(0);
  let stdin = BufReader::new(unsafe { std::fs::File::from_raw_fd(0) });

  stdin.lines().par_bridge()
    .for_each( |row| {
      let row = row.unwrap();
      for _ in 0 .. 1000
      {
        let c = row.len();
        counter.fetch_add(c, Ordering::Relaxed);
      }
    }
  );

  println!("{}", counter.load(Ordering::Relaxed));
}
```

Which directly wastes some CPU time (`for _ in 0 .. 1000`). The unsafe is necessary to make the input stream Send. I feed this program a multigigabyte file as part of a test. Once over a relatively slow network and once off an SSD.