### PR TITLE
Add more `FromParallelIterator` and `ParallelExtend`

### DIFF
--- a/src/iter/extend.rs
+++ b/src/iter/extend.rs
@@ -500,6 +500,16 @@ impl ParallelExtend<String> for String {
     }
 }
 
+/// Extends a string with boxed strings from a parallel iterator.
+impl ParallelExtend<Box<str>> for String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = Box<str>>,
+    {
+        extend!(self, par_iter, string_extend);
+    }
+}
+
 /// Extends a string with string slices from a parallel iterator.
 impl<'a> ParallelExtend<Cow<'a, str>> for String {
     fn par_extend<I>(&mut self, par_iter: I)

--- a/src/iter/from_par_iter.rs
+++ b/src/iter/from_par_iter.rs
@@ -6,6 +6,8 @@ use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
 use std::hash::{BuildHasher, Hash};
+use std::rc::Rc;
+use std::sync::Arc;
 
 /// Creates an empty default collection and extends it.
 fn collect_extended<C, I>(par_iter: I) -> C
@@ -28,6 +30,45 @@ where
         I: IntoParallelIterator<Item = T>,
     {
         collect_extended(par_iter)
+    }
+}
+
+/// Collects items from a parallel iterator into a boxed slice.
+impl<T> FromParallelIterator<T> for Box<[T]>
+where
+    T: Send,
+{
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        Vec::from_par_iter(par_iter).into()
+    }
+}
+
+/// Collects items from a parallel iterator into a reference-counted slice.
+impl<T> FromParallelIterator<T> for Rc<[T]>
+where
+    T: Send,
+{
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        Vec::from_par_iter(par_iter).into()
+    }
+}
+
+/// Collects items from a parallel iterator into an atomically-reference-counted slice.
+impl<T> FromParallelIterator<T> for Arc<[T]>
+where
+    T: Send,
+{
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        Vec::from_par_iter(par_iter).into()
     }
 }
 
@@ -169,6 +210,16 @@ impl FromParallelIterator<String> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
         I: IntoParallelIterator<Item = String>,
+    {
+        collect_extended(par_iter)
+    }
+}
+
+/// Collects boxed strings from a parallel iterator into one large string.
+impl FromParallelIterator<Box<str>> for String {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = Box<str>>,
     {
         collect_extended(par_iter)
     }


### PR DESCRIPTION
These all have sequential equivalents in the standard library.

* `impl<T> FromParallelIterator<T> for Box<[T]>`
* `impl<T> FromParallelIterator<T> for Rc<[T]>`
* `impl<T> FromParallelIterator<T> for Arc<[T]>`
* `impl FromParallelIterator<Box<str>> for String`
* `impl ParallelExtend<Box<str>> for String`
