### PR TITLE
Use wasm-sync to allow usage on the main browser thread

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
         include:
           - toolchain: stable
           - toolchain: nightly
+            cargoflags: --features web_spin_lock
             rustflags: -C target-feature=+atomics,+bulk-memory,+mutable-globals
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
@@ -80,7 +81,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: wasm32-unknown-unknown
-      - run: cargo build --verbose --target wasm32-unknown-unknown
+      - run: cargo build --verbose --target wasm32-unknown-unknown ${{ matrix.cargoflags }}
 
   # wasm32-wasi can test the fallback by running in wasmtime.
   wasi:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,6 @@ jobs:
 
   # wasm32-unknown-unknown builds, and even has the runtime fallback for
   # unsupported threading, but we don't have an environment to execute in.
-  # wasm32-wasi can test the fallback by running in wasmtime.
   wasm:
     name: WebAssembly (standalone)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,6 @@ jobs:
   done:
     name: Complete
     runs-on: ubuntu-latest
-    needs: [check, test, demo, i686, wasm, fmt]
+    needs: [check, test, demo, i686, wasm, wasi, fmt]
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,9 +71,7 @@ jobs:
       matrix:
         include:
           - toolchain: stable
-            targets: wasm32-unknown-unknown
           - toolchain: nightly
-            targets: wasm32-unknown-unknown
             rustflags: -C target-feature=+atomics,+bulk-memory,+mutable-globals
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,29 @@ jobs:
   # unsupported threading, but we don't have an environment to execute in.
   # wasm32-wasi can test the fallback by running in wasmtime.
   wasm:
-    name: WebAssembly
+    name: WebAssembly (standalone)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - toolchain: stable
+            targets: wasm32-unknown-unknown
+          - toolchain: nightly
+            targets: wasm32-unknown-unknown
+            rustflags: -C target-feature=+atomics,+bulk-memory,+mutable-globals
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: wasm32-unknown-unknown
+      - run: cargo build --verbose --target wasm32-unknown-unknown
+
+  # wasm32-wasi can test the fallback by running in wasmtime.
+  wasi:
+    name: WebAssembly (WASI)
     runs-on: ubuntu-latest
     env:
       CARGO_TARGET_WASM32_WASI_RUNNER: /home/runner/.wasmtime/bin/wasmtime
@@ -73,10 +95,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown,wasm32-wasi
-      - run: cargo check --verbose --target wasm32-unknown-unknown
-      - run: cargo check --verbose --target wasm32-wasi
+          targets: wasm32-wasi
       - run: curl https://wasmtime.dev/install.sh -sSf | bash
+      - run: cargo build --verbose --target wasm32-wasi
       - run: cargo test --verbose --target wasm32-wasi --package rayon
       - run: cargo test --verbose --target wasm32-wasi --package rayon-core
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ exclude = ["ci"]
 [dependencies]
 rayon-core = { version = "1.12.0", path = "rayon-core" }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", target_feature = "atomics"))'.dependencies]
+wasm_sync = "0.1.0"
+
 # This is a public dependency!
 [dependencies.either]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,19 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.12.0", path = "rayon-core" }
-
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", target_feature = "atomics"))'.dependencies]
-wasm_sync = "0.1.0"
+wasm_sync = { version = "0.1.0", optional = true }
 
 # This is a public dependency!
 [dependencies.either]
 version = "1.0"
 default-features = false
