### PR TITLE
Add full_blocking feature to thread pool

### DIFF
--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -135,6 +135,7 @@ pub(super) struct Registry {
     panic_handler: Option<Box<PanicHandler>>,
     start_handler: Option<Box<StartHandler>>,
     exit_handler: Option<Box<ExitHandler>>,
+    full_blocking: bool,
 
     // When this latch reaches 0, it means that all work on this
     // registry must be complete. This is ensured in the following ways:
@@ -267,6 +268,7 @@ impl Registry {
             panic_handler: builder.take_panic_handler(),
             start_handler: builder.take_start_handler(),
             exit_handler: builder.take_exit_handler(),
+            full_blocking: builder.get_full_blocking(),
         });
 
         // If we return early or panic, make sure to terminate existing threads.
@@ -493,7 +495,11 @@ impl Registry {
             if worker_thread.is_null() {
                 self.in_worker_cold(op)
             } else if (*worker_thread).registry().id() != self.id() {
-                self.in_worker_cross(&*worker_thread, op)
+                if self.full_blocking {
+                    self.in_worker_cross_blocking(&*worker_thread, op)
+                } else {
+                    self.in_worker_cross(&*worker_thread, op)
+                }
             } else {
                 // Perfectly valid to give them a `&T`: this is the
                 // current thread, so we know the data structure won't be
@@ -502,7 +508,7 @@ impl Registry {
             }
         }
     }
-
+    
     #[cold]
     unsafe fn in_worker_cold<OP, R>(&self, op: OP) -> R
     where
@@ -550,6 +556,30 @@ impl Registry {
         self.inject(job.as_job_ref());
         current_thread.wait_until(&job.latch);
         job.into_result()
+    }
+
+    #[cold]
+    unsafe fn in_worker_cross_blocking<OP, R>(&self, current_thread: &WorkerThread, op: OP) -> R
+    where
+        OP: FnOnce(&WorkerThread, bool) -> R + Send,
+        R: Send,
+    {
+        thread_local!(static LOCK_LATCH: LockLatch = LockLatch::new());
+
+        LOCK_LATCH.with(|l| {
+            let job = StackJob::new(
+                |injected| {
+                    let worker_thread = WorkerThread::current();
+                    assert!(injected && !worker_thread.is_null());
+                    op(&*worker_thread, true)
+                },
+                LatchRef::new(l),
+            );
+            self.inject(job.as_job_ref());
+            job.latch.wait_and_reset(); // Make sure we can use the same latch again next time.
+
+            job.into_result()
+        })
     }
 
     /// Increments the terminate counter. This increment should be

--- a/rayon-core/src/test.rs
+++ b/rayon-core/src/test.rs
@@ -206,7 +206,7 @@ fn cleared_current_thread() -> Result<(), ThreadPoolBuildError> {
 #[cfg_attr(any(target_os = "emscripten", target_family = "wasm"), ignore)]
 fn nested_thread_pools_deadlock() {
     let global_pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-    let lock_pool = Arc::new(ThreadPoolBuilder::new().num_threads(1).build().unwrap());
+    let lock_pool = Arc::new(ThreadPoolBuilder::new().full_blocking().num_threads(1).build().unwrap());
     let mutex = Arc::new(Mutex::new(0));
     let start_time = Instant::now();
 


### PR DESCRIPTION
This PR adds an option `full_blocking` to `ThreadPoolBuilder` that affects the behavior of nested thread pools.

When a job on a parent thread pool creates a job in a child thread pool and `full_blocking` is true, the parent job will block until the child job is completed. This is different from the default behavior where the parent thread is allowed to work on other jobs in the parent thread pool while the child job completes.

This behavior is useful for avoiding deadlocks caused by work-stealing and is helpful for instrumentation based profiling in multi-threaded settings.

See for more details:
https://github.com/rayon-rs/rayon/issues/1174