### PR TITLE
 Grammatical fixes in documentation comments

### DIFF
--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -1,4 +1,4 @@
-//! Contains support for user-managed thread pools, represented by the
+//! Contains support for user-managed thread-pools, represented by the
 //! the [`ThreadPool`] type (see that struct for details).
 //!
 //! [`ThreadPool`]: struct.ThreadPool.html
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 mod test;
 
-/// Represents a user created [thread-pool].
+/// Represents a user-created [thread-pool].
 ///
 /// Use a [`ThreadPoolBuilder`] to specify the number and/or names of threads
 /// in the pool. After calling [`ThreadPoolBuilder::build()`], you can then

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2895,7 +2895,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     }
 
     /// Determines if the elements of this `ParallelIterator`
-    /// are less or equal to those of another.
+    /// are less than or equal to those of another.
     fn le<I>(self, other: I) -> bool
     where
         I: IntoParallelIterator,
@@ -2918,7 +2918,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
     }
 
     /// Determines if the elements of this `ParallelIterator`
-    /// are less or equal to those of another.
+    /// are less than or equal to those of another.
     fn ge<I>(self, other: I) -> bool
     where
         I: IntoParallelIterator,


### PR DESCRIPTION

## Changes Made

### File: `rayon-core/src/thread_pool/mod.rs`
1. Changed compound term formatting:
   - Old: `user-managed thread pools`
   - New: `user-managed thread-pools`
   Reason: Maintaining consistent hyphenation of "thread-pool" throughout the documentation, as this compound term is used with hyphens elsewhere in the codebase.

2. Added hyphenation for compound adjective:
   - Old: `user created`
   - New: `user-created`
   Reason: The term "user-created" should be hyphenated to correctly form a compound adjective, improving readability and grammatical accuracy.

