### PR TITLE
[WIP] Create Scan parallel iterator

### DIFF
--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = "1.17.1"
 rand = "0.8"
 rand_xorshift = "0.3"
 regex = "1"
+ndarray = "0.15.6"
 
 [dependencies.serde]
 version = "1.0.85"

--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -33,6 +33,8 @@ mod sort;
 mod str_split;
 #[cfg(test)]
 mod vec_collect;
+#[cfg(test)]
+mod scan;
 
 #[cfg(test)]
 extern crate test;

--- a/rayon-demo/src/scan/mod.rs
+++ b/rayon-demo/src/scan/mod.rs
@@ -1,0 +1,124 @@
+use ndarray::{Array, Dim};
+use rayon::iter::*;
+use std::time::{Duration, Instant};
+use std::num::Wrapping;
+
+const SIZE: usize = 10000;
+
+enum Procs {
+    Sequential,
+    Parallel,
+}
+
+fn scan_sequential<T, P, I>(init: I, id: T, scan_op: P) -> Vec<T>
+where
+    T: Clone,
+    I: Fn() -> T,
+    P: FnMut(&mut T, &T) -> Option<T>,
+{
+    let v = vec![init(); SIZE];
+    let scan = v.iter().scan(id, scan_op);
+    scan.collect()
+}
+
+fn scan_parallel<T, P, I>(init: I, id: T, scan_op: P) -> Vec<T>
+where
+    T: Clone + Send + Sync,
+    I: Fn() -> T,
+    P: Fn(&T, &T) -> T + Sync,
+{
+    let v = vec![init(); SIZE];
+    let scan = v.into_par_iter().with_min_len(SIZE / 100).scan(&scan_op, id);
+    scan.collect()
+}
+
+/******* Addition with artificial delay *******/
+
+const DELAY: Duration = Duration::from_nanos(10);
+fn wait() -> i32 {
+    let time = Instant::now();
+
+    let mut sum = 0;
+    while time.elapsed() < DELAY {
+        sum += 1;
+    }
+    sum
+}
+
+fn scan_add(procs: Procs) -> Vec<i32> {
+    let init = || 2;
+    let id = 0;
+
+    match procs {
+        Procs::Sequential => {
+            let f = |state: &mut i32, x: &i32| {
+                test::black_box(wait());
+                *state += x;
+                Some(*state)
+            };
+            scan_sequential(init, id, f)
+        }
+        Procs::Parallel => {
+            let f = |x: &i32, y: &i32| {
+                test::black_box(wait());
+                *x + *y
+            };
+            scan_parallel(init, id, f)
+        }
+    }
+}
+
+#[bench]
+fn scan_add_sequential(b: &mut test::Bencher) {
+    b.iter(|| scan_add(Procs::Sequential));
+}
+
+#[bench]
+fn scan_add_parallel(b: &mut test::Bencher) {
+    b.iter(|| scan_add(Procs::Parallel));
+}
+
+#[test]
+fn test_scan_add() {
+    assert_eq!(scan_add(Procs::Sequential), scan_add(Procs::Parallel));
+}
+
+/******** Matrix multiplication with wrapping arithmetic *******/
+
+type Matrix = Array<Wrapping<i32>, Dim<[usize; 2]>>;
+fn scan_matmul(procs: Procs) -> Vec<Matrix> {
+    const MAT_SIZE: usize = 50;
+    let init = || {
+        Array::from_iter((0..((MAT_SIZE * MAT_SIZE) as i32)).map(|x| Wrapping(x)))
+            .into_shape((MAT_SIZE, MAT_SIZE))
+            .unwrap()
+    };
+    let id = Array::eye(MAT_SIZE);
+
+    match procs {
+        Procs::Sequential => {
+            let f = |state: &mut Matrix, x: &Matrix| {
+                *state = state.dot(x);
+                Some(state.clone())
+            };
+
+            scan_sequential(init, id, f)
+        }
+        Procs::Parallel => scan_parallel(init, id, |x, y| x.dot(y)),
+    }
+}
+
+#[bench]
+fn scan_matmul_sequential(b: &mut test::Bencher) {
+    b.iter(|| scan_matmul(Procs::Sequential));
+}
+
+#[bench]
+fn scan_matmul_parallel(b: &mut test::Bencher) {
+    b.iter(|| scan_matmul(Procs::Parallel));
+}
+
+#[test]
+fn test_scan_matmul() {
+    assert_eq!(scan_matmul(Procs::Sequential), scan_matmul(Procs::Parallel));
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -81,6 +81,7 @@
 
 use self::plumbing::*;
 use self::private::Try;
+use self::scan::Scan;
 pub use either::Either;
 use std::cmp::{self, Ordering};
 use std::iter::{Product, Sum};
@@ -157,6 +158,8 @@ mod update;
 mod while_some;
 mod zip;
 mod zip_eq;
+
+mod scan;
 
 pub use self::{
     chain::Chain,
@@ -1382,6 +1385,14 @@ pub trait ParallelIterator: Sized + Send {
         S: Send + Sum<Self::Item> + Sum<S>,
     {
         sum::sum(self)
+    }
+
+    fn scan<F>(self, scan_op: F, id: Self::Item) -> Scan<Self::Item, F>
+    where
+        F: Fn(&Self::Item, &Self::Item) -> Self::Item + Sync + Send,
+        <Self as ParallelIterator>::Item: Send + Sync,
+    {
+        scan::scan(self, scan_op, id)
     }
 
     /// Multiplies all the items in the iterator.

--- a/src/iter/scan.rs
+++ b/src/iter/scan.rs
@@ -1,0 +1,245 @@
+use super::plumbing::*;
+use super::*;
+use std::usize;
+use std::collections::LinkedList;
+
+pub(super) fn scan<PI, P, T>(pi: PI, scan_op: P, id: T) -> Scan<T, P>
+where
+    PI: ParallelIterator<Item = T>,
+    P: Fn(&T, &T) -> T + Send + Sync,
+    T: Send + Sync,
+{
+    let list = scan_p1(pi, &scan_op);
+    let data = list.into_iter().collect();
+    let offsets = compute_offsets(&data, &scan_op, id);
+    Scan::new(data, offsets, scan_op)
+}
+
+// Compute the offset for each chunk by performing another sequential scan
+// on the last value of each chunk
+fn compute_offsets<'a, P, T>(data: &Vec<Vec<T>>, scan_op: &'a P, id: T) -> Vec<T>
+where
+    P: Fn(&T, &T) -> T,
+{
+    let mut offsets: Vec<T> = Vec::with_capacity(data.len());
+    offsets.push(id);
+
+    for it in data {
+        // offsets is never empty because we already pushed id to it
+        let last = offsets.last().unwrap();
+        // `it` can never be empty due to implementation of ScanP1Folder
+        let next: T = (scan_op)(last, &it.last().unwrap());
+        offsets.push(next);
+    }
+    offsets
+}
+
+/******* scan part 1: consumer ******/
+
+// Breaks the iterator into pieces and performs sequential scan on each
+// Returns intermediate data, a LinkedList of the result of each seq scan
+fn scan_p1<'a, PI, P, T>(pi: PI, scan_op: &'a P) -> LinkedList<Vec<T>>
+where
+    PI: ParallelIterator<Item = T>,
+    P: Fn(&T, &T) -> T + Send + Sync,
+    T: Send,
+{
+    let consumer = ScanP1Consumer { scan_op };
+    pi.drive_unindexed(consumer)
+}
+
+struct ScanP1Consumer<'p, P> {
+    scan_op: &'p P,
+}
+
+impl<'p, P: Send> ScanP1Consumer<'p, P> {
+    fn new(scan_op: &'p P) -> ScanP1Consumer<'p, P> {
+        ScanP1Consumer { scan_op }
+    }
+}
+
+impl<'p, T, P: 'p> Consumer<T> for ScanP1Consumer<'p, P>
+where
+    T: Send,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    type Folder = ScanP1Folder<'p, T, P>;
+    type Reducer = ScanP1Reducer;
+    type Result = LinkedList<Vec<T>>;
+
+    fn split_at(self, _index: usize) -> (Self, Self, Self::Reducer) {
+        (
+            ScanP1Consumer::new(self.scan_op),
+            ScanP1Consumer::new(self.scan_op),
+            ScanP1Reducer,
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        ScanP1Folder {
+            vec: Vec::new(),
+            scan_op: self.scan_op,
+        }
+    }
+
+    fn full(&self) -> bool {
+        false
+    }
+}
+
+impl<'p, T, P: 'p> UnindexedConsumer<T> for ScanP1Consumer<'p, P>
+where
+    T: Send,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    fn split_off_left(&self) -> Self {
+        Self {
+            scan_op: self.scan_op,
+        }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        ScanP1Reducer
+    }
+}
+
+struct ScanP1Folder<'p, T, P> {
+    vec: Vec<T>,
+    scan_op: &'p P,
+}
+
+impl<'p, T, P> Folder<T> for ScanP1Folder<'p, T, P>
+where
+    P: Fn(&T, &T) -> T + 'p,
+{
+    type Result = LinkedList<Vec<T>>;
+
+    fn consume(mut self, item: T) -> Self {
+        let next = match self.vec.last() {
+            None => item,
+            Some(prev) => (self.scan_op)(prev, &item),
+        };
+        self.vec.push(next);
+        self
+    }
+
+    fn complete(self) -> Self::Result {
+        let mut list = LinkedList::new();
+        if !self.vec.is_empty() {
+            list.push_back(self.vec);
+        }
+        list
+    }
+
+    fn full(&self) -> bool {
+        false
+    }
+}
+
+struct ScanP1Reducer;
+
+impl<T> Reducer<LinkedList<T>> for ScanP1Reducer {
+    fn reduce(self, mut left: LinkedList<T>, mut right: LinkedList<T>) -> LinkedList<T> {
+        left.append(&mut right);
+        left
+    }
+}
+
+/*********** scan part 2: producer **********/
+
+#[derive(Debug)]
+pub struct Scan<T, P> {
+    data: Vec<Vec<T>>,
+    offsets: Vec<T>,
+    scan_op: P,
+}
+
+impl<T, P> Scan<T, P>
+where
+    T: Send + Sync,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    pub(super) fn new(data: Vec<Vec<T>>, offsets: Vec<T>, scan_op: P) -> Self {
+        Scan {
+            data,
+            offsets,
+            scan_op,
+        }
+    }
+}
+
+impl<T, P> ParallelIterator for Scan<T, P>
+where
+    T: Send + Sync,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge_unindexed(
+            ScanP2Producer {
+                data: &self.data,
+                offsets: &self.offsets,
+                scan_op: &self.scan_op,
+            },
+            consumer,
+        )
+    }
+}
+
+struct ScanP2Producer<'a, T, P> {
+    data: &'a [Vec<T>],
+    offsets: &'a [T],
+    scan_op: &'a P,
+}
+
+impl<'a, T, P> ScanP2Producer<'a, T, P>
+where
+    T: Send + Sync,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    pub(super) fn new(data: &'a [Vec<T>], offsets: &'a [T], scan_op: &'a P) -> Self {
+        ScanP2Producer {
+            data,
+            offsets,
+            scan_op,
+        }
+    }
+}
+
+impl<'a, T, P> UnindexedProducer for ScanP2Producer<'a, T, P>
+where
+    T: Send + Sync,
+    P: Fn(&T, &T) -> T + Send + Sync,
+{
+    type Item = T;
+
+    fn split(self) -> (Self, Option<Self>) {
+        let mid = self.offsets.len() / 2;
+        if mid == 0 {
+            return (self, None);
+        }
+        let (data_l, data_r) = self.data.split_at(mid);
+        let (offsets_l, offsets_r) = self.offsets.split_at(mid);
+
+        (
+            ScanP2Producer::new(data_l, offsets_l, self.scan_op),
+            Some(ScanP2Producer::new(data_r, offsets_r, self.scan_op)),
+        )
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+    where
+        F: Folder<Self::Item>,
+    {
+        let iter = self
+            .data
+            .iter()
+            .zip(self.offsets.iter())
+            .flat_map(|(chunk, offset)| chunk.iter().map(|x| (self.scan_op)(offset, x)));
+        folder.consume_iter(iter)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_debug_implementations)]
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![deny(unreachable_pub)]
 #![warn(rust_2018_idioms)]
 


### PR DESCRIPTION
Hi, here's a draft of a parallel scan function based on discussion in #329 and #393.

### General Approach

1. Use a consumer to split the iterator into pieces, and perform sequential scan on each, accumulating into a `Vec<T>`. The reduce step combines them into a `LinkedList<Vec<T>>`.
2. Sequentially, compute the "offset" we need to add to each section, by looking at the last element of each Vec (and doing another scan). Also, collect the linked list into a `Vec<Vec<T>>` so we can operate on it in parallel again. 
3. Create an unindexed producer which adds the offsets to each Vec in parallel. 

In order to maximize the parallelism, we don't want to split too much, since that creates more sequential work. I've been using `.with_min_len()` in order to prevent that.

Happy to take feedback on better ways to do any of these steps.

### Benchmarks

I also tried writing some benchmarks. I ran these on my M2 Mac with 12 threads.
- For a regular prefix sum or product on ints, the parallel overhead is too much to see any improvement with the parallel version. 
- Only sufficiently slow operations will benefit, but they can see a fairly large improvement. I tried testing this by writing an addition function that waits a certain amount of time before returning. With a 100000 size input:
    - With a delay time of 100ns, the parallel speedup is 2.99
    - With a delay time of 10000ns, the parallel speedup is 5.27
- A slightly more realistic example is matrix multiplication. Here's the execution time on various numbers of threads, compared to the sequential baseline.
<p align="center"><img width="500" alt="matrix scan" src="https://user-images.githubusercontent.com/36049232/225511900-b7016f91-8f7d-4823-9d1f-bc6e154e112b.png"></p>

### Potential Improvements
- Write a specialized version for prefix sums/products
- Output an indexed producer instead of unindexed. This is definitely harder, but I have a few ideas for how it might be doable. Is this important?
- Testing on higher core machines
- General cleanup + docs