### PR TITLE
Make pariter discoverable

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -78,6 +78,17 @@
 //! `Box<dyn ParallelIterator>` or other kind of dynamic allocation,
 //! because `ParallelIterator` is **not object-safe**.
 //! (This keeps the implementation simpler and allows extra optimizations.)
+//!
+//! Note that rayon's builtin functionality is suboptimal in cases when your
+//! input and/or output data is too big, for example, when it doesn't fit in
+//! memory. In particular, rayon is not designed for case when you want to read some
+//! potentially big amount of data from file (or network), split it to chunks,
+//! feed to thread pool, perform some operations in parallel and then collect back
+//! and output to file or network in correct order. In other words, rayon is
+//! supoptimal when you need streaming for your input or output data. In such
+//! cases consider [alternative solution].
+//!
+//! [alternative solution]: https://dpc.pw/adding-parallelism-to-your-rust-iterators
 
 use self::plumbing::*;
 use self::private::Try;


### PR DESCRIPTION
Recently I wanted parallel map for big data. I spent some time searching for solution and was unable to find it. Some was rejected, because they don't keep order. Some - because they cannot borrow stack variables. Eventually I wrote my own solution: https://github.com/rayon-rs/rayon/pull/1071 . I spent many days on it! And now I found solution, which solves all problems: pariter ( https://dpc.pw/adding-parallelism-to-your-rust-iterators ). So I propose to add link to pariter to docs to make it discoverable. So that others will not spend many days on reimplementing it