### PR TITLE
`add` and `mul` now use a `[T, T]` array instead of chained iter::once

### DIFF
--- a/src/iter/product.rs
+++ b/src/iter/product.rs
@@ -13,7 +13,7 @@ where
 }
 
 fn mul<T: Product>(left: T, right: T) -> T {
-    iter::once(left).chain(iter::once(right)).product()
+    [left, right].into_iter().product()
 }
 
 struct ProductConsumer<P: Send> {

--- a/src/iter/sum.rs
+++ b/src/iter/sum.rs
@@ -13,7 +13,7 @@ where
 }
 
 fn add<T: Sum>(left: T, right: T) -> T {
-    iter::once(left).chain(iter::once(right)).sum()
+    [left, right].into_iter().sum()
 }
 
 struct SumConsumer<S: Send> {


### PR DESCRIPTION
Minor update to `sum` and `product` parallel iterators, to have them use arrays instead of chains of iter::once.