### PR TITLE
Add `ParallelIterator::take_any_while` and `skip_any_while`

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2279,6 +2279,25 @@ pub trait ParallelIterator: Sized + Send {
     /// assert!(result.len() <= 50);
     /// assert!(result.windows(2).all(|w| w[0] < w[1]));
     /// ```
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// use std::sync::atomic::AtomicUsize;
+    /// use std::sync::atomic::Ordering::Relaxed;
+    ///
+    /// // Collect any group of items that sum <= 1000
+    /// let quota = AtomicUsize::new(1000);
+    /// let result: Vec<_> = (0_usize..100)
+    ///     .into_par_iter()
+    ///     .take_any_while(|&x| {
+    ///         quota.fetch_update(Relaxed, Relaxed, |q| q.checked_sub(x))
+    ///             .is_ok()
+    ///     })
+    ///     .collect();
+    ///
+    /// let sum = result.iter().sum::<usize>();
+    /// assert!(matches!(sum, 902..=1000));
+    /// ```
     fn take_any_while<P>(self, predicate: P) -> TakeAnyWhile<Self, P>
     where
         P: Fn(&Self::Item) -> bool + Sync + Send,

--- a/src/iter/skip_any_while.rs
+++ b/src/iter/skip_any_while.rs
@@ -1,0 +1,166 @@
+use super::plumbing::*;
+use super::*;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// `SkipAnyWhile` is an iterator that skips over elements from anywhere in `I`
+/// until the callback returns `false`.
+/// This struct is created by the [`skip_any_while()`] method on [`ParallelIterator`]
+///
+/// [`skip_any_while()`]: trait.ParallelIterator.html#method.skip_any_while
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct SkipAnyWhile<I: ParallelIterator, P> {
+    base: I,
+    predicate: P,
+}
+
+impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for SkipAnyWhile<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SkipAnyWhile")
+            .field("base", &self.base)
+            .finish()
+    }
+}
+
+impl<I, P> SkipAnyWhile<I, P>
+where
+    I: ParallelIterator,
+{
+    /// Creates a new `SkipAnyWhile` iterator.
+    pub(super) fn new(base: I, predicate: P) -> Self {
+        SkipAnyWhile { base, predicate }
+    }
+}
+
+impl<I, P> ParallelIterator for SkipAnyWhile<I, P>
+where
+    I: ParallelIterator,
+    P: Fn(&I::Item) -> bool + Sync + Send,
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        let consumer1 = SkipAnyWhileConsumer {
+            base: consumer,
+            predicate: &self.predicate,
+            skipping: &AtomicBool::new(true),
+        };
+        self.base.drive_unindexed(consumer1)
+    }
+}
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
+
+struct SkipAnyWhileConsumer<'p, C, P> {
+    base: C,
+    predicate: &'p P,
+    skipping: &'p AtomicBool,
+}
+
+impl<'p, T, C, P> Consumer<T> for SkipAnyWhileConsumer<'p, C, P>
+where
+    C: Consumer<T>,
+    P: Fn(&T) -> bool + Sync,
+{
+    type Folder = SkipAnyWhileFolder<'p, C::Folder, P>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (
+            SkipAnyWhileConsumer { base: left, ..self },
+            SkipAnyWhileConsumer {
+                base: right,
+                ..self
+            },
+            reducer,
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        SkipAnyWhileFolder {
+            base: self.base.into_folder(),
+            predicate: self.predicate,
+            skipping: self.skipping,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+impl<'p, T, C, P> UnindexedConsumer<T> for SkipAnyWhileConsumer<'p, C, P>
+where
+    C: UnindexedConsumer<T>,
+    P: Fn(&T) -> bool + Sync,
+{
+    fn split_off_left(&self) -> Self {
+        SkipAnyWhileConsumer {
+            base: self.base.split_off_left(),
+            ..*self
+        }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct SkipAnyWhileFolder<'p, C, P> {
+    base: C,
+    predicate: &'p P,
+    skipping: &'p AtomicBool,
+}
+
+fn skip<T>(item: &T, skipping: &AtomicBool, predicate: &impl Fn(&T) -> bool) -> bool {
+    if !skipping.load(Ordering::Relaxed) {
+        return false;
+    }
+    if predicate(item) {
+        return true;
+    }
+    skipping.store(false, Ordering::Relaxed);
+    false
+}
+
+impl<'p, T, C, P> Folder<T> for SkipAnyWhileFolder<'p, C, P>
+where
+    C: Folder<T>,
+    P: Fn(&T) -> bool + 'p,
+{
+    type Result = C::Result;
+
+    fn consume(mut self, item: T) -> Self {
+        if !skip(&item, self.skipping, self.predicate) {
+            self.base = self.base.consume(item);
+        }
+        self
+    }
+
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.base = self.base.consume_iter(
+            iter.into_iter()
+                .skip_while(move |x| skip(x, self.skipping, self.predicate)),
+        );
+        self
+    }
+
+    fn complete(self) -> C::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}

--- a/src/iter/take_any_while.rs
+++ b/src/iter/take_any_while.rs
@@ -1,0 +1,166 @@
+use super::plumbing::*;
+use super::*;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// `TakeAnyWhile` is an iterator that iterates over elements from anywhere in `I`
+/// until the callback returns `false`.
+/// This struct is created by the [`take_any_while()`] method on [`ParallelIterator`]
+///
+/// [`take_any_while()`]: trait.ParallelIterator.html#method.take_any_while
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Clone)]
+pub struct TakeAnyWhile<I: ParallelIterator, P> {
+    base: I,
+    predicate: P,
+}
+
+impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for TakeAnyWhile<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TakeAnyWhile")
+            .field("base", &self.base)
+            .finish()
+    }
+}
+
+impl<I, P> TakeAnyWhile<I, P>
+where
+    I: ParallelIterator,
+{
+    /// Creates a new `TakeAnyWhile` iterator.
+    pub(super) fn new(base: I, predicate: P) -> Self {
+        TakeAnyWhile { base, predicate }
+    }
+}
+
+impl<I, P> ParallelIterator for TakeAnyWhile<I, P>
+where
+    I: ParallelIterator,
+    P: Fn(&I::Item) -> bool + Sync + Send,
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        let consumer1 = TakeAnyWhileConsumer {
+            base: consumer,
+            predicate: &self.predicate,
+            taking: &AtomicBool::new(true),
+        };
+        self.base.drive_unindexed(consumer1)
+    }
+}
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
+
+struct TakeAnyWhileConsumer<'p, C, P> {
+    base: C,
+    predicate: &'p P,
+    taking: &'p AtomicBool,
+}
+
+impl<'p, T, C, P> Consumer<T> for TakeAnyWhileConsumer<'p, C, P>
+where
+    C: Consumer<T>,
+    P: Fn(&T) -> bool + Sync,
+{
+    type Folder = TakeAnyWhileFolder<'p, C::Folder, P>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (
+            TakeAnyWhileConsumer { base: left, ..self },
+            TakeAnyWhileConsumer {
+                base: right,
+                ..self
+            },
+            reducer,
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        TakeAnyWhileFolder {
+            base: self.base.into_folder(),
+            predicate: self.predicate,
+            taking: self.taking,
+        }
+    }
+
+    fn full(&self) -> bool {
+        !self.taking.load(Ordering::Relaxed) || self.base.full()
+    }
+}
+
+impl<'p, T, C, P> UnindexedConsumer<T> for TakeAnyWhileConsumer<'p, C, P>
+where
+    C: UnindexedConsumer<T>,
+    P: Fn(&T) -> bool + Sync,
+{
+    fn split_off_left(&self) -> Self {
+        TakeAnyWhileConsumer {
+            base: self.base.split_off_left(),
+            ..*self
+        }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct TakeAnyWhileFolder<'p, C, P> {
+    base: C,
+    predicate: &'p P,
+    taking: &'p AtomicBool,
+}
+
+fn take<T>(item: &T, taking: &AtomicBool, predicate: &impl Fn(&T) -> bool) -> bool {
+    if !taking.load(Ordering::Relaxed) {
+        return false;
+    }
+    if predicate(item) {
+        return true;
+    }
+    taking.store(false, Ordering::Relaxed);
+    false
+}
+
+impl<'p, T, C, P> Folder<T> for TakeAnyWhileFolder<'p, C, P>
+where
+    C: Folder<T>,
+    P: Fn(&T) -> bool + 'p,
+{
+    type Result = C::Result;
+
+    fn consume(mut self, item: T) -> Self {
+        if take(&item, self.taking, self.predicate) {
+            self.base = self.base.consume(item);
+        }
+        self
+    }
+
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        self.base = self.base.consume_iter(
+            iter.into_iter()
+                .take_while(move |x| take(x, self.taking, self.predicate)),
+        );
+        self
+    }
+
+    fn complete(self) -> C::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        !self.taking.load(Ordering::Relaxed) || self.base.full()
+    }
+}

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -158,7 +158,9 @@ fn clone_adaptors() {
     check(v.par_iter().positions(|_| true));
     check(v.par_iter().rev());
     check(v.par_iter().skip(42));
+    check(v.par_iter().skip_any_while(|_| false));
     check(v.par_iter().take(42));
+    check(v.par_iter().take_any_while(|_| true));
     check(v.par_iter().cloned().while_some());
     check(v.par_iter().with_max_len(1));
     check(v.par_iter().with_min_len(1));

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -173,8 +173,10 @@ fn debug_adaptors() {
     check(v.par_iter().rev());
     check(v.par_iter().skip(1));
     check(v.par_iter().skip_any(1));
+    check(v.par_iter().skip_any_while(|_| false));
     check(v.par_iter().take(1));
     check(v.par_iter().take_any(1));
+    check(v.par_iter().take_any_while(|_| true));
     check(v.par_iter().map(Some).while_some());
     check(v.par_iter().with_max_len(1));
     check(v.par_iter().with_min_len(1));


### PR DESCRIPTION
These are like `Iterator::take_while` and `skip_while`, but the `any`
names emphasize that they're not a straightforward parallelization, as
they does not honor the original iterator order.
