### PR TITLE
Use cargo's sparse protocol

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,16 @@ on:
       - staging
       - trying
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
 
   check:
     name: Check (1.59.0)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.59.0

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # 00:00 Sunday
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
 
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,7 @@ on: pull_request
 
 # Using 16MB stacks for deep test/debug recursion
 env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_MIN_STACK: 16777216
 
 jobs:
@@ -10,6 +11,8 @@ jobs:
   check:
     name: Check (1.59.0)
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.59.0


### PR DESCRIPTION
Cargo 1.68.0 added a "sparse" protocol, which we can opt into with an environment value.

I also added explicit "git" protocol setting to our MSRV testing -- 1.59 doesn't appear to read it anyway, but it may become relevant once the MSRV is bumped higher.