### PR TITLE
Thread trotteling

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -61,7 +61,8 @@
 //! conflicting requirements will need to be resolved before the build will
 //! succeed.
 
-#![deny(missing_debug_implementations)]
+// TODO
+//#![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unreachable_pub)]
 #![warn(rust_2018_idioms)]
@@ -102,6 +103,7 @@ pub use self::thread_pool::current_thread_has_pending_tasks;
 pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;
 pub use self::thread_pool::{yield_local, yield_now, Yield};
+pub use self::registry::Registry;
 
 #[cfg(not(feature = "web_spin_lock"))]
 use std::sync;

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -12,7 +12,7 @@ use crate::{scope, Scope};
 use crate::{scope_fifo, ScopeFifo};
 use crate::{ThreadPoolBuildError, ThreadPoolBuilder};
 use std::error::Error;
-use std::fmt;
+use std::{fmt, usize};
 use std::sync::Arc;
 
 mod test;
@@ -348,6 +348,22 @@ impl ThreadPool {
         // We assert that `self.registry` has not terminated.
         unsafe { spawn::spawn_in(op, &self.registry) }
     }
+
+    /// Block `num` threads
+    pub fn block_threads(&self, num: usize) {
+        self.registry.block_threads(num);
+    }
+
+    /// Unblock `num` threads
+    pub fn unblock_threads(&self, num: usize) {
+        self.registry.unblock_threads(num);
+    }
+
+    /// Adjust so `num` threads are unblocked
+    pub fn adjust_blocked_threads_threads(&self, num: usize) {
+        self.registry.adjust_blocked_threads(num);
+    }
+
 
     /// Spawns an asynchronous task in this thread-pool. This task will
     /// run in the implicit, global scope, which means that it may outlast


### PR DESCRIPTION
I have to implement something like a thread throttling approach.
Threads should be able to stop and start as needed (or, as my implementation suggest, can be set to sleep and wake up as needed from client libraries).
This could help f.e. for further developments regarding this issue: https://github.com/rayon-rs/rayon/issues/319

Implementation details in which I don't know if I went the right way:
- I implement a new `Latch`, a toggling latch for a global state in each thread.
- For using the newly implemented methods to block/unblock (=sleep/unsleep) I need to get access to the global `Registry` and I therefore made the Registry struct `public`.

I would love to hear, if this is a feature rayon should support and if I got the implementation right.