### PR TITLE
Remove the gitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Rayon documentation](https://docs.rs/rayon/badge.svg)](https://docs.rs/rayon)
 ![minimum rustc 1.63](https://img.shields.io/badge/rustc-1.63+-red.svg)
 [![build status](https://github.com/rayon-rs/rayon/workflows/main/badge.svg)](https://github.com/rayon-rs/rayon/actions)
-[![Join the chat at https://gitter.im/rayon-rs/Lobby](https://badges.gitter.im/rayon-rs/Lobby.svg)](https://gitter.im/rayon-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Rayon is a data-parallelism library for Rust. It is extremely
 lightweight and makes it easy to convert a sequential computation into


### PR DESCRIPTION
The gitter.im room (now in Matrix) is rarely used, and the few conversations that come up there would probably be better served by using a GitHub issue or discussion, where they would also be more accessible to future readers.