### PR TITLE
Change FAQ example with race conditions

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -211,15 +211,14 @@ this shortest route, you can just stop and avoid wasted effort. In
 sequential land, you might model this "best result" as a shared value
 like `Rc<Cell<usize>>` (here the `usize` represents the length of best
 path found so far); in parallel land, you'd use a `Arc<AtomicUsize>`.
-Now we can make our search function look like:
 
 ```rust
-fn search(path: &Path, cost_so_far: usize, best_cost: &Arc<AtomicUsize>) {
+fn search(path: &Path, cost_so_far: usize, best_cost: &AtomicUsize) {
     if cost_so_far >= best_cost.load(Ordering::SeqCst) {
         return;
     }
-    ...
-    best_cost.store(...);
+    // Using `fetch_min` to avoid a race condition, in case it changed since `load`.
+    best_cost.fetch_min(..., Ordering::SeqCst);
 }
 ```
 


### PR DESCRIPTION
Previously this example in the FAQ as written would've introduced a race condition.
While I know the objective of this example is not to show exactly correct code, it seemed a bit odd to me since there's a whole section earlier about preventing race conditions. The last change was a while ago, so the API wasn't the same, but it would be good to update it so there's no race conditions.