### PR TITLE
Parallel map, which transforms one sequential iterator into another

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -135,6 +135,7 @@ mod noop;
 mod once;
 mod panic_fuse;
 mod par_bridge;
+mod par_map;
 mod positions;
 mod product;
 mod reduce;
@@ -185,6 +186,7 @@ pub use self::{
     once::{once, Once},
     panic_fuse::PanicFuse,
     par_bridge::{IterBridge, ParallelBridge},
+    par_map::ParallelMap,
     positions::Positions,
     repeat::{repeat, repeatn, Repeat, RepeatN},
     rev::Rev,

--- a/src/iter/par_map.rs
+++ b/src/iter/par_map.rs
@@ -1,0 +1,199 @@
+use crate::ScopeFifo;
+use std::sync::Arc;
+use std::collections::VecDeque;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::sync_channel;
+
+trait LocalOrGlobalScope<'scope>
+where
+    Self: 'scope
+{
+    fn spawn_in_scope<Task>(&self, task: Task)
+    where
+        Task: for<'scoperef> FnOnce(&'scoperef Self),
+        Task: Send + 'scope;
+}
+
+impl<'scope> LocalOrGlobalScope<'scope> for ScopeFifo<'scope> {
+    fn spawn_in_scope<Task>(&self, task: Task)
+    where
+        Task: for<'scoperef> FnOnce(&'scoperef Self),
+        Task: Send + 'scope
+    {
+        self.spawn_fifo(task);
+    }
+}
+
+#[derive(Debug)]
+pub struct GlobalScope;
+
+impl LocalOrGlobalScope<'static> for GlobalScope {
+    fn spawn_in_scope<Task>(&self, task: Task)
+    where
+        Task: for<'scoperef> FnOnce(&'scoperef Self),
+        Task: Send + 'static
+    {
+        crate::spawn_fifo(||task(&GlobalScope));
+    }
+}
+
+pub struct ParallelMapIter<'scoperef, 'scope, SomeScope, InputIter, OutputItem>
+where
+    InputIter: Iterator
+{
+    chans: VecDeque<Receiver<OutputItem>>,
+    iter: std::iter::Fuse<InputIter>,
+    scope: &'scoperef SomeScope,
+
+    // We have to use "dyn" here, because return_position_impl_trait_in_trait is not yet stable
+    op: Arc<dyn for<'scoperef2> Fn(&'scoperef2 SomeScope, InputIter::Item) -> OutputItem + Sync + Send + 'scope>,
+}
+
+impl<'scoperef, 'scope, SomeScope, InputIter: Iterator, OutputItem> std::fmt::Debug for ParallelMapIter<'scoperef, 'scope, SomeScope, InputIter, OutputItem> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("ParallelMapIter").finish()
+    }
+}
+
+fn push_task<'scoperef, 'scope, SomeScope, InputItem, OutputItem>(
+    input: InputItem,
+    scope: &'scoperef SomeScope,
+    op: Arc<dyn for<'scoperef2> Fn(&'scoperef2 SomeScope, InputItem) -> OutputItem + Sync + Send + 'scope>,
+    chans: &mut VecDeque<Receiver<OutputItem>>
+)
+where
+    InputItem: Send + 'scope,
+    OutputItem: Send + 'scope,
+    SomeScope: LocalOrGlobalScope<'scope>,
+{
+    let (send, recv) = sync_channel(1);
+    scope.spawn_in_scope(|scope|{
+        send.send(op(scope, input)).unwrap();
+        drop(send);
+        drop(op);
+    });
+    chans.push_back(recv);
+}
+
+fn low_level_par_map<'scoperef, 'scope, SomeScope, InputIter, OutputItem, Op>(iter: InputIter, scope: &'scoperef SomeScope, capacity: usize, op: Op) -> ParallelMapIter<'scoperef, 'scope, SomeScope, InputIter, OutputItem>
+where
+    Op: for<'scoperef2> Fn(&'scoperef2 SomeScope, InputIter::Item) -> OutputItem,
+    Op: Sync + Send + 'scope,
+    InputIter::Item: Send + 'scope,
+    OutputItem: Send + 'scope,
+    SomeScope: LocalOrGlobalScope<'scope>,
+    InputIter: Iterator,
+{
+    assert!(capacity >= 1);
+    let mut chans = VecDeque::new();
+    let op: Arc<dyn for<'scoperef2> Fn(&'scoperef2 SomeScope, InputIter::Item) -> OutputItem + Sync + Send + 'scope> = Arc::new(op);
+    let mut iter = iter.fuse();
+    for _ in 0..(capacity - 1) {
+        if let Some(input) = iter.next() {
+            push_task(input, scope, Arc::clone(&op), &mut chans);
+        } else {
+            break;
+        }
+    }
+    ParallelMapIter { chans, iter, scope, op }
+}
+
+/// TODO
+pub trait ParallelMap: Iterator + Sized {
+    /// TODO
+    fn par_map_with_scope_and_capacity<'scoperef, 'scope, OutputItem, Op>(self, scope: &'scoperef ScopeFifo<'scope>, capacity: usize, op: Op) -> ParallelMapIter<'scoperef, 'scope, ScopeFifo<'scope>, Self, OutputItem>
+    where
+        Op: for<'scoperef2> Fn(&'scoperef2 ScopeFifo<'scope>, Self::Item) -> OutputItem,
+        Op: Sync + Send + 'scope,
+        Self::Item: Send + 'scope,
+        OutputItem: Send + 'scope,
+    {
+        low_level_par_map(self, scope, capacity, op)
+    }
+    /// TODO
+    fn par_map_with_scope<'scoperef, 'scope, OutputItem, Op>(self, scope: &'scoperef ScopeFifo<'scope>, op: Op) -> ParallelMapIter<'scoperef, 'scope, ScopeFifo<'scope>, Self, OutputItem>
+    where
+        Op: for<'scoperef2> Fn(&'scoperef2 ScopeFifo<'scope>, Self::Item) -> OutputItem,
+        Op: Sync + Send + 'scope,
+        Self::Item: Send + 'scope,
+        OutputItem: Send + 'scope,
+    {
+        // We can just call rayon::current_num_threads. Unfortunately, this will not work if the scope was created using rayon::ThreadPool::in_place_scope_fifo. So we have to spawn new task merely to learn number of threads
+        let (send, recv) = sync_channel(1);
+        scope.spawn_fifo(|_|{
+            send.send(crate::current_num_threads()).unwrap();
+            drop(send);
+        });
+        let capacity = recv.recv().unwrap() * 2;
+        drop(recv);
+        self.par_map_with_scope_and_capacity(scope, capacity, op)
+    }
+    /// TODO
+    fn par_map_with_capacity<OutputItem, Op>(self, capacity: usize, op: Op) -> ParallelMapIter<'static, 'static, GlobalScope, Self, OutputItem>
+    where
+        Op: Fn(Self::Item) -> OutputItem,
+        Op: Sync + Send + 'static,
+        Self::Item: Send + 'static,
+        OutputItem: Send + 'static,
+    {
+        low_level_par_map(self, &GlobalScope, capacity, move |_, input|op(input))
+    }
+    /// TODO
+    fn par_map<OutputItem, Op>(self, op: Op) -> ParallelMapIter<'static, 'static, GlobalScope, Self, OutputItem>
+    where
+        Op: Fn(Self::Item) -> OutputItem,
+        Op: Sync + Send + 'static,
+        Self::Item: Send + 'static,
+        OutputItem: Send + 'static,
+    {
+        self.par_map_with_capacity(crate::current_num_threads() * 2, op)
+    }
+    /// TODO
+    fn par_map_for_each_with_capacity<MapOp, ForEachOp, OutputItem>(self, capacity: usize, map_op: MapOp, for_each_op: ForEachOp)
+    where
+        MapOp: Fn(Self::Item) -> OutputItem,
+        MapOp: Sync + Send,
+        ForEachOp: FnMut(OutputItem),
+        Self::Item: Send,
+        OutputItem: Send,
+    {
+        crate::in_place_scope_fifo(|s|{
+            self.par_map_with_scope_and_capacity(s, capacity, move |_, input|map_op(input)).for_each(for_each_op);
+        });
+    }
+    /// TODO
+    fn par_map_for_each<MapOp, ForEachOp, OutputItem>(self, map_op: MapOp, for_each_op: ForEachOp)
+    where
+        MapOp: Fn(Self::Item) -> OutputItem,
+        MapOp: Sync + Send,
+        ForEachOp: FnMut(OutputItem),
+        Self::Item: Send,
+        OutputItem: Send,
+    {
+        self.par_map_for_each_with_capacity(crate::current_num_threads() * 2, map_op, for_each_op);
+    }
+}
+
+impl<InputIter: Iterator> ParallelMap for InputIter {
+}
+
+impl<'scoperef, 'scope, SomeScope, InputIter, OutputItem> Iterator for ParallelMapIter<'scoperef, 'scope, SomeScope, InputIter, OutputItem>
+where
+    InputIter: Iterator,
+    InputIter::Item: Send + 'scope,
+    OutputItem: Send + 'scope,
+    SomeScope: LocalOrGlobalScope<'scope>,
+{
+    type Item = OutputItem;
+    fn next(&mut self) -> Option<OutputItem> {
+        if let Some(input) = self.iter.next() {
+            push_task(input, self.scope, Arc::clone(&self.op), &mut self.chans);
+        }
+        #[allow(clippy::manual_map)]
+        if let Some(output) = self.chans.pop_front() {
+            Some(output.recv().unwrap())
+        } else {
+            None
+        }
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,7 @@ pub use crate::iter::ParallelDrainFull;
 pub use crate::iter::ParallelDrainRange;
 pub use crate::iter::ParallelExtend;
 pub use crate::iter::ParallelIterator;
+pub use crate::iter::ParallelMap;
 pub use crate::slice::ParallelSlice;
 pub use crate::slice::ParallelSliceMut;
 pub use crate::str::ParallelString;


### PR DESCRIPTION
This is `par_map` - combinator, which transforms one sequential iterator into another, while executing provided `op` on each element in parallel in rayon's thread pool. In other words, `a.par_map(op)` is somewhat equivalent to `a.par_bridge().map(op).collect::<Vec<_>>().into_iter()`, but with following differences:
- `par_map` keeps original order
- `par_map` is designed for cases when input or output sequence (or even both) doesn't fit in memory in full. In particular when input sequence is file or network. `par_map` provides very strong guarantees about what amount of data is stored in memory

`par_map` internally allocates `VecDeque` for dealing with in-fly operations. If current available parallelism (i. e. `rayon::current_num_threads`) equals N, then `par_map` makes sure that size of that `VecDeque` never exceeds `capacity`, which by default is equal to `N * 2`.

In other words: total count of cached input elements, cached output elements and in-fly operations never exceeds `capacity`, which by default is `N * 2`.

In other words: it is guaranteed that `par_map` will not consume input item number `k + capacity` until `par_map`'s consumer will consume output item number `k`.

The guarantees hold even in pathological cases, i. e. even if some `op`s execute fast, and some - slow.

You may ask: why `N * 2`, why not `N`? Consider this situation: the 0th `op` still run, but `op`s from range `1..=(N - 1)` already have finished. In this situation it makes sense to run Nth `op`.

I think this pull request provides final solution to my issue https://github.com/rayon-rs/rayon/issues/1070 and to long-standing issues https://github.com/rayon-rs/rayon/issues/858 and https://github.com/rayon-rs/rayon/issues/210 .

My solution is even stronger than problems stated in my issue https://github.com/rayon-rs/rayon/issues/1070 : not only I solve both big-to-small and small-to-big tasks, but also hypothetical big-to-big task.

Now let me list added functions
- `par_map`. Described above. Unfortunately, `op` must be `'static`
- `par_map_with_capacity`. Same, but allows to specify `capacity`
- `par_map_with_scope`. Same as `par_map`, but takes `ScopeFifo` and thus allows us to use stack variables in `op` (unlike many other solutions presented in https://github.com/rayon-rs/rayon/issues/858 and https://github.com/rayon-rs/rayon/issues/210 )
- `par_map_with_scope_and_capacity`
- `par_map_for_each`. Same as `par_map`, but with following differences. The call `input_iter.par_map_for_each(op_map, op_for_each)` applies `op_map` to every input element in parallel (`op_map` is executed in rayon's thread pool) and sequentially executes `op_for_each` in current thread in correct order on each element, produced by `op_map`. Both `op_map` and `op_for_each` can access stack variables. In other words, `input_iter.par_map_for_each(op_map, op_for_each)` is equivalent to this (in fact, this is how it is roughly implemented):
```rust
rayon::in_place_scope_fifo(|s|input_iter.par_map_with_scope(s, move |_, input|op_map(input)).for_each(op_for_each));
```
I think such pattern is common (it is exactly what I need in my application). So, I think this function will be useful for people, who need `par_map(...).for_each(...)`, while accessing stack variables, and don't want to deal with scopes directly. Usually `op_for_each` will write something to a file
- `par_map_for_each_with_capacity`

Okay, so you may say: "But this is not integrated with `rayon::iter::ParallelIterator`!" Well, yes. It would be great to create converter from parallel to sequential iterator. People ask for it in https://github.com/rayon-rs/rayon/issues/210 and https://github.com/rayon-rs/rayon/issues/858 . Unfortunately, for such many years nobody created such implementation. I don't want, either. I don't understand how `ParallelIterator` works and don't want to learn it. And I suspect this will be hard to provide guarantees similar to mine with `ParallelIterator`-based implementation. Moreover, as well as I understand, `par_bridge` doesn't keep order. So to create something similar to my pull request we need _two_ new converters: from seq. to par. and from par. to seq., and both should keep order. So I propose simply to merge my pull request instead of waiting for another couple of years until someone will write `ParallelIterator`-based solution. Look how many likes are in https://github.com/rayon-rs/rayon/issues/210 .

This pull request lacks docs and tests. I wait for opinions. If you agree with my direction, I will add docs and tests