### PR TITLE
Be more cautious about drain drops

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -78,7 +78,8 @@ impl<T: Send, const N: usize> IndexedParallelIterator for IntoIter<T, N> {
         unsafe {
             // Drain every item, and then the local array can just fall out of scope.
             let mut array = ManuallyDrop::new(self.array);
-            callback.callback(DrainProducer::new(&mut *array))
+            let producer = DrainProducer::new(array.as_mut_slice());
+            callback.callback(producer)
         }
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -226,8 +226,8 @@ impl<'data, T: 'data + Send> Producer for DrainProducer<'data, T> {
 impl<'data, T: 'data + Send> Drop for DrainProducer<'data, T> {
     fn drop(&mut self) {
         // extract the slice so we can use `Drop for [T]`
-        let slice_ptr = mem::take(&mut self.slice).as_mut_ptr();
-        unsafe { ptr::drop_in_place(slice_ptr) };
+        let slice_ptr: *mut [T] = mem::take::<&'data mut [T]>(&mut self.slice);
+        unsafe { ptr::drop_in_place::<[T]>(slice_ptr) };
     }
 }
 
@@ -277,9 +277,7 @@ impl<'data, T: 'data> iter::FusedIterator for SliceDrain<'data, T> {}
 impl<'data, T: 'data> Drop for SliceDrain<'data, T> {
     fn drop(&mut self) {
         // extract the iterator so we can use `Drop for [T]`
-        let slice_ptr = mem::replace(&mut self.iter, [].iter_mut())
-            .into_slice()
-            .as_mut_ptr();
-        unsafe { ptr::drop_in_place(slice_ptr) };
+        let slice_ptr: *mut [T] = mem::replace(&mut self.iter, [].iter_mut()).into_slice();
+        unsafe { ptr::drop_in_place::<[T]>(slice_ptr) };
     }
 }


### PR DESCRIPTION
This makes a greater effort to ensure that in all cases where either
`DrainProducer` or `SliceDrain` will drop data, there are no references
left pointing to that memory. It's not actually clear that this would be
a problem anyway, as long as there's nothing accessing that zombie data,
but it's not too much trouble to avoid it.

Fixes #1029.
