### PR TITLE
rename `repeatn` to `repeat_n`, deprecate `repeatn`, for parity with std

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -190,7 +190,7 @@ pub use self::{
     panic_fuse::PanicFuse,
     par_bridge::{IterBridge, ParallelBridge},
     positions::Positions,
-    repeat::{repeat, repeatn, Repeat, RepeatN},
+    repeat::{repeat, repeat_n, repeatn, Repeat, RepeatN},
     rev::Rev,
     skip::Skip,
     skip_any::SkipAny,

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -12,7 +12,7 @@ pub struct Repeat<T: Clone + Send> {
 /// cloning it). Note that this iterator has "infinite" length, so
 /// typically you would want to use `zip` or `take` or some other
 /// means to shorten it, or consider using
-/// [the `repeatn()` function](fn.repeatn.html) instead.
+/// [the `repeat_n()` function](fn.repeat_n.html) instead.
 ///
 /// # Examples
 ///
@@ -36,7 +36,7 @@ where
     /// The resulting `RepeatN` is an `IndexedParallelIterator`, allowing
     /// more functionality than `Repeat` alone.
     pub fn take(self, n: usize) -> RepeatN<T> {
-        repeatn(self.element, n)
+        repeat_n(self.element, n)
     }
 
     /// Iterates tuples, repeating the element with items from another
@@ -97,7 +97,7 @@ impl<T: Clone + Send> UnindexedProducer for RepeatProducer<T> {
     }
 }
 
-/// Iterator adaptor for [the `repeatn()` function](fn.repeatn.html).
+/// Iterator adaptor for [the `repeat_n()` function](fn.repeat_n.html).
 #[derive(Debug, Clone)]
 pub struct RepeatN<T: Clone + Send> {
     element: T,
@@ -111,10 +111,19 @@ pub struct RepeatN<T: Clone + Send> {
 ///
 /// ```
 /// use rayon::prelude::*;
-/// use rayon::iter::repeatn;
-/// let x: Vec<(i32, i32)> = repeatn(22, 3).zip(0..3).collect();
+/// use rayon::iter::repeat_n;
+/// let x: Vec<(i32, i32)> = repeat_n(22, 3).zip(0..3).collect();
 /// assert_eq!(x, vec![(22, 0), (22, 1), (22, 2)]);
 /// ```
+pub fn repeat_n<T: Clone + Send>(elt: T, n: usize) -> RepeatN<T> {
+    RepeatN {
+        element: elt,
+        count: n,
+    }
+}
+
+#[doc(hidden)]
+#[deprecated(note = "use `repeat_n`")]
 pub fn repeatn<T: Clone + Send>(elt: T, n: usize) -> RepeatN<T> {
     RepeatN {
         element: elt,

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -2183,9 +2183,9 @@ fn check_repeat_zip() {
 }
 
 #[test]
-fn check_repeatn_zip_left() {
+fn check_repeat_n_zip_left() {
     let v = vec![4, 4, 4, 4];
-    let mut fours: Vec<_> = repeatn(4, usize::MAX).zip(v).collect();
+    let mut fours: Vec<_> = repeat_n(4, usize::MAX).zip(v).collect();
     assert_eq!(fours.len(), 4);
     while let Some(item) = fours.pop() {
         assert_eq!(item, (4, 4));
@@ -2193,9 +2193,9 @@ fn check_repeatn_zip_left() {
 }
 
 #[test]
-fn check_repeatn_zip_right() {
+fn check_repeat_n_zip_right() {
     let v = vec![4, 4, 4, 4];
-    let mut fours: Vec<_> = v.into_par_iter().zip(repeatn(4, usize::MAX)).collect();
+    let mut fours: Vec<_> = v.into_par_iter().zip(repeat_n(4, usize::MAX)).collect();
     assert_eq!(fours.len(), 4);
     while let Some(item) = fours.pop() {
         assert_eq!(item, (4, 4));

--- a/tests/clones.rs
+++ b/tests/clones.rs
@@ -196,7 +196,7 @@ fn clone_once() {
 fn clone_repeat() {
     let x: Option<i32> = None;
     check(rayon::iter::repeat(x).while_some());
-    check(rayon::iter::repeatn(x, 1000));
+    check(rayon::iter::repeat_n(x, 1000));
 }
 
 #[test]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -207,7 +207,7 @@ fn debug_once() {
 fn debug_repeat() {
     let x: Option<i32> = None;
     check(rayon::iter::repeat(x));
-    check(rayon::iter::repeatn(x, 10));
+    check(rayon::iter::repeat_n(x, 10));
 }
 
 #[test]

--- a/tests/producer_split_at.rs
+++ b/tests/producer_split_at.rs
@@ -142,9 +142,9 @@ fn range_inclusive() {
 }
 
 #[test]
-fn repeatn() {
+fn repeat_n() {
     let v: Vec<_> = std::iter::repeat(1).take(5).collect();
-    check(&v, || rayon::iter::repeatn(1, 5));
+    check(&v, || rayon::iter::repeat_n(1, 5));
 }
 
 #[test]


### PR DESCRIPTION
fixes #1237 