### PR TITLE
Add `yield_now` and `yield_local`

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -38,7 +38,8 @@
 //! there is no other thread to share the work. However, since the pool is not running independent
 //! of the main thread, non-blocking calls like `spawn` may not execute at all, unless a lower-
 //! priority call like `broadcast` gives them an opening. The fallback mode does not try to emulate
-//! anything like thread preemption or `async` task switching.
+//! anything like thread preemption or `async` task switching, but `yield_now` or `yield_local`
+//! can also volunteer execution time.
 //!
 //! Explicit `ThreadPoolBuilder` methods always report their error without any fallback.
 //!
@@ -101,6 +102,7 @@ pub use self::spawn::{spawn, spawn_fifo};
 pub use self::thread_pool::current_thread_has_pending_tasks;
 pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;
+pub use self::thread_pool::{yield_local, yield_now};
 
 use self::registry::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -102,7 +102,7 @@ pub use self::spawn::{spawn, spawn_fifo};
 pub use self::thread_pool::current_thread_has_pending_tasks;
 pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;
-pub use self::thread_pool::{yield_local, yield_now};
+pub use self::thread_pool::{yield_local, yield_now, Yield};
 
 use self::registry::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -6,6 +6,7 @@ use crate::sleep::Sleep;
 use crate::unwind;
 use crate::{
     ErrorKind, ExitHandler, PanicHandler, StartHandler, ThreadPoolBuildError, ThreadPoolBuilder,
+    Yield,
 };
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use std::cell::Cell;
@@ -848,23 +849,23 @@ impl WorkerThread {
             .or_else(|| self.registry.pop_injected_job(self.index))
     }
 
-    pub(super) fn yield_now(&self) -> bool {
+    pub(super) fn yield_now(&self) -> Yield {
         match self.find_work() {
             Some(job) => unsafe {
                 self.execute(job);
-                true
+                Yield::Executed
             },
-            None => false,
+            None => Yield::Idle,
         }
     }
 
-    pub(super) fn yield_local(&self) -> bool {
+    pub(super) fn yield_local(&self) -> Yield {
         match self.take_local_job() {
             Some(job) => unsafe {
                 self.execute(job);
-                true
+                Yield::Executed
             },
-            None => false,
+            None => Yield::Idle,
         }
     }
 

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -343,10 +343,11 @@ impl ThreadPool {
     /// Cooperatively yields execution to Rayon.
     ///
     /// This is similar to the general [`yield_now()`], but only if the current
-    /// thread is part of *this* thread pool. Returns `Some(true)` if anything
-    /// was executed, `Some(false)` if nothing was available, or `None` if the
-    /// current thread is not part of this pool.
-    pub fn yield_now(&self) -> Option<bool> {
+    /// thread is part of *this* thread pool.
+    ///
+    /// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
+    /// nothing was available, or `None` if this thread is not part of any pool at all.
+    pub fn yield_now(&self) -> Option<Yield> {
         let curr = self.registry.current_thread()?;
         Some(curr.yield_now())
     }
@@ -354,10 +355,11 @@ impl ThreadPool {
     /// Cooperatively yields execution to local Rayon work.
     ///
     /// This is similar to the general [`yield_local()`], but only if the current
-    /// thread is part of *this* thread pool. Returns `Some(true)` if anything
-    /// was executed, `Some(false)` if nothing was available, or `None` if the
-    /// current thread is not part of this pool.
-    pub fn yield_local(&self) -> Option<bool> {
+    /// thread is part of *this* thread pool.
+    ///
+    /// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
+    /// nothing was available, or `None` if this thread is not part of any pool at all.
+    pub fn yield_local(&self) -> Option<Yield> {
         let curr = self.registry.current_thread()?;
         Some(curr.yield_local())
     }
@@ -433,9 +435,9 @@ pub fn current_thread_has_pending_tasks() -> Option<bool> {
 /// that call. If you are implementing a polling loop, you may want to also
 /// yield to the OS scheduler yourself if no Rayon work was found.
 ///
-/// Returns `Some(true)` if anything was executed, `Some(false)` if nothing was
-/// available, or `None` if this thread is not part of any pool at all.
-pub fn yield_now() -> Option<bool> {
+/// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
+/// nothing was available, or `None` if this thread is not part of any pool at all.
+pub fn yield_now() -> Option<Yield> {
     unsafe {
         let thread = WorkerThread::current().as_ref()?;
         Some(thread.yield_now())
@@ -450,11 +452,20 @@ pub fn yield_now() -> Option<bool> {
 ///
 /// This is similar to [`yield_now()`], but does not steal from other threads.
 ///
-/// Returns `Some(true)` if anything was executed, `Some(false)` if nothing was
-/// available, or `None` if this thread is not part of any pool at all.
-pub fn yield_local() -> Option<bool> {
+/// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
+/// nothing was available, or `None` if this thread is not part of any pool at all.
+pub fn yield_local() -> Option<Yield> {
     unsafe {
         let thread = WorkerThread::current().as_ref()?;
         Some(thread.yield_local())
     }
+}
+
+/// Result of [`yield_now()`] or [`yield_local()`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Yield {
+    /// Work was found and executed.
+    Executed,
+    /// No available work was found.
+    Idle,
 }

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -346,7 +346,7 @@ impl ThreadPool {
     /// thread is part of *this* thread pool.
     ///
     /// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
-    /// nothing was available, or `None` if this thread is not part of any pool at all.
+    /// nothing was available, or `None` if the current thread is not part this pool.
     pub fn yield_now(&self) -> Option<Yield> {
         let curr = self.registry.current_thread()?;
         Some(curr.yield_now())
@@ -358,7 +358,7 @@ impl ThreadPool {
     /// thread is part of *this* thread pool.
     ///
     /// Returns `Some(Yield::Executed)` if anything was executed, `Some(Yield::Idle)` if
-    /// nothing was available, or `None` if this thread is not part of any pool at all.
+    /// nothing was available, or `None` if the current thread is not part this pool.
     pub fn yield_local(&self) -> Option<Yield> {
         let curr = self.registry.current_thread()?;
         Some(curr.yield_local())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub use rayon_core::{in_place_scope, scope, Scope};
 pub use rayon_core::{in_place_scope_fifo, scope_fifo, ScopeFifo};
 pub use rayon_core::{join, join_context};
 pub use rayon_core::{spawn, spawn_fifo};
+pub use rayon_core::{yield_local, yield_now};
 
 /// We need to transmit raw pointers across threads. It is possible to do this
 /// without any unsafe code by converting pointers to usize or to AtomicPtr<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub use rayon_core::{in_place_scope, scope, Scope};
 pub use rayon_core::{in_place_scope_fifo, scope_fifo, ScopeFifo};
 pub use rayon_core::{join, join_context};
 pub use rayon_core::{spawn, spawn_fifo};
-pub use rayon_core::{yield_local, yield_now};
+pub use rayon_core::{yield_local, yield_now, Yield};
 
 /// We need to transmit raw pointers across threads. It is possible to do this
 /// without any unsafe code by converting pointers to usize or to AtomicPtr<T>


### PR DESCRIPTION
* `yield_now` looks for work anywhere in the thread pool and executes it.
* `yield_local` only looks in the thread-local deque (including broadcasts).

In either case, they return:
* `Some(Yield::Executed)` if work was found and executed.
* `Some(Yield::Idle)` if no work was found in their pool/thread.
* `None` if the current thread is not part of a thread pool.

These do not call `std::thread::yield_now()`, but the docs suggest polling loops might want to add that as a fallback.