### PR TITLE
Run tests w/ fallback on wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,8 +61,9 @@ jobs:
       - run: cargo test --verbose --package rayon
       - run: cargo test --verbose --package rayon-core
 
-  # wasm32-unknown-unknown builds, and even has the runtime fallback for
-  # unsupported threading, but we don't have an environment to execute in.
+  # wasm32-unknown-unknown has a runtime fallback for unsupported threading.
+  # Proper threading needs more glue and is tested in wasm-bindgen-rayon,
+  # but we can at least verify that all tests can run on Wasm with the fallback.
   wasm:
     name: WebAssembly (standalone)
     runs-on: ubuntu-latest
@@ -71,7 +72,8 @@ jobs:
         include:
           - toolchain: stable
           - toolchain: nightly
-            cargoflags: --features web_spin_lock
+            components: rust-src
+            cargoflags: -Z build-std=panic_abort,std --features web_spin_lock
             rustflags: -C target-feature=+atomics,+bulk-memory,+mutable-globals
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
@@ -80,8 +82,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: ${{ matrix.components }}
           targets: wasm32-unknown-unknown
-      - run: cargo build --verbose --target wasm32-unknown-unknown ${{ matrix.cargoflags }}
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - run: wasm-pack test --chrome --headless -- --verbose ${{ matrix.cargoflags }}
 
   # wasm32-wasi can test the fallback by running in wasmtime.
   wasi:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,8 @@ web_spin_lock = ["dep:wasm_sync", "rayon-core/web_spin_lock"]
 [dev-dependencies]
 rand = "0.8"
 rand_xorshift = "0.3"
+
+# Test dependencies for wasm32-unknown-unknown with wasm-bindgen.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen-test = "0.3"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -278,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,8 +481,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1062,9 +1074,11 @@ name = "rayon"
 version = "1.8.1"
 dependencies = [
  "either",
+ "getrandom",
  "rand",
  "rand_xorshift",
  "rayon-core",
+ "wasm-bindgen-test",
  "wasm_sync",
 ]
 
@@ -1477,6 +1491,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf9242c0d27999b831eae4767b2a146feb0b27d332d553e605864acd2afd403"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "wasm_sync"

--- a/tests/chars.rs
+++ b/tests/chars.rs
@@ -1,6 +1,12 @@
 use rayon::prelude::*;
 use std::char;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn half_open_correctness() {
     let low = char::from_u32(0xD800 - 0x7).unwrap();

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -1,5 +1,11 @@
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 fn check<I>(iter: I)
 where
     I: ParallelIterator + Clone,

--- a/tests/collect.rs
+++ b/tests/collect.rs
@@ -5,6 +5,12 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore)]
 fn collect_drop_on_unwind() {

--- a/tests/cross-pool.rs
+++ b/tests/cross-pool.rs
@@ -1,6 +1,12 @@
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn cross_pool_busy() {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,6 +1,12 @@
 use rayon::prelude::*;
 use std::fmt::Debug;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 fn check<I>(iter: I)
 where
     I: ParallelIterator + Debug,

--- a/tests/drain_vec.rs
+++ b/tests/drain_vec.rs
@@ -1,5 +1,11 @@
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn drain_vec_yielded() {
     let mut vec_org = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/tests/intersperse.rs
+++ b/tests/intersperse.rs
@@ -1,5 +1,11 @@
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn check_intersperse() {
     let v: Vec<_> = (0..1000).into_par_iter().intersperse(-1).collect();

--- a/tests/issue671-unzip.rs
+++ b/tests/issue671-unzip.rs
@@ -2,6 +2,12 @@
 
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn type_length_limit() {
     let input = vec![1, 2, 3, 4, 5];

--- a/tests/issue671.rs
+++ b/tests/issue671.rs
@@ -2,6 +2,12 @@
 
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn type_length_limit() {
     let _ = Vec::<Result<(), ()>>::new()

--- a/tests/iter_panic.rs
+++ b/tests/iter_panic.rs
@@ -4,6 +4,12 @@ use std::ops::Range;
 use std::panic::{self, UnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 const ITER: Range<i32> = 0..0x1_0000;
 const PANIC: i32 = 0xC000;
 

--- a/tests/named-threads.rs
+++ b/tests/named-threads.rs
@@ -3,6 +3,12 @@ use std::collections::HashSet;
 use rayon::prelude::*;
 use rayon::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn named_threads() {

--- a/tests/octillion.rs
+++ b/tests/octillion.rs
@@ -1,5 +1,11 @@
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 const OCTILLION: u128 = 1_000_000_000_000_000_000_000_000_000;
 
 /// Produce a parallel iterator for 0u128..10²⁷

--- a/tests/par_bridge_recursion.rs
+++ b/tests/par_bridge_recursion.rs
@@ -1,6 +1,12 @@
 use rayon::prelude::*;
 use std::iter::once_with;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 const N: usize = 100_000;
 
 #[test]

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -1,6 +1,12 @@
 use rayon::iter::plumbing::*;
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 /// Stress-test indexes for `Producer::split_at`.
 fn check<F, I>(expected: &[I::Item], mut f: F)
 where

--- a/tests/sort-panic-safe.rs
+++ b/tests/sort-panic-safe.rs
@@ -8,6 +8,12 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
 use std::thread;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 const ZERO: AtomicUsize = AtomicUsize::new(0);
 const LEN: usize = 20_000;
 

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -3,6 +3,12 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use rayon::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 fn seeded_rng() -> XorShiftRng {
     let mut seed = <XorShiftRng as SeedableRng>::Seed::default();
     (0..).zip(seed.as_mut()).for_each(|(i, x)| *x = i);


### PR DESCRIPTION
With this change, CI can actually run tests against wasm32-unknown-unknown with the fallback non-threaded implementation, which should help catch any bugs early.

This is a bit invasive, because this target requires a custom `#[wasm_bindgen_test]` attributes as well as a custom runner instead of the standard `#[test]`, but there is no way around it, and, having those changes only at the top of test files, I believe it's reasonably isolated.