### PR TITLE
Add cartesian_product to ParallelIterator

### DIFF
--- a/src/iter/cartesian_product.rs
+++ b/src/iter/cartesian_product.rs
@@ -1,0 +1,48 @@
+use super::plumbing::*;
+use super::repeat::*;
+use super::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
+/// `CartesianProduct` is an iterator that combines `i` and `j` into a single iterator that
+/// iterates over the cartesian product of the elements of `i` and `j`. This struct is created by
+/// the [`cartesian_product()`] method on [`ParallelIterator`]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone, Copy)]
+pub struct CartesianProduct<I, J>
+where
+    I: ParallelIterator,
+    J: ParallelIterator,
+{
+    i: I,
+    j: J,
+}
+
+impl<I, J> CartesianProduct<I, J>
+where
+    I: ParallelIterator,
+    J: IndexedParallelIterator,
+{
+    /// Creates a new `CartesianProduct` iterator.
+    pub(super) fn new(i: I, j: J) -> Self {
+        CartesianProduct { i, j }
+    }
+}
+
+impl<I, J> ParallelIterator for CartesianProduct<I, J>
+where
+    I: ParallelIterator,
+    J: IndexedParallelIterator + Clone + Sync,
+    I::Item: Clone + Send,
+{
+    type Item = (I::Item, J::Item);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        self.i
+            .into_par_iter()
+            .map(|i_item| repeat(i_item.clone()).zip(self.j.clone()))
+            .flatten()
+            .drive_unindexed(consumer)
+    }
+}

--- a/tests/cartesian_product.rs
+++ b/tests/cartesian_product.rs
@@ -1,0 +1,53 @@
+use rayon::prelude::*;
+use std::collections::HashSet;
+
+#[test]
+fn cartesian_ranges() {
+    let a: Vec<(usize, usize)> = (0..3).into_par_iter().cartesian_product(0..3).collect();
+    let b: HashSet<(usize, usize)> = HashSet::from_iter(a.into_iter());
+    assert!(b.contains(&(0, 0)));
+    assert!(b.contains(&(0, 1)));
+    assert!(b.contains(&(0, 2)));
+    assert!(b.contains(&(1, 0)));
+    assert!(b.contains(&(1, 1)));
+    assert!(b.contains(&(1, 2)));
+    assert!(b.contains(&(2, 0)));
+    assert!(b.contains(&(2, 1)));
+    assert!(b.contains(&(2, 2)));
+}
+
+#[test]
+fn cartesian_vecs() {
+    let a: Vec<(f64, f64)> = vec![0.1, 1.2, 2.4]
+        .into_par_iter()
+        .cartesian_product(vec![4.8, 16.32, 32.64])
+        .collect();
+    assert!(a.contains(&(0.1, 4.8)));
+    assert!(a.contains(&(0.1, 16.32)));
+    assert!(a.contains(&(0.1, 32.64)));
+    assert!(a.contains(&(1.2, 4.8)));
+    assert!(a.contains(&(1.2, 16.32)));
+    assert!(a.contains(&(1.2, 32.64)));
+    assert!(a.contains(&(2.4, 4.8)));
+    assert!(a.contains(&(2.4, 16.32)));
+    assert!(a.contains(&(2.4, 32.64)));
+}
+
+#[test]
+fn cartesian_chain() {
+    let a: Vec<(usize, usize, usize)> = (0..2)
+        .into_par_iter()
+        .cartesian_product(0..2)
+        .cartesian_product(0..2)
+        .map(|((a, b), c)| (a, b, c))
+        .collect();
+    let b: HashSet<(usize, usize, usize)> = HashSet::from_iter(a.into_iter());
+    assert!(b.contains(&(0, 0, 0)));
+    assert!(b.contains(&(0, 0, 1)));
+    assert!(b.contains(&(0, 1, 0)));
+    assert!(b.contains(&(0, 1, 1)));
+    assert!(b.contains(&(1, 0, 0)));
+    assert!(b.contains(&(1, 0, 1)));
+    assert!(b.contains(&(1, 1, 0)));
+    assert!(b.contains(&(1, 1, 1)));
+}


### PR DESCRIPTION
I was trying to use cartesian products from itertools and noticed it's not implemented for rayon and has an open issue: https://github.com/rayon-rs/rayon/issues/754

I wasn't trying to preallocate, just run a computation in the parallel iterator using a cartesian product generated by ranges. I ended up with this solution that worked for me. It's not implemented for `IndexedParallelIterator` like suggested in the issue, only for `ParallelIterator`. I don't know enough to know how this would impact performance.

Feel free to close this if it's not done properly or out of scope. I'm also open to suggestions if there's a better way to do this. 