+
+[features]
+# This feature switches to a spin-lock implementation on the browser's
+# main thread to avoid the forbidden `atomics.wait`.
+#
+# Only useful on the `wasm32-unknown-unknown` target.
+web_spin_lock = ["wasm_sync", "rayon-core/web_spin_lock"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-features = false
 # main thread to avoid the forbidden `atomics.wait`.
 #
 # Only useful on the `wasm32-unknown-unknown` target.
-web_spin_lock = ["wasm_sync", "rayon-core/web_spin_lock"]
+web_spin_lock = ["dep:wasm_sync", "rayon-core/web_spin_lock"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "scoped-tls",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -1476,6 +1477,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f22b3c2526c5834350ca8de37292cbd2cb7724e6c812930cfb8c558340cf76f"
+dependencies = [
+ "web-sys",
+]
 
 [[package]]
 name = "wayland-backend"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -19,9 +19,15 @@ categories = ["concurrency"]
 [dependencies]
 crossbeam-deque = "0.8.1"
 crossbeam-utils = "0.8.0"
+wasm_sync = { version = "0.1.0", optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", target_feature = "atomics"))'.dependencies]
-wasm_sync = "0.1.0"
+[features]
+
+# This feature switches to a spin-lock implementation on the browser's
+# main thread to avoid the forbidden `atomics.wait`.
+#
+# Only useful on the `wasm32-unknown-unknown` target.
+web_spin_lock = ["wasm_sync"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -27,7 +27,7 @@ wasm_sync = { version = "0.1.0", optional = true }
 # main thread to avoid the forbidden `atomics.wait`.
 #
 # Only useful on the `wasm32-unknown-unknown` target.
-web_spin_lock = ["wasm_sync"]
+web_spin_lock = ["dep:wasm_sync"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -20,6 +20,9 @@ categories = ["concurrency"]
 crossbeam-deque = "0.8.1"
 crossbeam-utils = "0.8.0"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", target_feature = "atomics"))'.dependencies]
+wasm_sync = "0.1.0"
+
 [dev-dependencies]
 rand = "0.8"
 rand_xorshift = "0.3"

--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -1,10 +1,11 @@
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::Arc;
 use std::usize;
 
 use crate::registry::{Registry, WorkerThread};
+use crate::sync::{Condvar, Mutex};
 
 /// We define various kinds of latches, which are all a primitive signaling
 /// mechanism. A latch starts as false. Eventually someone calls `set()` and

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -103,6 +103,20 @@ pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;
 pub use self::thread_pool::{yield_local, yield_now, Yield};
 
+#[cfg(not(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    target_feature = "atomics"
+)))]
+pub use std::sync;
+
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    target_feature = "atomics"
+))]
+pub use wasm_sync as sync;
+
 use self::registry::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 
 /// Returns the maximum number of threads that Rayon supports in a single thread-pool.

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -103,18 +103,10 @@ pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;
 pub use self::thread_pool::{yield_local, yield_now, Yield};
 
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_os = "unknown",
-    target_feature = "atomics"
-)))]
+#[cfg(not(feature = "web_spin_lock"))]
 use std::sync;
 
-#[cfg(all(
-    target_arch = "wasm32",
-    target_os = "unknown",
-    target_feature = "atomics"
-))]
+#[cfg(feature = "web_spin_lock")]
 use wasm_sync as sync;
 
 use self::registry::{CustomSpawn, DefaultSpawn, ThreadSpawn};

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -108,14 +108,14 @@ pub use self::thread_pool::{yield_local, yield_now, Yield};
     target_os = "unknown",
     target_feature = "atomics"
 )))]
-pub use std::sync;
+use std::sync;
 
 #[cfg(all(
     target_arch = "wasm32",
     target_os = "unknown",
     target_feature = "atomics"
 ))]
-pub use wasm_sync as sync;
+use wasm_sync as sync;
 
 use self::registry::{CustomSpawn, DefaultSpawn, ThreadSpawn};
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -1,6 +1,7 @@
 use crate::job::{JobFifo, JobRef, StackJob};
 use crate::latch::{AsCoreLatch, CoreLatch, Latch, LatchRef, LockLatch, OnceLatch, SpinLatch};
 use crate::sleep::Sleep;
+use crate::sync::Mutex;
 use crate::unwind;
 use crate::{
     ErrorKind, ExitHandler, PanicHandler, StartHandler, ThreadPoolBuildError, ThreadPoolBuilder,
@@ -15,7 +16,7 @@ use std::io;
 use std::mem;
 use std::ptr;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Once};
 use std::thread;
 use std::usize;
 

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -2,9 +2,9 @@
 //! for an overview.
 
 use crate::latch::CoreLatch;
