### PR TITLE
Add `ParallelString::par_split_ascii_whitespace`

### DIFF
--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -101,6 +101,7 @@ fn clone_str() {
     check(s.par_split('\n'));
     check(s.par_split_terminator('\n'));
     check(s.par_split_whitespace());
+    check(s.par_split_ascii_whitespace());
 }
 
 #[test]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -106,6 +106,7 @@ fn debug_str() {
     check(s.par_split('\n'));
     check(s.par_split_terminator('\n'));
     check(s.par_split_whitespace());
+    check(s.par_split_ascii_whitespace());
 }
 
 #[test]

--- a/tests/str.rs
+++ b/tests/str.rs
@@ -101,6 +101,12 @@ pub fn execute_strings_split() {
         assert_eq!(serial, parallel);
     }
 
+    for &(string, _) in &tests {
+        let serial: Vec<_> = string.split_ascii_whitespace().collect();
+        let parallel: Vec<_> = string.par_split_ascii_whitespace().collect();
+        assert_eq!(serial, parallel);
+    }
+
     // try matching separators too!
     for &(string, separator) in &tests {
         let serial: Vec<_> = string.matches(separator).collect();


### PR DESCRIPTION
This matches the standard library's `str::split_ascii_whitespace`, stable since rust-lang/rust#58047.