### PR TITLE
Clippy fixes

### DIFF
--- a/rayon-core/src/sleep/counters.rs
+++ b/rayon-core/src/sleep/counters.rs
@@ -212,12 +212,12 @@ impl AtomicCounters {
 
 #[inline]
 fn select_thread(word: usize, shift: usize) -> usize {
-    ((word >> shift) as usize) & THREADS_MAX
+    (word >> shift) & THREADS_MAX
 }
 
 #[inline]
 fn select_jec(word: usize) -> usize {
-    (word >> JEC_SHIFT) as usize
+    word >> JEC_SHIFT
 }
 
 impl Counters {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl<T> SendPtr<T> {
 // Implement Clone without the T: Clone bound from the derive
 impl<T> Clone for SendPtr<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 


### PR DESCRIPTION
- Fix `clippy::incorrect_clone_impl_on_copy_type` (denied)
- Fix `clippy::unnecessary_cast` (warning)
