### PR TITLE
Release rayon 1.8.1 and rayon-core 1.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Simple work-stealing parallelism for Rust"
@@ -19,7 +19,7 @@ members = ["rayon-demo", "rayon-core"]
 exclude = ["ci"]
 
 [dependencies]
-rayon-core = { version = "1.12.0", path = "rayon-core" }
+rayon-core = { version = "1.12.1", path = "rayon-core" }
 wasm_sync = { version = "0.1.0", optional = true }
 
 # This is a public dependency!

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release rayon 1.8.1 / rayon-core 1.12.1 (2024-01-17)
+
+- The new `"web_spin_lock"` crate feature makes mutexes spin on the main
+  browser thread in WebAssembly, rather than suffer an error about forbidden
+  `atomics.wait` if they were to block in that context. Thanks @RReverser!
+
 # Release rayon 1.8.0 / rayon-core 1.12.0 (2023-09-20)
 
 - The minimum supported `rustc` is now 1.63.

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -1059,7 +1059,7 @@ checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "either",
  "rand",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon"


### PR DESCRIPTION
- The new `"web_spin_lock"` crate feature makes mutexes spin on the main
  browser thread in WebAssembly, rather than suffer an error about forbidden
  `atomics.wait` if they were to block in that context. Thanks @RReverser!
