### PR TITLE
Update lots of doc links to use item paths instead of file paths

### DIFF
--- a/rayon-core/src/broadcast/mod.rs
+++ b/rayon-core/src/broadcast/mod.rs
@@ -13,9 +13,9 @@ mod test;
 /// within that threadpool. When the call has completed on each thread, returns
 /// a vector containing all of their return values.
 ///
-/// For more information, see the [`ThreadPool::broadcast()`][m] method.
+/// For more information, see the [`ThreadPool::broadcast()`] method.
 ///
-/// [m]: struct.ThreadPool.html#method.broadcast
+/// [`ThreadPool::broadcast()`]: crate::ThreadPool::broadcast()
 pub fn broadcast<OP, R>(op: OP) -> Vec<R>
 where
     OP: Fn(BroadcastContext<'_>) -> R + Sync,
@@ -30,9 +30,9 @@ where
 /// current stack frame -- therefore, it cannot capture any references onto the
 /// stack (you will likely need a `move` closure).
 ///
-/// For more information, see the [`ThreadPool::spawn_broadcast()`][m] method.
+/// For more information, see the [`ThreadPool::spawn_broadcast()`] method.
 ///
-/// [m]: struct.ThreadPool.html#method.spawn_broadcast
+/// [`ThreadPool::spawn_broadcast()`]: crate::ThreadPool::spawn_broadcast()
 pub fn spawn_broadcast<OP>(op: OP)
 where
     OP: Fn(BroadcastContext<'_>) + Send + Sync + 'static,

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -2,29 +2,22 @@
 //!
 //! These APIs have been mirrored in the Rayon crate and it is recommended to use these from there.
 //!
-//! [`join`] is used to take two closures and potentially run them in parallel.
+//! [`join()`] is used to take two closures and potentially run them in parallel.
 //!   - It will run in parallel if task B gets stolen before task A can finish.
 //!   - It will run sequentially if task A finishes before task B is stolen and can continue on task B.
 //!
-//! [`scope`] creates a scope in which you can run any number of parallel tasks.
+//! [`scope()`] creates a scope in which you can run any number of parallel tasks.
 //! These tasks can spawn nested tasks and scopes, but given the nature of work stealing, the order of execution can not be guaranteed.
 //! The scope will exist until all tasks spawned within the scope have been completed.
 //!
-//! [`spawn`] add a task into the 'static' or 'global' scope, or a local scope created by the [`scope()`] function.
+//! [`spawn()`] add a task into the 'static' or 'global' scope, or a local scope created by the [`scope()`] function.
 //!
 //! [`ThreadPool`] can be used to create your own thread pools (using [`ThreadPoolBuilder`]) or to customize the global one.
-//! Tasks spawned within the pool (using [`install()`], [`join()`], etc.) will be added to a deque,
+//! Tasks spawned within the pool (using [`install()`][tpinstall], [`join()`][tpjoin], etc.) will be added to a deque,
 //! where it becomes available for work stealing from other threads in the local threadpool.
 //!
-//! [`join`]: fn.join.html
-//! [`scope`]: fn.scope.html
-//! [`scope()`]: fn.scope.html
-//! [`spawn`]: fn.spawn.html
-//! [`ThreadPool`]: struct.threadpool.html
-//! [`install()`]: struct.ThreadPool.html#method.install
-//! [`spawn()`]: struct.ThreadPool.html#method.spawn
-//! [`join()`]: struct.ThreadPool.html#method.join
-//! [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
+//! [tpinstall]: ThreadPool::install()
+//! [tpjoin]: ThreadPool::join()
 //!
 //! # Global fallback when threading is unsupported
 //!
@@ -139,7 +132,7 @@ pub fn max_num_threads() -> usize {
 /// number may vary over time in future versions (see [the
 /// `num_threads()` method for details][snt]).
 ///
-/// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
+/// [snt]: ThreadPoolBuilder::num_threads
 pub fn current_num_threads() -> usize {
     crate::registry::Registry::current_num_threads()
 }
@@ -173,8 +166,7 @@ enum ErrorKind {
 /// rayon::ThreadPoolBuilder::new().num_threads(22).build_global().unwrap();
 /// ```
 ///
-/// [`ThreadPool`]: struct.ThreadPool.html
-/// [`build_global()`]: struct.ThreadPoolBuilder.html#method.build_global
+/// [`build_global()`]: Self::build_global()
 pub struct ThreadPoolBuilder<S = DefaultSpawn> {
     /// The number of threads in the rayon thread pool.
     /// If zero will use the RAYON_NUM_THREADS environment variable.
@@ -210,8 +202,6 @@ pub struct ThreadPoolBuilder<S = DefaultSpawn> {
 }
 
 /// Contains the rayon thread pool configuration. Use [`ThreadPoolBuilder`] instead.
-///
-/// [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
 #[deprecated(note = "Use `ThreadPoolBuilder`")]
 #[derive(Default)]
 pub struct Configuration {
@@ -295,11 +285,11 @@ impl ThreadPoolBuilder {
     /// Creates a scoped `ThreadPool` initialized using this configuration.
     ///
     /// This is a convenience function for building a pool using [`std::thread::scope`]
-    /// to spawn threads in a [`spawn_handler`](#method.spawn_handler).
+    /// to spawn threads in a [`spawn_handler`].
     /// The threads in this pool will start by calling `wrapper`, which should
     /// do initialization and continue by calling `ThreadBuilder::run()`.
     ///
-    /// [`std::thread::scope`]: https://doc.rust-lang.org/std/thread/fn.scope.html
+    /// [`spawn_handler`]: Self::spawn_handler()
     ///
     /// # Examples
     ///
@@ -409,10 +399,10 @@ impl<S> ThreadPoolBuilder<S> {
     ///
     /// This can also be used for a pool of scoped threads like [`crossbeam::scope`],
     /// or [`std::thread::scope`] introduced in Rust 1.63, which is encapsulated in
-    /// [`build_scoped`](#method.build_scoped).
+    /// [`build_scoped`].
     ///
     /// [`crossbeam::scope`]: https://docs.rs/crossbeam/0.8/crossbeam/fn.scope.html
-    /// [`std::thread::scope`]: https://doc.rust-lang.org/std/thread/fn.scope.html
+    /// [`build_scoped`]: Self::build_scoped()
     ///
     /// ```
     /// # use rayon_core as rayon;
@@ -624,7 +614,6 @@ impl<S> ThreadPoolBuilder<S> {
     /// [`scope_fifo()`] for a similar effect.
     ///
     /// [RFC #1]: https://github.com/rayon-rs/rfcs/blob/main/accepted/rfc0001-scope-scheduling.md
-    /// [`scope_fifo()`]: fn.scope_fifo.html
     #[deprecated(note = "use `scope_fifo` and `spawn_fifo` for similar effect")]
     pub fn breadth_first(mut self) -> Self {
         self.breadth_first = true;

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -19,8 +19,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Once};
 use std::thread;
 
-/// Thread builder used for customization via
-/// [`ThreadPoolBuilder::spawn_handler`](struct.ThreadPoolBuilder.html#method.spawn_handler).
+/// Thread builder used for customization via [`ThreadPoolBuilder::spawn_handler()`].
 pub struct ThreadBuilder {
     name: Option<String>,
     stack_size: Option<usize>,

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -1,9 +1,7 @@
 //! Methods for custom fork-join scopes, created by the [`scope()`]
 //! and [`in_place_scope()`] functions. These are a more flexible alternative to [`join()`].
 //!
-//! [`scope()`]: fn.scope.html
-//! [`in_place_scope()`]: fn.in_place_scope.html
-//! [`join()`]: ../join/join.fn.html
+//! [`join()`]: crate::join()
 
 use crate::broadcast::BroadcastContext;
 use crate::job::{ArcJob, HeapJob, JobFifo, JobRef};
@@ -23,8 +21,6 @@ mod test;
 
 /// Represents a fork-join scope which can be used to spawn any number of tasks.
 /// See [`scope()`] for more information.
-///
-///[`scope()`]: fn.scope.html
 pub struct Scope<'scope> {
     base: ScopeBase<'scope>,
 }
@@ -32,8 +28,6 @@ pub struct Scope<'scope> {
 /// Represents a fork-join scope which can be used to spawn any number of tasks.
 /// Those spawned from the same thread are prioritized in relative FIFO order.
 /// See [`scope_fifo()`] for more information.
-///
-///[`scope_fifo()`]: fn.scope_fifo.html
 pub struct ScopeFifo<'scope> {
     base: ScopeBase<'scope>,
     fifos: Vec<JobFifo>,
@@ -180,8 +174,6 @@ struct ScopeBase<'scope> {
 /// "stale" tasks.  For an alternate approach, consider
 /// [`scope_fifo()`] instead.
 ///
-/// [`scope_fifo()`]: fn.scope_fifo.html
-///
 /// # Accessing stack data
 ///
 /// In general, spawned tasks may access stack data in place that
@@ -305,8 +297,6 @@ where
 /// Tasks in a `scope_fifo()` run similarly to [`scope()`], but there's a
 /// difference in the order of execution. Consider a similar example:
 ///
-/// [`scope()`]: fn.scope.html
-///
 /// ```rust
 /// # use rayon_core as rayon;
 /// // point start
@@ -360,7 +350,7 @@ where
 ///
 /// For more details on this design, see Rayon [RFC #1].
 ///
-/// [`breadth_first`]: struct.ThreadPoolBuilder.html#method.breadth_first
+/// [`breadth_first`]: crate::ThreadPoolBuilder::breadth_first
 /// [RFC #1]: https://github.com/rayon-rs/rfcs/blob/main/accepted/rfc0001-scope-scheduling.md
 ///
 /// # Panics
@@ -515,7 +505,7 @@ impl<'scope> Scope<'scope> {
     /// The [`scope` function] has more extensive documentation about
     /// task spawning.
     ///
-    /// [`scope` function]: fn.scope.html
+    /// [`scope` function]: scope()
     pub fn spawn<BODY>(&self, body: BODY)
     where
         BODY: FnOnce(&Scope<'scope>) + Send + 'scope,
@@ -574,8 +564,7 @@ impl<'scope> ScopeFifo<'scope> {
     /// priority.  The [`scope_fifo` function] has more details about
     /// this distinction.
     ///
-    /// [`Scope::spawn()`]: struct.Scope.html#method.spawn
-    /// [`scope_fifo` function]: fn.scope_fifo.html
+    /// [`scope_fifo` function]: scope_fifo()
     pub fn spawn_fifo<BODY>(&self, body: BODY)
     where
         BODY: FnOnce(&ScopeFifo<'scope>) + Send + 'scope,

--- a/rayon-core/src/spawn/mod.rs
+++ b/rayon-core/src/spawn/mod.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 /// tied to the current stack frame, and hence it cannot hold any
 /// references other than those with `'static` lifetime. If you want
 /// to spawn a task that references stack data, use [the `scope()`
-/// function][scope] to create a scope.
+/// function] to create a scope.
 ///
-/// [scope]: fn.scope.html
+/// [the `scope()` function]: crate::scope()
 ///
 /// Since tasks spawned with this function cannot hold references into
 /// the enclosing stack frame, you almost certainly want to use a
@@ -32,16 +32,14 @@ use std::sync::Arc;
 /// threads can steal older "stale" tasks.  For an alternate approach,
 /// consider [`spawn_fifo()`] instead.
 ///
-/// [`spawn_fifo()`]: fn.spawn_fifo.html
-///
 /// # Panic handling
 ///
 /// If this closure should panic, the resulting panic will be
 /// propagated to the panic handler registered in the `ThreadPoolBuilder`,
-/// if any.  See [`ThreadPoolBuilder::panic_handler()`][ph] for more
+/// if any.  See [`ThreadPoolBuilder::panic_handler()`] for more
 /// details.
 ///
-/// [ph]: struct.ThreadPoolBuilder.html#method.panic_handler
+/// [`ThreadPoolBuilder::panic_handler()`]: crate::ThreadPoolBuilder::panic_handler()
 ///
 /// # Examples
 ///
@@ -106,27 +104,29 @@ where
 /// tied to the current stack frame, and hence it cannot hold any
 /// references other than those with `'static` lifetime. If you want
 /// to spawn a task that references stack data, use [the `scope_fifo()`
-/// function](fn.scope_fifo.html) to create a scope.
+/// function] to create a scope.
 ///
 /// The behavior is essentially the same as [the `spawn`
-/// function](fn.spawn.html), except that calls from the same thread
+/// function], except that calls from the same thread
 /// will be prioritized in FIFO order. This is similar to the now-
 /// deprecated [`breadth_first`] option, except the effect is isolated
 /// to relative `spawn_fifo` calls, not all threadpool tasks.
 ///
 /// For more details on this design, see Rayon [RFC #1].
 ///
-/// [`breadth_first`]: struct.ThreadPoolBuilder.html#method.breadth_first
+/// [the `scope_fifo()` function]: crate::scope_fifo()
+/// [the `spawn` function]: crate::spawn()
+/// [`breadth_first`]: crate::ThreadPoolBuilder::breadth_first
 /// [RFC #1]: https://github.com/rayon-rs/rfcs/blob/main/accepted/rfc0001-scope-scheduling.md
 ///
 /// # Panic handling
 ///
 /// If this closure should panic, the resulting panic will be
 /// propagated to the panic handler registered in the `ThreadPoolBuilder`,
-/// if any.  See [`ThreadPoolBuilder::panic_handler()`][ph] for more
+/// if any.  See [`ThreadPoolBuilder::panic_handler()`] for more
 /// details.
 ///
-/// [ph]: struct.ThreadPoolBuilder.html#method.panic_handler
+/// [`ThreadPoolBuilder::panic_handler()`]: crate::ThreadPoolBuilder::panic_handler
 pub fn spawn_fifo<F>(func: F)
 where
     F: FnOnce() + Send + 'static,

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -1,7 +1,5 @@
 //! Contains support for user-managed thread pools, represented by the
 //! the [`ThreadPool`] type (see that struct for details).
-//!
-//! [`ThreadPool`]: struct.ThreadPool.html
 
 use crate::broadcast::{self, BroadcastContext};
 use crate::join;
@@ -43,11 +41,8 @@ mod test;
 ///
 ///
 /// [thread-pool]: https://en.wikipedia.org/wiki/Thread_pool
-/// [`ThreadPool`]: struct.ThreadPool.html
-/// [`ThreadPool::new()`]: struct.ThreadPool.html#method.new
-/// [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
-/// [`ThreadPoolBuilder::build()`]: struct.ThreadPoolBuilder.html#method.build
-/// [`ThreadPool::install()`]: struct.ThreadPool.html#method.install
+/// [`ThreadPoolBuilder::build()`]: ThreadPoolBuilder::build()
+/// [`ThreadPool::install()`]: Self::install()
 pub struct ThreadPool {
     registry: Arc<Registry>,
 }
@@ -207,8 +202,7 @@ impl ThreadPool {
     /// then this number may vary over time in future versions (see [the
     /// `num_threads()` method for details][snt]).
     ///
-    /// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
-    /// [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
+    /// [snt]: ThreadPoolBuilder::num_threads()
     #[inline]
     pub fn current_num_threads(&self) -> usize {
         self.registry.num_threads()
@@ -233,7 +227,7 @@ impl ThreadPool {
     /// indices may wind up being reused if threads are terminated and
     /// restarted.
     ///
-    /// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
+    /// [snt]: ThreadPoolBuilder::num_threads()
     #[inline]
     pub fn current_thread_index(&self) -> Option<usize> {
         let curr = self.registry.current_thread()?;
@@ -283,9 +277,9 @@ impl ThreadPool {
     /// Creates a scope that executes within this thread-pool.
     /// Equivalent to `self.install(|| scope(...))`.
     ///
-    /// See also: [the `scope()` function][scope].
+    /// See also: [the `scope()` function].
     ///
-    /// [scope]: fn.scope.html
+    /// [the `scope()` function]: crate::scope()
     pub fn scope<'scope, OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce(&Scope<'scope>) -> R + Send,
@@ -298,9 +292,9 @@ impl ThreadPool {
     /// Spawns from the same thread are prioritized in relative FIFO order.
     /// Equivalent to `self.install(|| scope_fifo(...))`.
     ///
-    /// See also: [the `scope_fifo()` function][scope_fifo].
+    /// See also: [the `scope_fifo()` function].
     ///
-    /// [scope_fifo]: fn.scope_fifo.html
+    /// [the `scope_fifo()` function]: crate::scope_fifo()
     pub fn scope_fifo<'scope, OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce(&ScopeFifo<'scope>) -> R + Send,
@@ -311,9 +305,9 @@ impl ThreadPool {
 
     /// Creates a scope that spawns work into this thread-pool.
     ///
-    /// See also: [the `in_place_scope()` function][in_place_scope].
+    /// See also: [the `in_place_scope()` function].
     ///
-    /// [in_place_scope]: fn.in_place_scope.html
+    /// [the `in_place_scope()` function]: crate::in_place_scope()
     pub fn in_place_scope<'scope, OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce(&Scope<'scope>) -> R,
@@ -323,9 +317,9 @@ impl ThreadPool {
 
     /// Creates a scope that spawns work into this thread-pool in FIFO order.
     ///
-    /// See also: [the `in_place_scope_fifo()` function][in_place_scope_fifo].
+    /// See also: [the `in_place_scope_fifo()` function].
     ///
-    /// [in_place_scope_fifo]: fn.in_place_scope_fifo.html
+    /// [the `in_place_scope_fifo()` function]: crate::in_place_scope_fifo()
     pub fn in_place_scope_fifo<'scope, OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce(&ScopeFifo<'scope>) -> R,
@@ -340,7 +334,7 @@ impl ThreadPool {
     ///
     /// See also: [the `spawn()` function defined on scopes][spawn].
     ///
-    /// [spawn]: struct.Scope.html#method.spawn
+    /// [spawn]: Scope::spawn()
     pub fn spawn<OP>(&self, op: OP)
     where
         OP: FnOnce() + Send + 'static,
@@ -356,7 +350,7 @@ impl ThreadPool {
     ///
     /// See also: [the `spawn_fifo()` function defined on scopes][spawn_fifo].
     ///
-    /// [spawn_fifo]: struct.ScopeFifo.html#method.spawn_fifo
+    /// [spawn_fifo]: ScopeFifo::spawn_fifo()
     pub fn spawn_fifo<OP>(&self, op: OP)
     where
         OP: FnOnce() + Send + 'static,
@@ -425,9 +419,9 @@ impl fmt::Debug for ThreadPool {
 /// lifetime. However, multiple threads may share the same index if
 /// they are in distinct thread-pools.
 ///
-/// See also: [the `ThreadPool::current_thread_index()` method].
+/// See also: [the `ThreadPool::current_thread_index()` method][m].
 ///
-/// [m]: struct.ThreadPool.html#method.current_thread_index
+/// [m]: ThreadPool::current_thread_index()
 ///
 /// # Future compatibility note
 ///
@@ -439,7 +433,7 @@ impl fmt::Debug for ThreadPool {
 /// indices may wind up being reused if threads are terminated and
 /// restarted.
 ///
-/// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
+/// [snt]: ThreadPoolBuilder::num_threads()
 #[inline]
 pub fn current_thread_index() -> Option<usize> {
     unsafe {
@@ -453,7 +447,7 @@ pub fn current_thread_index() -> Option<usize> {
 /// `None`. For more information, see [the
 /// `ThreadPool::current_thread_has_pending_tasks()` method][m].
 ///
-/// [m]: struct.ThreadPool.html#method.current_thread_has_pending_tasks
+/// [m]: ThreadPool::current_thread_has_pending_tasks()
 #[inline]
 pub fn current_thread_has_pending_tasks() -> Option<bool> {
     unsafe {

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -1,9 +1,9 @@
-//! Parallel iterator types for [standard collections][std::collections]
+//! Parallel iterator types for [standard collections]
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
 //!
-//! [std::collections]: https://doc.rust-lang.org/stable/std/collections/
+//! [standard collections]: std::collections
 
 /// Convert an iterable collection into a parallel iterator by first
 /// collecting into a temporary `Vec`, then iterating that.

--- a/src/iter/blocks.rs
+++ b/src/iter/blocks.rs
@@ -53,8 +53,7 @@ where
 ///
 /// This struct is created by the [`by_exponential_blocks()`] method on [`IndexedParallelIterator`]
 ///
-/// [`by_exponential_blocks()`]: trait.IndexedParallelIterator.html#method.by_exponential_blocks
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`by_exponential_blocks()`]: IndexedParallelIterator::by_exponential_blocks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct ExponentialBlocks<I> {
@@ -96,8 +95,7 @@ fn exponential_size(size: &usize) -> Option<usize> {
 ///
 /// This struct is created by the [`by_uniform_blocks()`] method on [`IndexedParallelIterator`]
 ///
-/// [`by_uniform_blocks()`]: trait.IndexedParallelIterator.html#method.by_uniform_blocks
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`by_uniform_blocks()`]: IndexedParallelIterator::by_uniform_blocks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct UniformBlocks<I> {

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -6,8 +6,7 @@ use std::iter;
 /// `Chain` is an iterator that joins `b` after `a` in one continuous iterator.
 /// This struct is created by the [`chain()`] method on [`ParallelIterator`]
 ///
-/// [`chain()`]: trait.ParallelIterator.html#method.chain
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`chain()`]: ParallelIterator::chain()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Chain<A, B>

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -6,8 +6,7 @@ use crate::math::div_round_up;
 ///
 /// This struct is created by the [`chunks()`] method on [`IndexedParallelIterator`]
 ///
-/// [`chunks()`]: trait.IndexedParallelIterator.html#method.chunks
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`chunks()`]: IndexedParallelIterator::chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Chunks<I>

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -7,8 +7,7 @@ use std::iter;
 ///
 /// This struct is created by the [`cloned()`] method on [`ParallelIterator`]
 ///
-/// [`cloned()`]: trait.ParallelIterator.html#method.cloned
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`cloned()`]: ParallelIterator::cloned()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Cloned<I: ParallelIterator> {

--- a/src/iter/copied.rs
+++ b/src/iter/copied.rs
@@ -7,8 +7,7 @@ use std::iter;
 ///
 /// This struct is created by the [`copied()`] method on [`ParallelIterator`]
 ///
-/// [`copied()`]: trait.ParallelIterator.html#method.copied
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`copied()`]: ParallelIterator::copied()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Copied<I: ParallelIterator> {

--- a/src/iter/empty.rs
+++ b/src/iter/empty.rs
@@ -27,7 +27,9 @@ pub fn empty<T: Send>() -> Empty<T> {
     }
 }
 
-/// Iterator adaptor for [the `empty()` function](fn.empty.html).
+/// Iterator adaptor for [the `empty()` function].
+///
+/// [the `empty()` function]: empty()
 pub struct Empty<T: Send> {
     marker: PhantomData<T>,
 }

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -6,8 +6,7 @@ use std::ops::Range;
 /// `Enumerate` is an iterator that returns the current count along with the element.
 /// This struct is created by the [`enumerate()`] method on [`IndexedParallelIterator`]
 ///
-/// [`enumerate()`]: trait.IndexedParallelIterator.html#method.enumerate
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`enumerate()`]: IndexedParallelIterator::enumerate()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Enumerate<I: IndexedParallelIterator> {

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -6,8 +6,7 @@ use std::fmt::{self, Debug};
 /// `Filter` takes a predicate `filter_op` and filters out elements that match.
 /// This struct is created by the [`filter()`] method on [`ParallelIterator`]
 ///
-/// [`filter()`]: trait.ParallelIterator.html#method.filter
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`filter()`]: ParallelIterator::filter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Filter<I: ParallelIterator, P> {

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -6,8 +6,7 @@ use std::fmt::{self, Debug};
 /// `FilterMap` creates an iterator that uses `filter_op` to both filter and map elements.
 /// This struct is created by the [`filter_map()`] method on [`ParallelIterator`].
 ///
-/// [`filter_map()`]: trait.ParallelIterator.html#method.filter_map
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`filter_map()`]: ParallelIterator::filter_map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FilterMap<I: ParallelIterator, P> {

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -6,8 +6,7 @@ use std::fmt::{self, Debug};
 /// `FlatMap` maps each element to a parallel iterator, then flattens these iterators together.
 /// This struct is created by the [`flat_map()`] method on [`ParallelIterator`]
 ///
-/// [`flat_map()`]: trait.ParallelIterator.html#method.flat_map
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`flat_map()`]: ParallelIterator::flat_map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FlatMap<I: ParallelIterator, F> {

--- a/src/iter/flat_map_iter.rs
+++ b/src/iter/flat_map_iter.rs
@@ -6,8 +6,7 @@ use std::fmt::{self, Debug};
 /// `FlatMapIter` maps each element to a serial iterator, then flattens these iterators together.
 /// This struct is created by the [`flat_map_iter()`] method on [`ParallelIterator`]
 ///
-/// [`flat_map_iter()`]: trait.ParallelIterator.html#method.flat_map_iter
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`flat_map_iter()`]: ParallelIterator::flat_map_iter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FlatMapIter<I: ParallelIterator, F> {

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -4,8 +4,7 @@ use super::*;
 /// `Flatten` turns each element to a parallel iterator, then flattens these iterators
 /// together. This struct is created by the [`flatten()`] method on [`ParallelIterator`].
 ///
-/// [`flatten()`]: trait.ParallelIterator.html#method.flatten
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`flatten()`]: ParallelIterator::flatten()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Flatten<I: ParallelIterator> {

--- a/src/iter/flatten_iter.rs
+++ b/src/iter/flatten_iter.rs
@@ -4,8 +4,7 @@ use super::*;
 /// `FlattenIter` turns each element to a serial iterator, then flattens these iterators
 /// together. This struct is created by the [`flatten_iter()`] method on [`ParallelIterator`].
 ///
-/// [`flatten_iter()`]: trait.ParallelIterator.html#method.flatten_iter
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`flatten_iter()`]: ParallelIterator::flatten_iter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct FlattenIter<I: ParallelIterator> {

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -22,8 +22,7 @@ where
 /// `Fold` is an iterator that applies a function over an iterator producing a single value.
 /// This struct is created by the [`fold()`] method on [`ParallelIterator`]
 ///
-/// [`fold()`]: trait.ParallelIterator.html#method.fold
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`fold()`]: ParallelIterator::fold()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Fold<I, ID, F> {
@@ -197,8 +196,7 @@ where
 /// `FoldWith` is an iterator that applies a function over an iterator producing a single value.
 /// This struct is created by the [`fold_with()`] method on [`ParallelIterator`]
 ///
-/// [`fold_with()`]: trait.ParallelIterator.html#method.fold_with
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`fold_with()`]: ParallelIterator::fold_with()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FoldWith<I, U, F> {

--- a/src/iter/fold_chunks.rs
+++ b/src/iter/fold_chunks.rs
@@ -10,8 +10,7 @@ use crate::math::div_round_up;
 ///
 /// This struct is created by the [`fold_chunks()`] method on [`IndexedParallelIterator`]
 ///
-/// [`fold_chunks()`]: trait.IndexedParallelIterator.html#method.fold_chunks
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`fold_chunks()`]: IndexedParallelIterator::fold_chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FoldChunks<I, ID, F>

--- a/src/iter/fold_chunks_with.rs
+++ b/src/iter/fold_chunks_with.rs
@@ -10,8 +10,7 @@ use crate::math::div_round_up;
 ///
 /// This struct is created by the [`fold_chunks_with()`] method on [`IndexedParallelIterator`]
 ///
-/// [`fold_chunks_with()`]: trait.IndexedParallelIterator.html#method.fold_chunks
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`fold_chunks_with()`]: IndexedParallelIterator::fold_chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct FoldChunksWith<I, U, F>

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -9,8 +9,7 @@ use std::iter;
 ///
 /// This struct is created by the [`inspect()`] method on [`ParallelIterator`]
 ///
-/// [`inspect()`]: trait.ParallelIterator.html#method.inspect
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`inspect()`]: ParallelIterator::inspect()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Inspect<I: ParallelIterator, F> {

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -6,8 +6,7 @@ use std::iter::Fuse;
 /// `i` and `j` in one continuous iterator. This struct is created by
 /// the [`interleave()`] method on [`IndexedParallelIterator`]
 ///
-/// [`interleave()`]: trait.IndexedParallelIterator.html#method.interleave
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`interleave()`]: IndexedParallelIterator::interleave()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Interleave<I, J>

--- a/src/iter/interleave_shortest.rs
+++ b/src/iter/interleave_shortest.rs
@@ -8,8 +8,7 @@ use super::*;
 /// This struct is created by the [`interleave_shortest()`] method on
 /// [`IndexedParallelIterator`].
 ///
-/// [`interleave_shortest()`]: trait.IndexedParallelIterator.html#method.interleave_shortest
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`interleave_shortest()`]: IndexedParallelIterator::interleave_shortest()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct InterleaveShortest<I, J>

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -7,8 +7,7 @@ use std::iter::{self, Fuse};
 /// item of the adapted iterator.  This struct is created by the
 /// [`intersperse()`] method on [`ParallelIterator`]
 ///
-/// [`intersperse()`]: trait.ParallelIterator.html#method.intersperse
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`intersperse()`]: ParallelIterator::intersperse()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct Intersperse<I>

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -4,8 +4,7 @@ use super::*;
 /// `MinLen` is an iterator that imposes a minimum length on iterator splits.
 /// This struct is created by the [`with_min_len()`] method on [`IndexedParallelIterator`]
 ///
-/// [`with_min_len()`]: trait.IndexedParallelIterator.html#method.with_min_len
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`with_min_len()`]: IndexedParallelIterator::with_min_len()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct MinLen<I: IndexedParallelIterator> {
@@ -138,8 +137,7 @@ where
 /// `MaxLen` is an iterator that imposes a maximum length on iterator splits.
 /// This struct is created by the [`with_max_len()`] method on [`IndexedParallelIterator`]
 ///
-/// [`with_max_len()`]: trait.IndexedParallelIterator.html#method.with_max_len
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`with_max_len()`]: IndexedParallelIterator::with_max_len()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct MaxLen<I: IndexedParallelIterator> {

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -8,8 +8,7 @@ use std::iter;
 ///
 /// This struct is created by the [`map()`] method on [`ParallelIterator`]
 ///
-/// [`map()`]: trait.ParallelIterator.html#method.map
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`map()`]: ParallelIterator::map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Map<I: ParallelIterator, F> {

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -7,8 +7,7 @@ use std::fmt::{self, Debug};
 ///
 /// This struct is created by the [`map_with()`] method on [`ParallelIterator`]
 ///
-/// [`map_with()`]: trait.ParallelIterator.html#method.map_with
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`map_with()`]: ParallelIterator::map_with()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct MapWith<I: ParallelIterator, T, F> {
@@ -339,8 +338,7 @@ where
 ///
 /// This struct is created by the [`map_init()`] method on [`ParallelIterator`]
 ///
-/// [`map_init()`]: trait.ParallelIterator.html#method.map_init
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`map_init()`]: ParallelIterator::map_init()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct MapInit<I: ParallelIterator, INIT, F> {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -49,10 +49,10 @@
 //!   collection to extend, you can use [`collect()`] to create a new
 //!   one from scratch.)
 //!
-//! [the `ParallelSlice` trait]: ../slice/trait.ParallelSlice.html
-//! [the `ParallelString` trait]: ../str/trait.ParallelString.html
-//! [`par_extend`]: trait.ParallelExtend.html
-//! [`collect()`]: trait.ParallelIterator.html#method.collect
+//! [the `ParallelSlice` trait]: crate::slice::ParallelSlice
+//! [the `ParallelString` trait]: crate::str::ParallelString
+//! [`par_extend`]: ParallelExtend
+//! [`collect()`]: ParallelIterator::collect()
 //!
 //! To see the full range of methods available on parallel iterators,
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
@@ -61,11 +61,9 @@
 //! If you'd like to build a custom parallel iterator, or to write your own
 //! combinator, then check out the [split] function and the [plumbing] module.
 //!
-//! [regular iterator]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
-//! [`ParallelIterator`]: trait.ParallelIterator.html
-//! [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
-//! [split]: fn.split.html
-//! [plumbing]: plumbing/index.html
+//! [regular iterator]: Iterator
+//! [split]: split()
+//! [plumbing]: plumbing
 //!
 //! Note: Several of the `ParallelIterator` methods rely on a `Try` trait which
 //! has been deliberately obscured from the public API.  This trait is intended
@@ -215,9 +213,6 @@ pub use self::{
 /// By implementing `IntoParallelIterator` for a type, you define how it will
 /// transformed into an iterator. This is a parallel version of the standard
 /// library's [`std::iter::IntoIterator`] trait.
-///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`std::iter::IntoIterator`]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
 pub trait IntoParallelIterator {
     /// The parallel iterator type that will be created.
     type Iter: ParallelIterator<Item = Self::Item>;
@@ -246,7 +241,7 @@ pub trait IntoParallelIterator {
     /// assert_eq!(v, [(0, 5), (1, 6), (2, 7), (3, 8), (4, 9)]);
     /// ```
     ///
-    /// [`zip`]: trait.IndexedParallelIterator.html#method.zip
+    /// [`zip`]: IndexedParallelIterator::zip()
     fn into_par_iter(self) -> Self::Iter;
 }
 
@@ -260,9 +255,6 @@ pub trait IntoParallelIterator {
 /// `for I where &I: IntoParallelIterator`. In most cases, users
 /// will want to implement [`IntoParallelIterator`] rather than implement
 /// this trait directly.
-///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`IntoParallelIterator`]: trait.IntoParallelIterator.html
 pub trait IntoParallelRefIterator<'data> {
     /// The type of the parallel iterator that will be returned.
     type Iter: ParallelIterator<Item = Self::Item>;
@@ -311,9 +303,6 @@ where
 /// `for I where &mut I: IntoParallelIterator`. In most cases, users
 /// will want to implement [`IntoParallelIterator`] rather than implement
 /// this trait directly.
-///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`IntoParallelIterator`]: trait.IntoParallelIterator.html
 pub trait IntoParallelRefMutIterator<'data> {
     /// The type of iterator that will be created.
     type Iter: ParallelIterator<Item = Self::Item>;
@@ -360,8 +349,7 @@ where
 /// For examples of using parallel iterators, see [the docs on the
 /// `iter` module][iter].
 ///
-/// [iter]: index.html
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [iter]: self
 pub trait ParallelIterator: Sized + Send {
     /// The type of item that this parallel iterator produces.
     /// For example, if you use the [`for_each`] method, this is the type of
@@ -1653,7 +1641,7 @@ pub trait ParallelIterator: Sized + Send {
     /// the rest of the items in the iterator as soon as possible
     /// (just as `find` stops iterating once a match is found).
     ///
-    /// [find]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find
+    /// [find]: Iterator::find()
     ///
     /// # Examples
     ///
@@ -1937,7 +1925,7 @@ pub trait ParallelIterator: Sized + Send {
     /// to stop processing other items sooner, with the cost of additional
     /// synchronization overhead, which may also inhibit some optimizations.
     ///
-    /// [`join`]: ../fn.join.html#panics
+    /// [`join`]: crate::join()#panics
     ///
     /// # Examples
     ///
@@ -1971,12 +1959,11 @@ pub trait ParallelIterator: Sized + Send {
     /// of how many elements the iterator contains, and even allows you to reuse
     /// an existing vector's backing store rather than allocating a fresh vector.
     ///
-    /// See also [`collect_vec_list()`][Self::collect_vec_list] for collecting
-    /// into a `LinkedList<Vec<T>>`.
+    /// See also [`collect_vec_list()`] for collecting into a
+    /// `LinkedList<Vec<T>>`.
     ///
-    /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
-    /// [`collect_into_vec()`]:
-    ///     trait.IndexedParallelIterator.html#method.collect_into_vec
+    /// [`collect_into_vec()`]: IndexedParallelIterator::collect_into_vec()
+    /// [`collect_vec_list()`]: Self::collect_vec_list()
     ///
     /// # Examples
     ///
@@ -2675,8 +2662,8 @@ pub trait IndexedParallelIterator: ParallelIterator {
     /// See also [`par_chunks()`] and [`par_chunks_mut()`] for similar behavior on
     /// slices, without having to allocate intermediate `Vec`s for the chunks.
     ///
-    /// [`par_chunks()`]: ../slice/trait.ParallelSlice.html#method.par_chunks
-    /// [`par_chunks_mut()`]: ../slice/trait.ParallelSliceMut.html#method.par_chunks_mut
+    /// [`par_chunks()`]: crate::slice::ParallelSlice::par_chunks()
+    /// [`par_chunks_mut()`]: crate::slice::ParallelSliceMut::par_chunks_mut()
     ///
     /// **Panics** if `chunk_size` is 0.
     ///
@@ -3275,8 +3262,7 @@ pub trait IndexedParallelIterator: ParallelIterator {
 ///
 /// `FromParallelIterator` is used through [`ParallelIterator`]'s [`collect()`] method.
 ///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`collect()`]: trait.ParallelIterator.html#method.collect
+/// [`collect()`]: ParallelIterator::collect()
 ///
 /// # Examples
 ///
@@ -3317,21 +3303,19 @@ where
     /// a more 'native' technique is to use the [`par_iter.fold`] or
     /// [`par_iter.fold_with`] methods to create the collection.
     /// Alternatively, if your collection is 'natively' parallel, you
-    /// can use `par_iter.for_each` to process each element in turn.
+    /// can use [`par_iter.for_each`] to process each element in turn.
     ///
-    /// [`LinkedList`]: https://doc.rust-lang.org/std/collections/struct.LinkedList.html
+    /// [`LinkedList`]: std::collections::LinkedList
     /// [`collect_vec_list`]: ParallelIterator::collect_vec_list
-    /// [`par_iter.fold`]: trait.ParallelIterator.html#method.fold
-    /// [`par_iter.fold_with`]: trait.ParallelIterator.html#method.fold_with
-    /// [`par_iter.for_each`]: trait.ParallelIterator.html#method.for_each
+    /// [`par_iter.fold`]: ParallelIterator::fold()
+    /// [`par_iter.fold_with`]: ParallelIterator::fold_with()
+    /// [`par_iter.for_each`]: ParallelIterator::for_each()
     fn from_par_iter<I>(par_iter: I) -> Self
     where
         I: IntoParallelIterator<Item = T>;
 }
 
 /// `ParallelExtend` extends an existing collection with items from a [`ParallelIterator`].
-///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
 ///
 /// # Examples
 ///
@@ -3387,8 +3371,6 @@ where
 ///
 /// Types which are indexable typically implement [`ParallelDrainRange`]
 /// instead, where you can drain fully with `par_drain(..)`.
-///
-/// [`ParallelDrainRange`]: trait.ParallelDrainRange.html
 pub trait ParallelDrainFull {
     /// The draining parallel iterator type that will be created.
     type Iter: ParallelIterator<Item = Self::Item>;
@@ -3429,8 +3411,6 @@ pub trait ParallelDrainFull {
 /// from a collection while retaining the original capacity.
 ///
 /// Types which are not indexable may implement [`ParallelDrainFull`] instead.
-///
-/// [`ParallelDrainFull`]: trait.ParallelDrainFull.html
 pub trait ParallelDrainRange<Idx = usize> {
     /// The draining parallel iterator type that will be created.
     type Iter: ParallelIterator<Item = Self::Item>;

--- a/src/iter/once.rs
+++ b/src/iter/once.rs
@@ -25,7 +25,9 @@ pub fn once<T: Send>(item: T) -> Once<T> {
     Once { item }
 }
 
-/// Iterator adaptor for [the `once()` function](fn.once.html).
+/// Iterator adaptor for [the `once()` function].
+///
+/// [the `once()` function]: once()
 #[derive(Clone, Debug)]
 pub struct Once<T: Send> {
     item: T,

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -8,8 +8,7 @@ use std::thread;
 ///
 /// This struct is created by the [`panic_fuse()`] method on [`ParallelIterator`]
 ///
-/// [`panic_fuse()`]: trait.ParallelIterator.html#method.panic_fuse
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`panic_fuse()`]: ParallelIterator::panic_fuse()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct PanicFuse<I: ParallelIterator> {

--- a/src/iter/par_bridge.rs
+++ b/src/iter/par_bridge.rs
@@ -68,8 +68,6 @@ where
 ///
 /// This type is created when using the `par_bridge` method on `ParallelBridge`. See the
 /// [`ParallelBridge`] documentation for details.
-///
-/// [`ParallelBridge`]: trait.ParallelBridge.html
 #[derive(Debug, Clone)]
 pub struct IterBridge<Iter> {
     iter: Iter,

--- a/src/iter/plumbing/mod.rs
+++ b/src/iter/plumbing/mod.rs
@@ -13,12 +13,12 @@ use super::IndexedParallelIterator;
 /// the plumbing README][r] for more details.
 ///
 /// [r]: https://github.com/rayon-rs/rayon/blob/main/src/iter/plumbing/README.md#producer-callback
-/// [FnOnce]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html
+/// [FnOnce]: std::ops::FnOnce
 pub trait ProducerCallback<T> {
     /// The type of value returned by this callback. Analogous to
     /// [`Output` from the `FnOnce` trait][Output].
     ///
-    /// [Output]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html#associatedtype.Output
+    /// [Output]: std::ops::FnOnce::Output
     type Output;
 
     /// Invokes the callback with the given producer as argument. The
@@ -74,7 +74,7 @@ pub trait Producer: Send + Sized {
     /// parallel splits to reduce overhead, so this should not be
     /// needed.
     ///
-    /// [`with_min_len`]: ../trait.IndexedParallelIterator.html#method.with_min_len
+    /// [`with_min_len`]: super::IndexedParallelIterator::with_min_len()
     fn min_len(&self) -> usize {
         1
     }
@@ -87,7 +87,7 @@ pub trait Producer: Send + Sized {
     /// attempts to adjust the size of parallel splits to reduce
     /// overhead, so this should not be needed.
     ///
-    /// [`with_max_len`]: ../trait.IndexedParallelIterator.html#method.with_max_len
+    /// [`with_max_len`]: super::IndexedParallelIterator::with_max_len()
     fn max_len(&self) -> usize {
         usize::MAX
     }
@@ -119,9 +119,7 @@ pub trait Producer: Send + Sized {
 /// README][r] for further details.
 ///
 /// [r]: https://github.com/rayon-rs/rayon/blob/main/src/iter/plumbing/README.md
-/// [fold]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.fold
-/// [`Folder`]: trait.Folder.html
-/// [`Producer`]: trait.Producer.html
+/// [fold]: Iterator::fold()
 pub trait Consumer<Item>: Send + Sized {
     /// The type of folder that this consumer can be converted into.
     type Folder: Folder<Item, Result = Self::Result>;
@@ -152,7 +150,7 @@ pub trait Consumer<Item>: Send + Sized {
 /// method. At the end, once all items have been consumed, it can then
 /// be converted (using `complete`) into a final value.
 ///
-/// [fold]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.fold
+/// [fold]: Iterator::fold()
 pub trait Folder<Item>: Sized {
     /// The type of result that will ultimately be produced by the folder.
     type Result;
@@ -343,8 +341,8 @@ impl LengthSplitter {
 /// iterators: it is often used as the definition of the
 /// [`drive_unindexed`] or [`drive`] methods.
 ///
-/// [`drive_unindexed`]: ../trait.ParallelIterator.html#tymethod.drive_unindexed
-/// [`drive`]: ../trait.IndexedParallelIterator.html#tymethod.drive
+/// [`drive_unindexed`]: super::ParallelIterator::drive_unindexed()
+/// [`drive`]: super::IndexedParallelIterator::drive()
 pub fn bridge<I, C>(par_iter: I, consumer: C) -> C::Result
 where
     I: IndexedParallelIterator,
@@ -373,7 +371,7 @@ where
 }
 
 /// This helper function is used to "connect" a producer and a
-/// consumer. You may prefer to call [`bridge`], which wraps this
+/// consumer. You may prefer to call [`bridge()`], which wraps this
 /// function. This function will draw items from `producer` and feed
 /// them to `consumer`, splitting and creating parallel tasks when
 /// needed.
@@ -382,9 +380,8 @@ where
 /// iterators: it is often used as the definition of the
 /// [`drive_unindexed`] or [`drive`] methods.
 ///
-/// [`bridge`]: fn.bridge.html
-/// [`drive_unindexed`]: ../trait.ParallelIterator.html#tymethod.drive_unindexed
-/// [`drive`]: ../trait.IndexedParallelIterator.html#tymethod.drive
+/// [`drive_unindexed`]: super::ParallelIterator::drive_unindexed()
+/// [`drive`]: super::IndexedParallelIterator::drive()
 pub fn bridge_producer_consumer<P, C>(len: usize, producer: P, consumer: C) -> C::Result
 where
     P: Producer,
@@ -437,9 +434,7 @@ where
     }
 }
 
-/// A variant of [`bridge_producer_consumer`] where the producer is an unindexed producer.
-///
-/// [`bridge_producer_consumer`]: fn.bridge_producer_consumer.html
+/// A variant of [`bridge_producer_consumer()`] where the producer is an unindexed producer.
 pub fn bridge_unindexed<P, C>(producer: P, consumer: C) -> C::Result
 where
     P: UnindexedProducer,

--- a/src/iter/positions.rs
+++ b/src/iter/positions.rs
@@ -8,8 +8,7 @@ use std::fmt::{self, Debug};
 ///
 /// This struct is created by the [`positions()`] method on [`IndexedParallelIterator`]
 ///
-/// [`positions()`]: trait.IndexedParallelIterator.html#method.positions
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`positions()`]: IndexedParallelIterator::positions()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Positions<I: IndexedParallelIterator, P> {

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -2,7 +2,9 @@ use super::plumbing::*;
 use super::*;
 use std::iter;
 
-/// Iterator adaptor for [the `repeat()` function](fn.repeat.html).
+/// Iterator adaptor for [the `repeat()` function].
+///
+/// [the `repeat()` function]: repeat()
 #[derive(Debug, Clone)]
 pub struct Repeat<T: Clone + Send> {
     element: T,
@@ -12,7 +14,9 @@ pub struct Repeat<T: Clone + Send> {
 /// cloning it). Note that this iterator has "infinite" length, so
 /// typically you would want to use `zip` or `take` or some other
 /// means to shorten it, or consider using
-/// [the `repeatn()` function](fn.repeatn.html) instead.
+/// [the `repeatn()` function] instead.
+///
+/// [the `repeatn()` function]: repeatn()
 ///
 /// # Examples
 ///
@@ -31,17 +35,20 @@ where
     T: Clone + Send,
 {
     /// Takes only `n` repeats of the element, similar to the general
-    /// [`take()`](trait.IndexedParallelIterator.html#method.take).
+    /// [`take()`].
     ///
     /// The resulting `RepeatN` is an `IndexedParallelIterator`, allowing
     /// more functionality than `Repeat` alone.
+    ///
+    /// [`take()`]: IndexedParallelIterator::take()
     pub fn take(self, n: usize) -> RepeatN<T> {
         repeatn(self.element, n)
     }
 
     /// Iterates tuples, repeating the element with items from another
-    /// iterator, similar to the general
-    /// [`zip()`](trait.IndexedParallelIterator.html#method.zip).
+    /// iterator, similar to the general [`zip()`].
+    ///
+    /// [`zip()`]: IndexedParallelIterator::zip()
     pub fn zip<Z>(self, zip_op: Z) -> Zip<RepeatN<T>, Z::Iter>
     where
         Z: IntoParallelIterator,
@@ -97,7 +104,9 @@ impl<T: Clone + Send> UnindexedProducer for RepeatProducer<T> {
     }
 }
 
-/// Iterator adaptor for [the `repeatn()` function](fn.repeatn.html).
+/// Iterator adaptor for [the `repeatn()` function].
+///
+/// [the `repeatn()` function]: repeatn()
 #[derive(Debug, Clone)]
 pub struct RepeatN<T: Clone + Send> {
     element: T,

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -5,8 +5,7 @@ use std::iter;
 /// `Rev` is an iterator that produces elements in reverse order. This struct
 /// is created by the [`rev()`] method on [`IndexedParallelIterator`]
 ///
-/// [`rev()`]: trait.IndexedParallelIterator.html#method.rev
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`rev()`]: IndexedParallelIterator::rev()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Rev<I: IndexedParallelIterator> {

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -5,8 +5,7 @@ use super::*;
 /// `Skip` is an iterator that skips over the first `n` elements.
 /// This struct is created by the [`skip()`] method on [`IndexedParallelIterator`]
 ///
-/// [`skip()`]: trait.IndexedParallelIterator.html#method.skip
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`skip()`]: IndexedParallelIterator::skip()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Skip<I> {

--- a/src/iter/skip_any.rs
+++ b/src/iter/skip_any.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// `SkipAny` is an iterator that skips over `n` elements from anywhere in `I`.
 /// This struct is created by the [`skip_any()`] method on [`ParallelIterator`]
 ///
-/// [`skip_any()`]: trait.ParallelIterator.html#method.skip_any
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`skip_any()`]: ParallelIterator::skip_any()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct SkipAny<I: ParallelIterator> {

--- a/src/iter/skip_any_while.rs
+++ b/src/iter/skip_any_while.rs
@@ -7,8 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// until the callback returns `false`.
 /// This struct is created by the [`skip_any_while()`] method on [`ParallelIterator`]
 ///
-/// [`skip_any_while()`]: trait.ParallelIterator.html#method.skip_any_while
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`skip_any_while()`]: ParallelIterator::skip_any_while()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct SkipAnyWhile<I: ParallelIterator, P> {

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -113,8 +113,6 @@ where
 
 /// `Split` is a parallel iterator using arbitrary data and a splitting function.
 /// This struct is created by the [`split()`] function.
-///
-/// [`split()`]: fn.split.html
 #[derive(Clone)]
 pub struct Split<D, S> {
     data: D,

--- a/src/iter/step_by.rs
+++ b/src/iter/step_by.rs
@@ -6,8 +6,7 @@ use std::iter;
 /// `StepBy` is an iterator that skips `n` elements between each yield, where `n` is the given step.
 /// This struct is created by the [`step_by()`] method on [`IndexedParallelIterator`]
 ///
-/// [`step_by()`]: trait.IndexedParallelIterator.html#method.step_by
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`step_by()`]: IndexedParallelIterator::step_by()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct StepBy<I: IndexedParallelIterator> {

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -4,8 +4,7 @@ use super::*;
 /// `Take` is an iterator that iterates over the first `n` elements.
 /// This struct is created by the [`take()`] method on [`IndexedParallelIterator`]
 ///
-/// [`take()`]: trait.IndexedParallelIterator.html#method.take
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`take()`]: IndexedParallelIterator::take()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Take<I> {

--- a/src/iter/take_any.rs
+++ b/src/iter/take_any.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// `TakeAny` is an iterator that iterates over `n` elements from anywhere in `I`.
 /// This struct is created by the [`take_any()`] method on [`ParallelIterator`]
 ///
-/// [`take_any()`]: trait.ParallelIterator.html#method.take_any
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`take_any()`]: ParallelIterator::take_any()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct TakeAny<I: ParallelIterator> {

--- a/src/iter/take_any_while.rs
+++ b/src/iter/take_any_while.rs
@@ -7,8 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// until the callback returns `false`.
 /// This struct is created by the [`take_any_while()`] method on [`ParallelIterator`]
 ///
-/// [`take_any_while()`]: trait.ParallelIterator.html#method.take_any_while
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`take_any_while()`]: ParallelIterator::take_any_while()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct TakeAnyWhile<I: ParallelIterator, P> {

--- a/src/iter/try_fold.rs
+++ b/src/iter/try_fold.rs
@@ -26,8 +26,7 @@ where
 /// `TryFold` is an iterator that applies a function over an iterator producing a single value.
 /// This struct is created by the [`try_fold()`] method on [`ParallelIterator`]
 ///
-/// [`try_fold()`]: trait.ParallelIterator.html#method.try_fold
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`try_fold()`]: ParallelIterator::try_fold()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct TryFold<I, U, ID, F> {
@@ -187,8 +186,7 @@ where
 /// `TryFoldWith` is an iterator that applies a function over an iterator producing a single value.
 /// This struct is created by the [`try_fold_with()`] method on [`ParallelIterator`]
 ///
-/// [`try_fold_with()`]: trait.ParallelIterator.html#method.try_fold_with
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`try_fold_with()`]: ParallelIterator::try_fold_with()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct TryFoldWith<I, U: Try, F> {

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -8,8 +8,7 @@ use std::fmt::{self, Debug};
 ///
 /// This struct is created by the [`update()`] method on [`ParallelIterator`]
 ///
-/// [`update()`]: trait.ParallelIterator.html#method.update
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`update()`]: ParallelIterator::update()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Update<I: ParallelIterator, F> {

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -7,8 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// This struct is created by the [`while_some()`] method on [`ParallelIterator`]
 ///
-/// [`while_some()`]: trait.ParallelIterator.html#method.while_some
-/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`while_some()`]: ParallelIterator::while_some()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct WhileSome<I: ParallelIterator> {

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -6,8 +6,7 @@ use std::iter;
 /// of pairs. This struct is created by the [`zip()`] method on
 /// [`IndexedParallelIterator`]
 ///
-/// [`zip()`]: trait.IndexedParallelIterator.html#method.zip
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`zip()`]: IndexedParallelIterator::zip()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct Zip<A: IndexedParallelIterator, B: IndexedParallelIterator> {

--- a/src/iter/zip_eq.rs
+++ b/src/iter/zip_eq.rs
@@ -7,8 +7,7 @@ use super::*;
 /// This struct is created by the [`zip_eq`] method on [`IndexedParallelIterator`],
 /// see its documentation for more information.
 ///
-/// [`zip_eq`]: trait.IndexedParallelIterator.html#method.zip_eq
-/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+/// [`zip_eq`]: IndexedParallelIterator::zip_eq()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct ZipEq<A: IndexedParallelIterator, B: IndexedParallelIterator> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! - **High-level parallel constructs** are the simplest way to use Rayon and also
 //!   typically the most efficient.
-//!   - [Parallel iterators][iter module] make it easy to convert a sequential iterator to
+//!   - [Parallel iterators] make it easy to convert a sequential iterator to
 //!     execute in parallel.
 //!     - The [`ParallelIterator`] trait defines general methods for all parallel iterators.
 //!     - The [`IndexedParallelIterator`] trait adds methods for iterators that support random
@@ -30,12 +30,11 @@
 //!   - [`ThreadPoolBuilder`] can be used to create your own thread pools or customize
 //!     the global one.
 //!
-//! [iter module]: iter/index.html
-//! [`join`]: fn.join.html
-//! [`scope`]: fn.scope.html
-//! [`par_sort`]: slice/trait.ParallelSliceMut.html#method.par_sort
-//! [`par_extend`]: iter/trait.ParallelExtend.html#tymethod.par_extend
-//! [`ThreadPoolBuilder`]: struct.ThreadPoolBuilder.html
+//! [Parallel iterators]: iter
+//! [`par_sort`]: slice::ParallelSliceMut::par_sort
+//! [`par_extend`]: iter::ParallelExtend::par_extend
+//! [`ParallelIterator`]: iter::ParallelIterator
+//! [`IndexedParallelIterator`]: iter::IndexedParallelIterator
 //!
 //! # Basic usage and the Rayon prelude
 //!
@@ -51,14 +50,12 @@
 //! parallel implementations of many iterative functions such as [`map`],
 //! [`for_each`], [`filter`], [`fold`], and [more].
 //!
-//! [`rayon::prelude`]: prelude/index.html
-//! [`map`]: iter/trait.ParallelIterator.html#method.map
-//! [`for_each`]: iter/trait.ParallelIterator.html#method.for_each
-//! [`filter`]: iter/trait.ParallelIterator.html#method.filter
-//! [`fold`]: iter/trait.ParallelIterator.html#method.fold
-//! [more]: iter/trait.ParallelIterator.html#provided-methods
-//! [`ParallelIterator`]: iter/trait.ParallelIterator.html
-//! [`IndexedParallelIterator`]: iter/trait.IndexedParallelIterator.html
+//! [`rayon::prelude`]: prelude
+//! [`map`]: iter::ParallelIterator::map
+//! [`for_each`]: iter::ParallelIterator::for_each
+//! [`filter`]: iter::ParallelIterator::filter
+//! [`fold`]: iter::ParallelIterator::fold
+//! [more]: iter::ParallelIterator#provided-methods
 //!
 //! # Crate Layout
 //!
@@ -72,9 +69,8 @@
 //! these submodules unless you need to name iterator types
 //! explicitly.
 //!
-//! [the `option` module of `std`]: https://doc.rust-lang.org/std/option/index.html
-//! [the `collections` from `std`]: https://doc.rust-lang.org/std/collections/index.html
-//! [`std`]: https://doc.rust-lang.org/std/
+//! [the `option` module of `std`]: std::option
+//! [the `collections` from `std`]: std::collections
 //!
 //! # Targets without threading
 //!

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,9 +1,9 @@
-//! Parallel iterator types for [options][std::option]
+//! Parallel iterator types for [options]
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
 //!
-//! [std::option]: https://doc.rust-lang.org/stable/std/option/
+//! [options]: std::option
 
 use crate::iter::plumbing::*;
 use crate::iter::*;
@@ -15,9 +15,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// This `struct` is created by the [`into_par_iter`] function.
 ///
-/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
-/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
-/// [`into_par_iter`]: ../iter/trait.IntoParallelIterator.html#tymethod.into_par_iter
+/// [`into_par_iter`]: IntoParallelIterator::into_par_iter()
 #[derive(Debug, Clone)]
 pub struct IntoIter<T: Send> {
     opt: Option<T>,
@@ -80,9 +78,7 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
 ///
 /// This `struct` is created by the [`par_iter`] function.
 ///
-/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
-/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
-/// [`par_iter`]: ../iter/trait.IntoParallelRefIterator.html#tymethod.par_iter
+/// [`par_iter`]: IntoParallelRefIterator::par_iter()
 #[derive(Debug)]
 pub struct Iter<'a, T: Sync> {
     inner: IntoIter<&'a T>,
@@ -118,9 +114,7 @@ delegate_indexed_iterator! {
 ///
 /// This `struct` is created by the [`par_iter_mut`] function.
 ///
-/// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
-/// [`Some`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.Some
-/// [`par_iter_mut`]: ../iter/trait.IntoParallelRefMutIterator.html#tymethod.par_iter_mut
+/// [`par_iter_mut`]: IntoParallelRefMutIterator::par_iter_mut()
 #[derive(Debug)]
 pub struct IterMut<'a, T: Send> {
     inner: IntoIter<&'a mut T>,

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,4 +1,4 @@
-//! Parallel iterator types for [ranges][std::range],
+//! Parallel iterator types for [ranges],
 //! the type for values created by `a..b` expressions
 //!
 //! You will rarely need to interact with this module directly unless you have
@@ -14,7 +14,7 @@
 //! assert_eq!((0..100).sum::<u64>(), r);
 //! ```
 //!
-//! [std::range]: https://doc.rust-lang.org/core/ops/struct.Range.html
+//! [ranges]: std::ops::Range
 
 use crate::iter::plumbing::*;
 use crate::iter::*;

--- a/src/range_inclusive.rs
+++ b/src/range_inclusive.rs
@@ -1,4 +1,4 @@
-//! Parallel iterator types for [inclusive ranges][std::range],
+//! Parallel iterator types for [inclusive ranges],
 //! the type for values created by `a..=b` expressions
 //!
 //! You will rarely need to interact with this module directly unless you have
@@ -14,7 +14,7 @@
 //! assert_eq!((0..=100).sum::<u64>(), r);
 //! ```
 //!
-//! [std::range]: https://doc.rust-lang.org/core/ops/struct.RangeInclusive.html
+//! [inclusive ranges]: std::ops::RangeInclusive
 
 use crate::iter::plumbing::*;
 use crate::iter::*;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,9 +1,9 @@
-//! Parallel iterator types for [results][std::result]
+//! Parallel iterator types for [results]
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
 //!
-//! [std::result]: https://doc.rust-lang.org/stable/std/result/
+//! [results]: std::result
 
 use crate::iter::plumbing::*;
 use crate::iter::*;

--- a/src/slice/chunk_by.rs
+++ b/src/slice/chunk_by.rs
@@ -143,7 +143,7 @@ where
 ///
 /// This struct is created by the [`par_chunk_by`] method on `&[T]`.
 ///
-/// [`par_chunk_by`]: trait.ParallelSlice.html#method.par_chunk_by
+/// [`par_chunk_by`]: super::ParallelSlice::par_chunk_by()
 pub struct ChunkBy<'data, T, P> {
     pred: P,
     slice: &'data [T],
@@ -200,7 +200,7 @@ where
 ///
 /// This struct is created by the [`par_chunk_by_mut`] method on `&mut [T]`.
 ///
-/// [`par_chunk_by_mut`]: trait.ParallelSliceMut.html#method.par_chunk_by_mut
+/// [`par_chunk_by_mut`]: super::ParallelSliceMut::par_chunk_by_mut()
 pub struct ChunkByMut<'data, T, P> {
     pred: P,
     slice: &'data mut [T],

--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -1,9 +1,9 @@
-//! Parallel iterator types for [slices][std::slice]
+//! Parallel iterator types for [slices]
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
 //!
-//! [std::slice]: https://doc.rust-lang.org/stable/std/slice/
+//! [slices]: std::slice
 
 mod chunk_by;
 mod chunks;

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,4 +1,4 @@
-//! Parallel iterator types for [strings][std::str]
+//! Parallel iterator types for [strings]
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
@@ -9,10 +9,8 @@
 //! It is implemented for `char`, `&[char]`, `[char; N]`, `&[char; N]`,
 //! and any function or closure `F: Fn(char) -> bool + Sync + Send`.
 //!
-//! [`ParallelString::par_split()`]: trait.ParallelString.html#method.par_split
-//! [`par_split_terminator()`]: trait.ParallelString.html#method.par_split_terminator
-//!
-//! [std::str]: https://doc.rust-lang.org/stable/std/str/
+//! [`par_split_terminator()`]: ParallelString::par_split_terminator()
+//! [strings]: std::str
 
 use crate::iter::plumbing::*;
 use crate::iter::*;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,9 +1,9 @@
-//! Parallel iterator types for [vectors][std::vec] (`Vec<T>`)
+//! Parallel iterator types for [vectors] (`Vec<T>`)
 //!
 //! You will rarely need to interact with this module directly unless you need
 //! to name one of the iterator types.
 //!
-//! [std::vec]: https://doc.rust-lang.org/stable/std/vec/
+//! [vectors]: std::vec
 
 use crate::iter::plumbing::*;
 use crate::iter::*;


### PR DESCRIPTION
Hi! I noticed that a lot of intra-doc links in `rayon-core` and `rayon` uses webpage links (i.e. `iter/trait.ParallelExtend.html#tymethod.par_extend`) instead of item paths (i.e. `iter::ParallelExtend::par_extend()`).

This PR converts as many intra-doc links as I could find into item paths. This ensures that if Rustdoc ever changes how its documentation is structured in the file system (unlikely, but not impossible), `rayon` and `rayon-core`'s docs will continue to function as normal.

This PR also fixes a couple small pieces of documentation which I assume were meant to link to another item.

I made sure to double-check all of my work - but if you find any documentation links I missed, or any that are now broken, please let me know.

Notes:
* https://github.com/rayon-rs/rayon/blob/d179ea9fa69cab08a3b2762ff9b15249a71b9b94/rayon-core/src/lib.rs#L414 - If `crossbeam` were a dependency of `rayon-core`, I would be able to change this to an item path. But alas, it is not.
* https://github.com/rayon-rs/rayon/blob/d179ea9fa69cab08a3b2762ff9b15249a71b9b94/rayon-core/src/join/mod.rs#L41 - Attempting to change this link to use an item path (i.e. `rayon::slice::ParallelSliceMut::par_sort()`) results in a broken link warning.
* https://github.com/rayon-rs/rayon/blob/d179ea9fa69cab08a3b2762ff9b15249a71b9b94/src/array.rs#L6 - I do not know how to link to the primitive using an item path; using `std::array` links to the `std::array` module rather than the `[T; N]` primitive.