### PR TITLE
Improve inlining of scope latch counters

### DIFF
--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -286,8 +286,9 @@ impl Latch for LockLatch {
 /// contexts).
 #[derive(Debug)]
 pub(super) struct CountLatch {
-    core_latch: CoreLatch,
+    // counter is first to nudge layout like CountLockLatch
     counter: AtomicUsize,
+    core_latch: CoreLatch,
 }
 
 impl CountLatch {
@@ -347,8 +348,9 @@ impl AsCoreLatch for CountLatch {
 
 #[derive(Debug)]
 pub(super) struct CountLockLatch {
-    lock_latch: LockLatch,
+    // counter is first to nudge layout like CountLatch
     counter: AtomicUsize,
+    lock_latch: LockLatch,
 }
 
 impl CountLockLatch {


### PR DESCRIPTION
The `increment` and `set` methods now have `#[inline]` hints, and the
`counter` fields in `CountLatch` and `CountLockLatch` are now listed
first to increase the chance that layout puts them at the same offset.
(That layout is not critical to ensure, but works out nicely.)
