### PR TITLE
Revert "Use cargo's sparse protocol"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,16 +5,11 @@ on:
       - staging
       - trying
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
 jobs:
 
   check:
     name: Check (1.59.0)
     runs-on: ubuntu-latest
-    env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.59.0

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -6,9 +6,6 @@ on:
   schedule:
     - cron: '0 0 * * 0' # 00:00 Sunday
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
 jobs:
 
   test:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,6 @@ on: pull_request
 
 # Using 16MB stacks for deep test/debug recursion
 env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_MIN_STACK: 16777216
 
 jobs:
@@ -11,8 +10,6 @@ jobs:
   check:
     name: Check (1.59.0)
     runs-on: ubuntu-latest
-    env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.59.0


### PR DESCRIPTION
This reverts commit ed42b2926f0317056aa65ce802964191e37fe5f5.

The sparse protocol is the default in Rust 1.70, so we can just leave it
to defaults across all our CI-tested versions.