+use crate::sync::{Condvar, Mutex};
 use crossbeam_utils::CachePadded;
 use std::sync::atomic::Ordering;
-use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::usize;
 

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,5 +1,5 @@
+use rayon_core::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Mutex;
 
 use crate::iter::plumbing::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};
 use crate::iter::ParallelIterator;

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,4 +1,17 @@
-use rayon_core::sync::Mutex;
+#[cfg(not(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    target_feature = "atomics"
+)))]
+use std::sync::Mutex;
+
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    target_feature = "atomics"
+))]
+use wasm_sync::Mutex;
+
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use crate::iter::plumbing::{bridge_unindexed, Folder, UnindexedConsumer, UnindexedProducer};

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -1,15 +1,7 @@
-#[cfg(not(all(
-    target_arch = "wasm32",
-    target_os = "unknown",
-    target_feature = "atomics"
-)))]
+#[cfg(not(feature = "web_spin_lock"))]
 use std::sync::Mutex;
 
-#[cfg(all(
-    target_arch = "wasm32",
-    target_os = "unknown",
-    target_feature = "atomics"
-))]
+#[cfg(feature = "web_spin_lock")]
 use wasm_sync::Mutex;
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,7 +7,7 @@
 
 use crate::iter::plumbing::*;
 use crate::iter::*;
-use std::sync::Mutex;
+use rayon_core::sync::Mutex;
 
 use crate::option;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,7 +7,7 @@
 
 use crate::iter::plumbing::*;
 use crate::iter::*;
-use rayon_core::sync::Mutex;
+use std::sync::Mutex;
 
 use crate::option;
 


### PR DESCRIPTION
One of the most common complaints I've been receiving in [wasm-bindgen-rayon](https://github.com/RReverser/wasm-bindgen-rayon) that prevents people from using Rayon on the Web is the complexity of manually splitting up the code that uses Rayon into a Web Worker from code that drives the UI.

It requires custom message passing for proxying between two threads (Workers), which, admittedly, feels particularly silly when using a tool that is meant to simplify working with threads for you.

This all stems from a [Wasm limitation](https://github.com/WebAssembly/threads/issues/177) that disallows `atomic.wait` on the main browser thread. In theory, it's a reasonable limitation, since blocking main thread on the web is more problematic than on other platforms as it blocks web app's UI from being responsive altogether, and because there is no limit on how long atomic wait can block. In practice, however, it causes enough issues for users that various toolchains - even Emscripten - work around this issue by spin-locking when on the main thread.

Rust / wasm-bindgen decided not to adopt the same workaround, following the core Wasm decision, which is also a fair stance for general implementation of `Mutex` and other blocking primitives, but I believe Rayon usecase is sufficiently special. Code using parallel iterators is almost always guaranteed to run for less or, worst-case, ~same time as code using regular iterators, so it doesn't make sense to "punish" Rayon users and prevent them from being able to use parallel iterators on the main thread when it will lead to a _more_ responsive UI than using regular iterators.

This PR adds a `cfg`-conditional dependency on [wasm_sync](https://docs.rs/wasm_sync/latest/wasm_sync/) that automatically switches to the allowed spin-based `Mutex` and `Condvar` when it detects it's running on the main thread, and to regular `std::sync` based implementation otherwise, thus avoiding the `atomics.wait` error. This dependency will only be added when building for `wasm32-unknown-unknown` - that is, not affecting WASI and Emscripten users - and only when building with `-C target-feature=+atomics`, so not affecting users who rely on Rayon's single-threaded fallback mode either. I hope this kind of very limited override will be acceptable as it makes it much easier to use Rayon on the web.

When this is merged, I'll be able to leverage it in wasm-bindgen-rayon and [significantly simplify](https://github.com/RReverser/wasm-bindgen-rayon/compare/main...RReverser:wasm-bindgen-rayon:wasm-sync?expand=1) demos, tests and docs by avoiding that extra Worker machinery (e.g. see `demo/wasm-worker.js` and `demo/index.js` merged into single simple JS file in the linked diff).