### PR TITLE
Extend the ParallelExtend implementations

### DIFF
--- a/src/iter/from_par_iter.rs
+++ b/src/iter/from_par_iter.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
+use std::ffi::{OsStr, OsString};
 use std::hash::{BuildHasher, Hash};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -230,6 +231,36 @@ impl<'a> FromParallelIterator<Cow<'a, str>> for String {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
         I: IntoParallelIterator<Item = Cow<'a, str>>,
+    {
+        collect_extended(par_iter)
+    }
+}
+
+/// Collects OS-string slices from a parallel iterator into an OS-string.
+impl<'a> FromParallelIterator<&'a OsStr> for OsString {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = &'a OsStr>,
+    {
+        collect_extended(par_iter)
+    }
+}
+
+/// Collects OS-strings from a parallel iterator into one large OS-string.
+impl FromParallelIterator<OsString> for OsString {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = OsString>,
+    {
+        collect_extended(par_iter)
+    }
+}
+
+/// Collects OS-string slices from a parallel iterator into an OS-string.
+impl<'a> FromParallelIterator<Cow<'a, OsStr>> for OsString {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = Cow<'a, OsStr>>,
     {
         collect_extended(par_iter)
     }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2376,15 +2376,15 @@ pub trait ParallelIterator: Sized + Send {
     /// assert_eq!(total_len, 2550);
     /// ```
     fn collect_vec_list(self) -> LinkedList<Vec<Self::Item>> {
-        match self.opt_len() {
-            Some(0) => LinkedList::new(),
-            Some(len) => {
-                // Pseudo-specialization. See impl of ParallelExtend for Vec for more details.
-                let mut v = Vec::new();
-                collect::special_extend(self, len, &mut v);
-                LinkedList::from([v])
+        match extend::fast_collect(self) {
+            Either::Left(vec) => {
+                let mut list = LinkedList::new();
+                if !vec.is_empty() {
+                    list.push_back(vec);
+                }
+                list
             }
-            None => extend::drive_list_vec(self),
+            Either::Right(list) => list,
         }
     }
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -11,6 +11,7 @@ use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
 use std::f64;
+use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::sync::mpsc;
 use std::usize;
@@ -1568,13 +1569,27 @@ fn par_iter_collect_cows() {
     assert_eq!(a, b);
 
     // Collects `str` into a `String`
-    let a: Cow<'_, str> = s.split_whitespace().collect();
-    let b: Cow<'_, str> = s.par_split_whitespace().collect();
+    let sw = s.split_whitespace();
+    let psw = s.par_split_whitespace();
+    let a: Cow<'_, str> = sw.clone().collect();
+    let b: Cow<'_, str> = psw.clone().collect();
     assert_eq!(a, b);
 
     // Collects `String` into a `String`
-    let a: Cow<'_, str> = s.split_whitespace().map(str::to_owned).collect();
-    let b: Cow<'_, str> = s.par_split_whitespace().map(str::to_owned).collect();
+    let a: Cow<'_, str> = sw.map(str::to_owned).collect();
+    let b: Cow<'_, str> = psw.map(str::to_owned).collect();
+    assert_eq!(a, b);
+
+    // Collects `OsStr` into a `OsString`
+    let sw = s.split_whitespace().map(OsStr::new);
+    let psw = s.par_split_whitespace().map(OsStr::new);
+    let a: Cow<'_, OsStr> = Cow::Owned(sw.clone().collect());
+    let b: Cow<'_, OsStr> = psw.clone().collect();
+    assert_eq!(a, b);
+
+    // Collects `OsString` into a `OsString`
+    let a: Cow<'_, OsStr> = Cow::Owned(sw.map(OsStr::to_owned).collect());
+    let b: Cow<'_, OsStr> = psw.map(OsStr::to_owned).collect();
     assert_eq!(a, b);
 }
 


### PR DESCRIPTION
- All `ParallelExtend` impls now try to use the `Vec` pseudo-specialization.
- Add `ParallelExtend` and `FromParallelIterator` for `OsString` to match `std` (since 1.52).