### PR TITLE
Add ParallelIterator::collect_vec_list

### DIFF
--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::LinkedList;
-
 use super::{IndexedParallelIterator, ParallelIterator};
 
 mod consumer;

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -66,24 +66,6 @@ where
     });
 }
 
-/// Collects the iterator into a linked list of vectors.
-///
-/// This is called by `ParallelIterator::collect_vec_list`.
-pub(super) fn collect_vec_list<I>(pi: I) -> LinkedList<Vec<I::Item>>
-where
-    I: ParallelIterator,
-{
-    match pi.opt_len() {
-        Some(len) => {
-            // Pseudo-specialization. See impl of ParallelExtend for Vec for more details.
-            let mut v = Vec::new();
-            super::collect::special_extend(pi, len, &mut v);
-            LinkedList::from([v])
-        }
-        None => super::extend::drive_list_vec(pi),
-    }
-}
-
 /// Create a consumer on the slice of memory we are collecting into.
 ///
 /// The consumer needs to be used inside the scope function, and the

--- a/src/iter/extend.rs
+++ b/src/iter/extend.rs
@@ -12,16 +12,21 @@ use std::hash::{BuildHasher, Hash};
 /// parallel, then extending the collection sequentially.
 macro_rules! extend {
     ($self:ident, $par_iter:ident, $extend:ident) => {
-        $extend(
-            $self,
-            $par_iter.into_par_iter().drive_unindexed(ListVecConsumer),
-        );
+        $extend($self, drive_list_vec($par_iter));
     };
 }
 
 /// Computes the total length of a `LinkedList<Vec<_>>`.
 fn len<T>(list: &LinkedList<Vec<T>>) -> usize {
     list.iter().map(Vec::len).sum()
+}
+
+pub(super) fn drive_list_vec<I, T>(pi: I) -> LinkedList<Vec<T>>
+where
+    I: IntoParallelIterator<Item = T>,
+    T: Send,
+{
+    pi.into_par_iter().drive_unindexed(ListVecConsumer)
 }
 
 struct ListVecConsumer;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1962,6 +1962,9 @@ pub trait ParallelIterator: Sized + Send {
     /// of how many elements the iterator contains, and even allows you to reuse
     /// an existing vector's backing store rather than allocating a fresh vector.
     ///
+    /// See also [`collect_vec_list()`][Self::collect_vec_list] for collecting
+    /// into a `LinkedList<Vec<T>>`.
+    ///
     /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
     /// [`collect_into_vec()`]:
     ///     trait.IndexedParallelIterator.html#method.collect_into_vec
@@ -2367,7 +2370,9 @@ pub trait ParallelIterator: Sized + Send {
     ///     .flat_map(|x| 0..x)
     ///     .collect_vec_list();
     ///
-    /// let total_len = result.iter().flatten().count();
+    /// // `par_iter.collect_vec_list().into_iter().flatten()` turns
+    /// // a parallel iterator into a serial one
+    /// let total_len = result.into_iter().flatten().count();
     /// assert_eq!(total_len, 2550);
     /// ```
     fn collect_vec_list(self) -> LinkedList<Vec<Self::Item>> {
@@ -3232,14 +3237,15 @@ where
     ///
     /// If your collection is not naturally parallel, the easiest (and
     /// fastest) way to do this is often to collect `par_iter` into a
-    /// [`LinkedList`] or other intermediate data structure and then
-    /// sequentially extend your collection. However, a more 'native'
-    /// technique is to use the [`par_iter.fold`] or
+    /// [`LinkedList`] (via [`collect_vec_list`]) or another intermediate
+    /// data structure and then sequentially extend your collection. However,
+    /// a more 'native' technique is to use the [`par_iter.fold`] or
     /// [`par_iter.fold_with`] methods to create the collection.
     /// Alternatively, if your collection is 'natively' parallel, you
     /// can use `par_iter.for_each` to process each element in turn.
     ///
     /// [`LinkedList`]: https://doc.rust-lang.org/std/collections/struct.LinkedList.html
+    /// [`collect_vec_list`]: ParallelIterator::collect_vec_list
     /// [`par_iter.fold`]: trait.ParallelIterator.html#method.fold
     /// [`par_iter.fold_with`]: trait.ParallelIterator.html#method.fold_with
     /// [`par_iter.for_each`]: trait.ParallelIterator.html#method.for_each

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2372,6 +2372,7 @@ pub trait ParallelIterator: Sized + Send {
     /// ```
     fn collect_vec_list(self) -> LinkedList<Vec<Self::Item>> {
         match self.opt_len() {
+            Some(0) => LinkedList::new(),
             Some(len) => {
                 // Pseudo-specialization. See impl of ParallelExtend for Vec for more details.
                 let mut v = Vec::new();

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2371,7 +2371,15 @@ pub trait ParallelIterator: Sized + Send {
     /// assert_eq!(total_len, 2550);
     /// ```
     fn collect_vec_list(self) -> LinkedList<Vec<Self::Item>> {
-        collect::collect_vec_list(self)
+        match self.opt_len() {
+            Some(len) => {
+                // Pseudo-specialization. See impl of ParallelExtend for Vec for more details.
+                let mut v = Vec::new();
+                collect::special_extend(self, len, &mut v);
+                LinkedList::from([v])
+            }
+            None => extend::drive_list_vec(self),
+        }
     }
 
     /// Internal method used to define the behavior of this parallel

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2352,9 +2352,8 @@ pub trait ParallelIterator: Sized + Send {
     /// Internally, most [`FromParallelIterator`]/[`ParallelExtend`] implementations
     /// use this strategy; each job collecting their chunk of the iterator to a `Vec<T>`
     /// and those chunks getting merged into a `LinkedList`, before then extending the
-    /// collection with each vector. This is the most efficient way to collect an
-    /// unindexed parallel iterator (again, indexed parallel iterators can be
-    /// efficiently collected simply into a vector).
+    /// collection with each vector. This is a very efficient way to collect an
+    /// unindexed parallel iterator, without much intermediate data movement.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I wasn't exactly sure where the `collect_vec_list` implementation should go, since the necessary internals are in `extend` but it's logically a `collect` function. Also, I feel like the documentation could be better, I'd appreciate feedback on that.

Resolves #1127
