### PR TITLE
Stop deriving traits on JobRef

### DIFF
--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -30,7 +30,6 @@ pub(super) trait Job {
 /// Internally, we store the job's data in a `*const ()` pointer.  The
 /// true type is something like `*const StackJob<...>`, but we hide
 /// it. We also carry the "execute fn" from the `Job` trait.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(super) struct JobRef {
     pointer: *const (),
     execute_fn: unsafe fn(*const ()),
@@ -72,6 +71,17 @@ where
     pub(super) latch: L,
     func: UnsafeCell<Option<F>>,
     result: UnsafeCell<JobResult<R>>,
+}
+
+impl<L, F, R> PartialEq<JobRef> for StackJob<L, F, R>
+where
+    L: Latch + Sync,
+    F: FnOnce(bool) -> R + Send,
+    R: Send,
+{
+    fn eq(&self, job: &JobRef) -> bool {
+        job.pointer == <*const Self>::cast(self) && job.execute_fn == Self::execute
+    }
 }
 
 impl<L, F, R> StackJob<L, F, R>

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -134,8 +134,7 @@ where
         // done here so that the stack frame can keep it all live
         // long enough.
         let job_b = StackJob::new(call_b(oper_b), SpinLatch::new(worker_thread));
-        let job_b_ref = job_b.as_job_ref();
-        worker_thread.push(job_b_ref);
+        worker_thread.push(job_b.as_job_ref());
 
         // Execute task a; hopefully b gets stolen in the meantime.
         let status_a = unwind::halt_unwinding(call_a(oper_a, injected));
@@ -151,7 +150,7 @@ where
         // those off to get to it.
         while !job_b.latch.probe() {
             if let Some(job) = worker_thread.take_local_job() {
-                if job == job_b_ref {
+                if job_b == job {
                     // Found it! Let's run it.
                     //
                     // Note that this could panic, but it's ok if we unwind here.

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -615,7 +615,7 @@ impl<'scope> ScopeFifo<'scope> {
                 // SAFETY: this job will execute before the scope ends.
                 unsafe { worker.push(fifo.push(job_ref)) };
             }
-            None => self.base.registry.inject(&[job_ref]),
+            None => self.base.registry.inject(job_ref),
         }
     }
 

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -154,7 +154,7 @@ where
     // in a locally-FIFO order.  Otherwise, just use the pool's global injector.
     match registry.current_thread() {
         Some(worker) => worker.push_fifo(job_ref),
-        None => registry.inject(&[job_ref]),
+        None => registry.inject(job_ref),
     }
     mem::forget(abort_guard);
 }


### PR DESCRIPTION
I don't see any difference in benchmarks from this, and only a slight reduction in code size. If nothing else I think it's more principled that `JobRef` should not implement `Copy` in particular. `Registry::inject` taking a slice of jobs was an over-abstraction that we never used.