### PR TITLE
Fix #1064

### DIFF
--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -468,4 +468,6 @@ pub enum Yield {
     Executed,
     /// No available work was found.
     Idle,
+    /// Another job that has yielded is already on the stack.
+    Recursive,
 }

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -468,6 +468,7 @@ pub enum Yield {
     Executed,
     /// No available work was found.
     Idle,
-    /// Another job that has yielded is already on the stack.
+    /// Another job that has yielded is already on this thread's stack, so to prevent a stack
+    /// overflow we will not start a third job.
     Recursive,
 }


### PR DESCRIPTION
Fixes #1064 by preventing two jobs on the same thread from yielding at once.