### PR TITLE
mark spawn function unsafe

### DIFF
--- a/rayon-core/src/broadcast/test.rs
+++ b/rayon-core/src/broadcast/test.rs
@@ -251,7 +251,7 @@ fn broadcast_after_spawn() {
 
     // Queue a regular spawn on a thread-local deque.
     crate::registry::in_worker(move |_, _| {
-        crate::spawn(move || tx.send(22).unwrap());
+        unsafe { crate::spawn(move || tx.send(22).unwrap()) };
     });
 
     // Broadcast runs after the local deque is empty.

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -57,7 +57,7 @@ use std::sync::Arc;
 ///     GLOBAL_COUNTER.fetch_add(1, Ordering::SeqCst);
 /// });
 /// ```
-pub fn spawn<F>(func: F)
+pub unsafe fn spawn<F>(func: F)
 where
     F: FnOnce() + Send + 'static,
 {
@@ -127,7 +127,7 @@ where
 /// details.
 ///
 /// [ph]: struct.ThreadPoolBuilder.html#method.panic_handler
-pub fn spawn_fifo<F>(func: F)
+pub unsafe fn spawn_fifo<F>(func: F)
 where
     F: FnOnce() + Send + 'static,
 {

--- a/rayon-core/src/spawn/test.rs
+++ b/rayon-core/src/spawn/test.rs
@@ -11,7 +11,7 @@ use crate::ThreadPoolBuilder;
 fn spawn_then_join_in_worker() {
     let (tx, rx) = channel();
     scope(move |_| {
-        spawn(move || tx.send(22).unwrap());
+        unsafe { spawn(move || tx.send(22).unwrap()) };
     });
     assert_eq!(22, rx.recv().unwrap());
 }
@@ -20,7 +20,7 @@ fn spawn_then_join_in_worker() {
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn spawn_then_join_outside_worker() {
     let (tx, rx) = channel();
-    spawn(move || tx.send(22).unwrap());
+    unsafe { spawn(move || tx.send(22).unwrap()) };
     assert_eq!(22, rx.recv().unwrap());
 }
 
@@ -72,9 +72,9 @@ fn termination_while_things_are_executing() {
             // At this point, we know the "main" reference to the
             // `ThreadPool` has been dropped, but there are still
             // active threads. Launch one more.
-            spawn(move || {
+            unsafe { spawn(move || {
                 tx1.send(data).unwrap();
-            });
+            }) };
         });
     }
 
@@ -131,9 +131,9 @@ fn custom_panic_handler_and_nested_spawn() {
         // launch 3 nested spawn-asyncs; these should be in the same
         // thread-pool and hence inherit the same panic handler
         for _ in 0..PANICS {
-            spawn(move || {
+            unsafe { spawn(move || {
                 panic!("Hello, world!");
-            });
+            }) };
         }
     });
 
@@ -156,14 +156,15 @@ macro_rules! test_order {
         pool.install(move || {
             for i in 0..10 {
                 let tx = tx.clone();
-                $outer_spawn(move || {
-                    for j in 0..10 {
-                        let tx = tx.clone();
-                        $inner_spawn(move || {
-                            tx.send(i * 10 + j).unwrap();
-                        });
-                    }
-                });
+                unsafe {
+                    $outer_spawn(move || {
+                        for j in 0..10 {
+                            let tx = tx.clone();
+                            $inner_spawn(move || {
+                                tx.send(i * 10 + j).unwrap();
+                            });
+                        }
+                    }) };
             }
         });
         rx.iter().collect::<Vec<i32>>()
@@ -241,7 +242,7 @@ macro_rules! test_mixed_order {
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_lifo_fifo_order() {
-    let vec = test_mixed_order!(spawn, spawn_fifo);
+    let vec = unsafe { test_mixed_order!(spawn, spawn_fifo) };
     let expected = vec![3, -1, 2, -2, 1, -3, 0];
     assert_eq!(vec, expected);
 }
@@ -249,7 +250,7 @@ fn mixed_lifo_fifo_order() {
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn mixed_fifo_lifo_order() {
-    let vec = test_mixed_order!(spawn_fifo, spawn);
+    let vec = unsafe { test_mixed_order!(spawn_fifo, spawn) };
     let expected = vec![0, -3, 1, -2, 2, -1, 3];
     assert_eq!(vec, expected);
 }

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -386,7 +386,7 @@ fn yield_now_to_spawn() {
     let (tx, rx) = crossbeam_channel::bounded(1);
 
     // Queue a regular spawn.
-    crate::spawn(move || tx.send(22).unwrap());
+    unsafe { crate::spawn(move || tx.send(22).unwrap()) };
 
     // The single-threaded fallback mode (for wasm etc.) won't
     // get a chance to run the spawn if we never yield to it.
@@ -404,7 +404,7 @@ fn yield_local_to_spawn() {
     let (tx, rx) = crossbeam_channel::bounded(1);
 
     // Queue a regular spawn.
-    crate::spawn(move || tx.send(22).unwrap());
+    unsafe { crate::spawn(move || tx.send(22).unwrap()) };
 
     // The single-threaded fallback mode (for wasm etc.) won't
     // get a chance to run the spawn if we never yield to it.


### PR DESCRIPTION
https://github.com/rayon-rs/rayon/blob/3ffed8e7e2d57ed9b69bcb3b50e32fdc2265bf9b/rayon-core/src/spawn/mod.rs#L60-L66
https://github.com/rayon-rs/rayon/blob/3ffed8e7e2d57ed9b69bcb3b50e32fdc2265bf9b/rayon-core/src/spawn/mod.rs#L130-L136
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.