### PR TITLE
Relax trait bounds on many structs

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -40,7 +40,7 @@ impl<T: Send, const N: usize> IntoParallelIterator for [T; N] {
 
 /// Parallel iterator that moves out of an array.
 #[derive(Debug, Clone)]
-pub struct IntoIter<T: Send, const N: usize> {
+pub struct IntoIter<T, const N: usize> {
     array: [T; N],
 }
 

--- a/src/collections/btree_map.rs
+++ b/src/collections/btree_map.rs
@@ -11,27 +11,27 @@ use crate::vec;
 
 /// Parallel iterator over a B-Tree map
 #[derive(Debug)] // std doesn't Clone
-pub struct IntoIter<K: Ord + Send, V: Send> {
+pub struct IntoIter<K, V> {
     inner: vec::IntoIter<(K, V)>,
 }
 
 into_par_vec! {
     BTreeMap<K, V> => IntoIter<K, V>,
-    impl<K: Ord + Send, V: Send>
+    impl<K: Send, V: Send>
 }
 
 delegate_iterator! {
     IntoIter<K, V> => (K, V),
-    impl<K: Ord + Send, V: Send>
+    impl<K: Send, V: Send>
 }
 
 /// Parallel iterator over an immutable reference to a B-Tree map
 #[derive(Debug)]
-pub struct Iter<'a, K: Ord + Sync, V: Sync> {
+pub struct Iter<'a, K, V> {
     inner: vec::IntoIter<(&'a K, &'a V)>,
 }
 
-impl<'a, K: Ord + Sync, V: Sync> Clone for Iter<'a, K, V> {
+impl<K, V> Clone for Iter<'_, K, V> {
     fn clone(&self) -> Self {
         Iter {
             inner: self.inner.clone(),
@@ -41,26 +41,26 @@ impl<'a, K: Ord + Sync, V: Sync> Clone for Iter<'a, K, V> {
 
 into_par_vec! {
     &'a BTreeMap<K, V> => Iter<'a, K, V>,
-    impl<'a, K: Ord + Sync, V: Sync>
+    impl<'a, K: Sync, V: Sync>
 }
 
 delegate_iterator! {
     Iter<'a, K, V> => (&'a K, &'a V),
-    impl<'a, K: Ord + Sync + 'a, V: Sync + 'a>
+    impl<'a, K: Sync + 'a, V: Sync + 'a>
 }
 
 /// Parallel iterator over a mutable reference to a B-Tree map
 #[derive(Debug)]
-pub struct IterMut<'a, K: Ord + Sync, V: Send> {
+pub struct IterMut<'a, K, V> {
     inner: vec::IntoIter<(&'a K, &'a mut V)>,
 }
 
 into_par_vec! {
     &'a mut BTreeMap<K, V> => IterMut<'a, K, V>,
-    impl<'a, K: Ord + Sync, V: Send>
+    impl<'a, K: Sync, V: Send>
 }
 
 delegate_iterator! {
     IterMut<'a, K, V> => (&'a K, &'a mut V),
-    impl<'a, K: Ord + Sync + 'a, V: Send + 'a>
+    impl<'a, K: Sync + 'a, V: Send + 'a>
 }

--- a/src/collections/btree_set.rs
+++ b/src/collections/btree_set.rs
@@ -11,27 +11,27 @@ use crate::vec;
 
 /// Parallel iterator over a B-Tree set
 #[derive(Debug)] // std doesn't Clone
-pub struct IntoIter<T: Ord + Send> {
+pub struct IntoIter<T> {
     inner: vec::IntoIter<T>,
 }
 
 into_par_vec! {
     BTreeSet<T> => IntoIter<T>,
-    impl<T: Ord + Send>
+    impl<T: Send>
 }
 
 delegate_iterator! {
     IntoIter<T> => T,
-    impl<T: Ord + Send>
+    impl<T: Send>
 }
 
 /// Parallel iterator over an immutable reference to a B-Tree set
 #[derive(Debug)]
-pub struct Iter<'a, T: Ord + Sync> {
+pub struct Iter<'a, T> {
     inner: vec::IntoIter<&'a T>,
 }
 
-impl<'a, T: Ord + Sync + 'a> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Iter {
             inner: self.inner.clone(),
@@ -41,12 +41,12 @@ impl<'a, T: Ord + Sync + 'a> Clone for Iter<'a, T> {
 
 into_par_vec! {
     &'a BTreeSet<T> => Iter<'a, T>,
-    impl<'a, T: Ord + Sync>
+    impl<'a, T: Sync>
 }
 
 delegate_iterator! {
     Iter<'a, T> => &'a T,
-    impl<'a, T: Ord + Sync + 'a>
+    impl<'a, T: Sync + 'a>
 }
 
 // `BTreeSet` doesn't have a mutable `Iterator`

--- a/src/collections/linked_list.rs
+++ b/src/collections/linked_list.rs
@@ -11,7 +11,7 @@ use crate::vec;
 
 /// Parallel iterator over a linked list
 #[derive(Debug, Clone)]
-pub struct IntoIter<T: Send> {
+pub struct IntoIter<T> {
     inner: vec::IntoIter<T>,
 }
 
@@ -27,11 +27,11 @@ delegate_iterator! {
 
 /// Parallel iterator over an immutable reference to a linked list
 #[derive(Debug)]
-pub struct Iter<'a, T: Sync> {
+pub struct Iter<'a, T> {
     inner: vec::IntoIter<&'a T>,
 }
 
-impl<'a, T: Sync> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Iter {
             inner: self.inner.clone(),
@@ -46,12 +46,12 @@ into_par_vec! {
 
 delegate_iterator! {
     Iter<'a, T> => &'a T,
-    impl<'a, T: Sync + 'a>
+    impl<'a, T: Sync>
 }
 
 /// Parallel iterator over a mutable reference to a linked list
 #[derive(Debug)]
-pub struct IterMut<'a, T: Send> {
+pub struct IterMut<'a, T> {
     inner: vec::IntoIter<&'a mut T>,
 }
 
@@ -62,5 +62,5 @@ into_par_vec! {
 
 delegate_iterator! {
     IterMut<'a, T> => &'a mut T,
-    impl<'a, T: Send + 'a>
+    impl<'a, T: Send>
 }

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -9,20 +9,12 @@ use std::iter;
 /// [`chain()`]: ParallelIterator::chain()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Chain<A, B>
-where
-    A: ParallelIterator,
-    B: ParallelIterator<Item = A::Item>,
-{
+pub struct Chain<A, B> {
     a: A,
     b: B,
 }
 
-impl<A, B> Chain<A, B>
-where
-    A: ParallelIterator,
-    B: ParallelIterator<Item = A::Item>,
-{
+impl<A, B> Chain<A, B> {
     /// Creates a new `Chain` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         Chain { a, b }

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -8,18 +8,12 @@ use super::*;
 /// [`chunks()`]: IndexedParallelIterator::chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Chunks<I>
-where
-    I: IndexedParallelIterator,
-{
+pub struct Chunks<I> {
     size: usize,
     i: I,
 }
 
-impl<I> Chunks<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> Chunks<I> {
     /// Creates a new `Chunks` iterator
     pub(super) fn new(i: I, size: usize) -> Self {
         Chunks { i, size }

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -10,14 +10,11 @@ use std::iter;
 /// [`cloned()`]: ParallelIterator::cloned()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Cloned<I: ParallelIterator> {
+pub struct Cloned<I> {
     base: I,
 }
 
-impl<I> Cloned<I>
-where
-    I: ParallelIterator,
-{
+impl<I> Cloned<I> {
     /// Creates a new `Cloned` iterator.
     pub(super) fn new(base: I) -> Self {
         Cloned { base }

--- a/src/iter/copied.rs
+++ b/src/iter/copied.rs
@@ -10,14 +10,11 @@ use std::iter;
 /// [`copied()`]: ParallelIterator::copied()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Copied<I: ParallelIterator> {
+pub struct Copied<I> {
     base: I,
 }
 
-impl<I> Copied<I>
-where
-    I: ParallelIterator,
-{
+impl<I> Copied<I> {
     /// Creates a new `Copied` iterator.
     pub(super) fn new(base: I) -> Self {
         Copied { base }

--- a/src/iter/empty.rs
+++ b/src/iter/empty.rs
@@ -30,13 +30,15 @@ pub fn empty<T: Send>() -> Empty<T> {
 /// Iterator adaptor for [the `empty()` function].
 ///
 /// [the `empty()` function]: empty()
-pub struct Empty<T: Send> {
+pub struct Empty<T> {
     marker: PhantomData<T>,
 }
 
-impl<T: Send> Clone for Empty<T> {
+impl<T> Clone for Empty<T> {
     fn clone(&self) -> Self {
-        empty()
+        Empty {
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -9,14 +9,11 @@ use std::ops::Range;
 /// [`enumerate()`]: IndexedParallelIterator::enumerate()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Enumerate<I: IndexedParallelIterator> {
+pub struct Enumerate<I> {
     base: I,
 }
 
-impl<I> Enumerate<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> Enumerate<I> {
     /// Creates a new `Enumerate` iterator.
     pub(super) fn new(base: I) -> Self {
         Enumerate { base }

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -9,21 +9,18 @@ use std::fmt::{self, Debug};
 /// [`filter()`]: ParallelIterator::filter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Filter<I: ParallelIterator, P> {
+pub struct Filter<I, P> {
     base: I,
     filter_op: P,
 }
 
-impl<I: ParallelIterator + Debug, P> Debug for Filter<I, P> {
+impl<I: Debug, P> Debug for Filter<I, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Filter").field("base", &self.base).finish()
     }
 }
 
-impl<I, P> Filter<I, P>
-where
-    I: ParallelIterator,
-{
+impl<I, P> Filter<I, P> {
     /// Creates a new `Filter` iterator.
     pub(super) fn new(base: I, filter_op: P) -> Self {
         Filter { base, filter_op }

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -9,12 +9,12 @@ use std::fmt::{self, Debug};
 /// [`filter_map()`]: ParallelIterator::filter_map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct FilterMap<I: ParallelIterator, P> {
+pub struct FilterMap<I, P> {
     base: I,
     filter_op: P,
 }
 
-impl<I: ParallelIterator + Debug, P> Debug for FilterMap<I, P> {
+impl<I: Debug, P> Debug for FilterMap<I, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FilterMap")
             .field("base", &self.base)
@@ -22,7 +22,7 @@ impl<I: ParallelIterator + Debug, P> Debug for FilterMap<I, P> {
     }
 }
 
-impl<I: ParallelIterator, P> FilterMap<I, P> {
+impl<I, P> FilterMap<I, P> {
     /// Creates a new `FilterMap` iterator.
     pub(super) fn new(base: I, filter_op: P) -> Self {
         FilterMap { base, filter_op }

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -9,18 +9,18 @@ use std::fmt::{self, Debug};
 /// [`flat_map()`]: ParallelIterator::flat_map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct FlatMap<I: ParallelIterator, F> {
+pub struct FlatMap<I, F> {
     base: I,
     map_op: F,
 }
 
-impl<I: ParallelIterator + Debug, F> Debug for FlatMap<I, F> {
+impl<I: Debug, F> Debug for FlatMap<I, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlatMap").field("base", &self.base).finish()
     }
 }
 
-impl<I: ParallelIterator, F> FlatMap<I, F> {
+impl<I, F> FlatMap<I, F> {
     /// Creates a new `FlatMap` iterator.
     pub(super) fn new(base: I, map_op: F) -> Self {
         FlatMap { base, map_op }

--- a/src/iter/flat_map_iter.rs
+++ b/src/iter/flat_map_iter.rs
@@ -9,12 +9,12 @@ use std::fmt::{self, Debug};
 /// [`flat_map_iter()`]: ParallelIterator::flat_map_iter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct FlatMapIter<I: ParallelIterator, F> {
+pub struct FlatMapIter<I, F> {
     base: I,
     map_op: F,
 }
 
-impl<I: ParallelIterator + Debug, F> Debug for FlatMapIter<I, F> {
+impl<I: Debug, F> Debug for FlatMapIter<I, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlatMapIter")
             .field("base", &self.base)
@@ -22,7 +22,7 @@ impl<I: ParallelIterator + Debug, F> Debug for FlatMapIter<I, F> {
     }
 }
 
-impl<I: ParallelIterator, F> FlatMapIter<I, F> {
+impl<I, F> FlatMapIter<I, F> {
     /// Creates a new `FlatMapIter` iterator.
     pub(super) fn new(base: I, map_op: F) -> Self {
         FlatMapIter { base, map_op }

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -7,14 +7,11 @@ use super::*;
 /// [`flatten()`]: ParallelIterator::flatten()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Flatten<I: ParallelIterator> {
+pub struct Flatten<I> {
     base: I,
 }
 
-impl<I> Flatten<I>
-where
-    I: ParallelIterator<Item: IntoParallelIterator>,
-{
+impl<I> Flatten<I> {
     /// Creates a new `Flatten` iterator.
     pub(super) fn new(base: I) -> Self {
         Flatten { base }

--- a/src/iter/flatten_iter.rs
+++ b/src/iter/flatten_iter.rs
@@ -7,14 +7,11 @@ use super::*;
 /// [`flatten_iter()`]: ParallelIterator::flatten_iter()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct FlattenIter<I: ParallelIterator> {
+pub struct FlattenIter<I> {
     base: I,
 }
 
-impl<I> FlattenIter<I>
-where
-    I: ParallelIterator<Item: IntoIterator<Item: Send>>,
-{
+impl<I> FlattenIter<I> {
     /// Creates a new `FlattenIter` iterator.
     pub(super) fn new(base: I) -> Self {
         FlattenIter { base }

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -3,13 +3,7 @@ use super::*;
 
 use std::fmt::{self, Debug};
 
-impl<U, I, ID, F> Fold<I, ID, F>
-where
-    I: ParallelIterator,
-    F: Fn(U, I::Item) -> U + Sync + Send,
-    ID: Fn() -> U + Sync + Send,
-    U: Send,
-{
+impl<I, ID, F> Fold<I, ID, F> {
     pub(super) fn new(base: I, identity: ID, fold_op: F) -> Self {
         Fold {
             base,
@@ -31,7 +25,7 @@ pub struct Fold<I, ID, F> {
     fold_op: F,
 }
 
-impl<I: ParallelIterator + Debug, ID, F> Debug for Fold<I, ID, F> {
+impl<I: Debug, ID, F> Debug for Fold<I, ID, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Fold").field("base", &self.base).finish()
     }
@@ -178,12 +172,7 @@ where
 
 // ///////////////////////////////////////////////////////////////////////////
 
-impl<U, I, F> FoldWith<I, U, F>
-where
-    I: ParallelIterator,
-    F: Fn(U, I::Item) -> U + Sync + Send,
-    U: Send + Clone,
-{
+impl<I, U, F> FoldWith<I, U, F> {
     pub(super) fn new(base: I, item: U, fold_op: F) -> Self {
         FoldWith {
             base,
@@ -205,7 +194,7 @@ pub struct FoldWith<I, U, F> {
     fold_op: F,
 }
 
-impl<I: ParallelIterator + Debug, U: Debug, F> Debug for FoldWith<I, U, F> {
+impl<I: Debug, U: Debug, F> Debug for FoldWith<I, U, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FoldWith")
             .field("base", &self.base)

--- a/src/iter/fold_chunks.rs
+++ b/src/iter/fold_chunks.rs
@@ -12,17 +12,14 @@ use super::*;
 /// [`fold_chunks()`]: IndexedParallelIterator::fold_chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct FoldChunks<I, ID, F>
-where
-    I: IndexedParallelIterator,
-{
+pub struct FoldChunks<I, ID, F> {
     base: I,
     chunk_size: usize,
     fold_op: F,
     identity: ID,
 }
 
-impl<I: IndexedParallelIterator + Debug, ID, F> Debug for FoldChunks<I, ID, F> {
+impl<I: Debug, ID, F> Debug for FoldChunks<I, ID, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Fold")
             .field("base", &self.base)
@@ -31,13 +28,7 @@ impl<I: IndexedParallelIterator + Debug, ID, F> Debug for FoldChunks<I, ID, F> {
     }
 }
 
-impl<I, ID, U, F> FoldChunks<I, ID, F>
-where
-    I: IndexedParallelIterator,
-    ID: Fn() -> U + Send + Sync,
-    F: Fn(U, I::Item) -> U + Send + Sync,
-    U: Send,
-{
+impl<I, ID, F> FoldChunks<I, ID, F> {
     /// Creates a new `FoldChunks` iterator
     pub(super) fn new(base: I, chunk_size: usize, identity: ID, fold_op: F) -> Self {
         FoldChunks {

--- a/src/iter/fold_chunks_with.rs
+++ b/src/iter/fold_chunks_with.rs
@@ -12,17 +12,14 @@ use super::*;
 /// [`fold_chunks_with()`]: IndexedParallelIterator::fold_chunks()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct FoldChunksWith<I, U, F>
-where
-    I: IndexedParallelIterator,
-{
+pub struct FoldChunksWith<I, U, F> {
     base: I,
     chunk_size: usize,
     item: U,
     fold_op: F,
 }
 
-impl<I: IndexedParallelIterator + Debug, U: Debug, F> Debug for FoldChunksWith<I, U, F> {
+impl<I: Debug, U: Debug, F> Debug for FoldChunksWith<I, U, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Fold")
             .field("base", &self.base)
@@ -32,12 +29,7 @@ impl<I: IndexedParallelIterator + Debug, U: Debug, F> Debug for FoldChunksWith<I
     }
 }
 
-impl<I, U, F> FoldChunksWith<I, U, F>
-where
-    I: IndexedParallelIterator,
-    U: Send + Clone,
-    F: Fn(U, I::Item) -> U + Send + Sync,
-{
+impl<I, U, F> FoldChunksWith<I, U, F> {
     /// Creates a new `FoldChunksWith` iterator
     pub(super) fn new(base: I, chunk_size: usize, item: U, fold_op: F) -> Self {
         FoldChunksWith {

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -12,21 +12,18 @@ use std::iter;
 /// [`inspect()`]: ParallelIterator::inspect()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Inspect<I: ParallelIterator, F> {
+pub struct Inspect<I, F> {
     base: I,
     inspect_op: F,
 }
 
-impl<I: ParallelIterator + Debug, F> Debug for Inspect<I, F> {
+impl<I: Debug, F> Debug for Inspect<I, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Inspect").field("base", &self.base).finish()
     }
 }
 
-impl<I, F> Inspect<I, F>
-where
-    I: ParallelIterator,
-{
+impl<I, F> Inspect<I, F> {
     /// Creates a new `Inspect` iterator.
     pub(super) fn new(base: I, inspect_op: F) -> Self {
         Inspect { base, inspect_op }

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -9,20 +9,12 @@ use std::iter::Fuse;
 /// [`interleave()`]: IndexedParallelIterator::interleave()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Interleave<I, J>
-where
-    I: IndexedParallelIterator,
-    J: IndexedParallelIterator<Item = I::Item>,
-{
+pub struct Interleave<I, J> {
     i: I,
     j: J,
 }
 
-impl<I, J> Interleave<I, J>
-where
-    I: IndexedParallelIterator,
-    J: IndexedParallelIterator<Item = I::Item>,
-{
+impl<I, J> Interleave<I, J> {
     /// Creates a new `Interleave` iterator
     pub(super) fn new(i: I, j: J) -> Self {
         Interleave { i, j }

--- a/src/iter/interleave_shortest.rs
+++ b/src/iter/interleave_shortest.rs
@@ -11,11 +11,7 @@ use super::*;
 /// [`interleave_shortest()`]: IndexedParallelIterator::interleave_shortest()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct InterleaveShortest<I, J>
-where
-    I: IndexedParallelIterator,
-    J: IndexedParallelIterator<Item = I::Item>,
-{
+pub struct InterleaveShortest<I, J> {
     interleave: Interleave<Take<I>, Take<J>>,
 }
 

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -12,7 +12,7 @@ use std::iter::{self, Fuse};
 #[derive(Clone, Debug)]
 pub struct Intersperse<I>
 where
-    I: ParallelIterator<Item: Clone>,
+    I: ParallelIterator,
 {
     base: I,
     item: I::Item,

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -7,15 +7,12 @@ use super::*;
 /// [`with_min_len()`]: IndexedParallelIterator::with_min_len()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct MinLen<I: IndexedParallelIterator> {
+pub struct MinLen<I> {
     base: I,
     min: usize,
 }
 
-impl<I> MinLen<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> MinLen<I> {
     /// Creates a new `MinLen` iterator.
     pub(super) fn new(base: I, min: usize) -> Self {
         MinLen { base, min }
@@ -140,15 +137,12 @@ where
 /// [`with_max_len()`]: IndexedParallelIterator::with_max_len()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct MaxLen<I: IndexedParallelIterator> {
+pub struct MaxLen<I> {
     base: I,
     max: usize,
 }
 
-impl<I> MaxLen<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> MaxLen<I> {
     /// Creates a new `MaxLen` iterator.
     pub(super) fn new(base: I, max: usize) -> Self {
         MaxLen { base, max }

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -11,21 +11,18 @@ use std::iter;
 /// [`map()`]: ParallelIterator::map()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Map<I: ParallelIterator, F> {
+pub struct Map<I, F> {
     base: I,
     map_op: F,
 }
 
-impl<I: ParallelIterator + Debug, F> Debug for Map<I, F> {
+impl<I: Debug, F> Debug for Map<I, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Map").field("base", &self.base).finish()
     }
 }
 
-impl<I, F> Map<I, F>
-where
-    I: ParallelIterator,
-{
+impl<I, F> Map<I, F> {
     /// Creates a new `Map` iterator.
     pub(super) fn new(base: I, map_op: F) -> Self {
         Map { base, map_op }

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -10,13 +10,13 @@ use std::fmt::{self, Debug};
 /// [`map_with()`]: ParallelIterator::map_with()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct MapWith<I: ParallelIterator, T, F> {
+pub struct MapWith<I, T, F> {
     base: I,
     item: T,
     map_op: F,
 }
 
-impl<I: ParallelIterator + Debug, T: Debug, F> Debug for MapWith<I, T, F> {
+impl<I: Debug, T: Debug, F> Debug for MapWith<I, T, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapWith")
             .field("base", &self.base)
@@ -25,10 +25,7 @@ impl<I: ParallelIterator + Debug, T: Debug, F> Debug for MapWith<I, T, F> {
     }
 }
 
-impl<I, T, F> MapWith<I, T, F>
-where
-    I: ParallelIterator,
-{
+impl<I, T, F> MapWith<I, T, F> {
     /// Creates a new `MapWith` iterator.
     pub(super) fn new(base: I, item: T, map_op: F) -> Self {
         MapWith { base, item, map_op }
@@ -341,22 +338,19 @@ where
 /// [`map_init()`]: ParallelIterator::map_init()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct MapInit<I: ParallelIterator, INIT, F> {
+pub struct MapInit<I, INIT, F> {
     base: I,
     init: INIT,
     map_op: F,
 }
 
-impl<I: ParallelIterator + Debug, INIT, F> Debug for MapInit<I, INIT, F> {
+impl<I: Debug, INIT, F> Debug for MapInit<I, INIT, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapInit").field("base", &self.base).finish()
     }
 }
 
-impl<I, INIT, F> MapInit<I, INIT, F>
-where
-    I: ParallelIterator,
-{
+impl<I, INIT, F> MapInit<I, INIT, F> {
     /// Creates a new `MapInit` iterator.
     pub(super) fn new(base: I, init: INIT, map_op: F) -> Self {
         MapInit { base, init, map_op }

--- a/src/iter/once.rs
+++ b/src/iter/once.rs
@@ -29,7 +29,7 @@ pub fn once<T: Send>(item: T) -> Once<T> {
 ///
 /// [the `once()` function]: once()
 #[derive(Clone, Debug)]
-pub struct Once<T: Send> {
+pub struct Once<T> {
     item: T,
 }
 

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -11,7 +11,7 @@ use std::thread;
 /// [`panic_fuse()`]: ParallelIterator::panic_fuse()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct PanicFuse<I: ParallelIterator> {
+pub struct PanicFuse<I> {
     base: I,
 }
 
@@ -35,10 +35,7 @@ impl<'a> Fuse<'a> {
     }
 }
 
-impl<I> PanicFuse<I>
-where
-    I: ParallelIterator,
-{
+impl<I> PanicFuse<I> {
     /// Creates a new `PanicFuse` iterator.
     pub(super) fn new(base: I) -> PanicFuse<I> {
         PanicFuse { base }

--- a/src/iter/positions.rs
+++ b/src/iter/positions.rs
@@ -11,12 +11,12 @@ use std::fmt::{self, Debug};
 /// [`positions()`]: IndexedParallelIterator::positions()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Positions<I: IndexedParallelIterator, P> {
+pub struct Positions<I, P> {
     base: I,
     predicate: P,
 }
 
-impl<I: IndexedParallelIterator + Debug, P> Debug for Positions<I, P> {
+impl<I: Debug, P> Debug for Positions<I, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Positions")
             .field("base", &self.base)
@@ -24,10 +24,7 @@ impl<I: IndexedParallelIterator + Debug, P> Debug for Positions<I, P> {
     }
 }
 
-impl<I, P> Positions<I, P>
-where
-    I: IndexedParallelIterator,
-{
+impl<I, P> Positions<I, P> {
     /// Create a new `Positions` iterator.
     pub(super) fn new(base: I, predicate: P) -> Self {
         Positions { base, predicate }

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -8,14 +8,11 @@ use std::iter;
 /// [`rev()`]: IndexedParallelIterator::rev()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Rev<I: IndexedParallelIterator> {
+pub struct Rev<I> {
     base: I,
 }
 
-impl<I> Rev<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> Rev<I> {
     /// Creates a new `Rev` iterator.
     pub(super) fn new(base: I) -> Self {
         Rev { base }

--- a/src/iter/skip_any.rs
+++ b/src/iter/skip_any.rs
@@ -8,15 +8,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// [`skip_any()`]: ParallelIterator::skip_any()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct SkipAny<I: ParallelIterator> {
+pub struct SkipAny<I> {
     base: I,
     count: usize,
 }
 
-impl<I> SkipAny<I>
-where
-    I: ParallelIterator,
-{
+impl<I> SkipAny<I> {
     /// Creates a new `SkipAny` iterator.
     pub(super) fn new(base: I, count: usize) -> Self {
         SkipAny { base, count }

--- a/src/iter/skip_any_while.rs
+++ b/src/iter/skip_any_while.rs
@@ -10,12 +10,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// [`skip_any_while()`]: ParallelIterator::skip_any_while()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct SkipAnyWhile<I: ParallelIterator, P> {
+pub struct SkipAnyWhile<I, P> {
     base: I,
     predicate: P,
 }
 
-impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for SkipAnyWhile<I, P> {
+impl<I: fmt::Debug, P> fmt::Debug for SkipAnyWhile<I, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SkipAnyWhile")
             .field("base", &self.base)
@@ -23,10 +23,7 @@ impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for SkipAnyWhile<I, P> {
     }
 }
 
-impl<I, P> SkipAnyWhile<I, P>
-where
-    I: ParallelIterator,
-{
+impl<I, P> SkipAnyWhile<I, P> {
     /// Creates a new `SkipAnyWhile` iterator.
     pub(super) fn new(base: I, predicate: P) -> Self {
         SkipAnyWhile { base, predicate }

--- a/src/iter/step_by.rs
+++ b/src/iter/step_by.rs
@@ -8,15 +8,12 @@ use std::iter;
 /// [`step_by()`]: IndexedParallelIterator::step_by()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct StepBy<I: IndexedParallelIterator> {
+pub struct StepBy<I> {
     base: I,
     step: usize,
 }
 
-impl<I> StepBy<I>
-where
-    I: IndexedParallelIterator,
-{
+impl<I> StepBy<I> {
     /// Creates a new `StepBy` iterator.
     pub(super) fn new(base: I, step: usize) -> Self {
         StepBy { base, step }

--- a/src/iter/take_any.rs
+++ b/src/iter/take_any.rs
@@ -8,15 +8,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// [`take_any()`]: ParallelIterator::take_any()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
-pub struct TakeAny<I: ParallelIterator> {
+pub struct TakeAny<I> {
     base: I,
     count: usize,
 }
 
-impl<I> TakeAny<I>
-where
-    I: ParallelIterator,
-{
+impl<I> TakeAny<I> {
     /// Creates a new `TakeAny` iterator.
     pub(super) fn new(base: I, count: usize) -> Self {
         TakeAny { base, count }

--- a/src/iter/take_any_while.rs
+++ b/src/iter/take_any_while.rs
@@ -10,12 +10,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// [`take_any_while()`]: ParallelIterator::take_any_while()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct TakeAnyWhile<I: ParallelIterator, P> {
+pub struct TakeAnyWhile<I, P> {
     base: I,
     predicate: P,
 }
 
-impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for TakeAnyWhile<I, P> {
+impl<I: fmt::Debug, P> fmt::Debug for TakeAnyWhile<I, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TakeAnyWhile")
             .field("base", &self.base)
@@ -23,10 +23,7 @@ impl<I: ParallelIterator + fmt::Debug, P> fmt::Debug for TakeAnyWhile<I, P> {
     }
 }
 
-impl<I, P> TakeAnyWhile<I, P>
-where
-    I: ParallelIterator,
-{
+impl<I, P> TakeAnyWhile<I, P> {
     /// Creates a new `TakeAnyWhile` iterator.
     pub(super) fn new(base: I, predicate: P) -> Self {
         TakeAnyWhile { base, predicate }

--- a/src/iter/try_fold.rs
+++ b/src/iter/try_fold.rs
@@ -6,13 +6,7 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::ops::ControlFlow::{self, Break, Continue};
 
-impl<U, I, ID, F> TryFold<I, U, ID, F>
-where
-    I: ParallelIterator,
-    F: Fn(U::Output, I::Item) -> U + Sync + Send,
-    ID: Fn() -> U::Output + Sync + Send,
-    U: Try + Send,
-{
+impl<I, U, ID, F> TryFold<I, U, ID, F> {
     pub(super) fn new(base: I, identity: ID, fold_op: F) -> Self {
         TryFold {
             base,
@@ -167,12 +161,7 @@ where
 
 // ///////////////////////////////////////////////////////////////////////////
 
-impl<U, I, F> TryFoldWith<I, U, F>
-where
-    I: ParallelIterator,
-    F: Fn(U::Output, I::Item) -> U + Sync,
-    U: Try<Output: Clone + Send> + Send,
-{
+impl<I, U: Try, F> TryFoldWith<I, U, F> {
     pub(super) fn new(base: I, item: U::Output, fold_op: F) -> Self {
         TryFoldWith {
             base,
@@ -196,7 +185,7 @@ pub struct TryFoldWith<I, U: Try, F> {
 
 impl<I, U, F> Debug for TryFoldWith<I, U, F>
 where
-    I: ParallelIterator + Debug,
+    I: Debug,
     U: Try<Output: Debug>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -11,21 +11,18 @@ use std::fmt::{self, Debug};
 /// [`update()`]: ParallelIterator::update()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Update<I: ParallelIterator, F> {
+pub struct Update<I, F> {
     base: I,
     update_op: F,
 }
 
-impl<I: ParallelIterator + Debug, F> Debug for Update<I, F> {
+impl<I: Debug, F> Debug for Update<I, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Update").field("base", &self.base).finish()
     }
 }
 
-impl<I, F> Update<I, F>
-where
-    I: ParallelIterator,
-{
+impl<I, F> Update<I, F> {
     /// Creates a new `Update` iterator.
     pub(super) fn new(base: I, update_op: F) -> Self {
         Update { base, update_op }

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -10,14 +10,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// [`while_some()`]: ParallelIterator::while_some()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct WhileSome<I: ParallelIterator> {
+pub struct WhileSome<I> {
     base: I,
 }
 
-impl<I> WhileSome<I>
-where
-    I: ParallelIterator,
-{
+impl<I> WhileSome<I> {
     /// Creates a new `WhileSome` iterator.
     pub(super) fn new(base: I) -> Self {
         WhileSome { base }

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -9,16 +9,12 @@ use std::iter;
 /// [`zip()`]: IndexedParallelIterator::zip()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct Zip<A: IndexedParallelIterator, B: IndexedParallelIterator> {
+pub struct Zip<A, B> {
     a: A,
     b: B,
 }
 
-impl<A, B> Zip<A, B>
-where
-    A: IndexedParallelIterator,
-    B: IndexedParallelIterator,
-{
+impl<A, B> Zip<A, B> {
     /// Creates a new `Zip` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         Zip { a, b }

--- a/src/iter/zip_eq.rs
+++ b/src/iter/zip_eq.rs
@@ -10,15 +10,11 @@ use super::*;
 /// [`zip_eq`]: IndexedParallelIterator::zip_eq()
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct ZipEq<A: IndexedParallelIterator, B: IndexedParallelIterator> {
+pub struct ZipEq<A, B> {
     zip: Zip<A, B>,
 }
 
-impl<A, B> ZipEq<A, B>
-where
-    A: IndexedParallelIterator,
-    B: IndexedParallelIterator,
-{
+impl<A, B> ZipEq<A, B> {
     /// Creates a new `ZipEq` iterator.
     pub(super) fn new(a: A, b: B) -> Self {
         ZipEq {

--- a/src/option.rs
+++ b/src/option.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// [`into_par_iter`]: IntoParallelIterator::into_par_iter()
 #[derive(Debug, Clone)]
-pub struct IntoIter<T: Send> {
+pub struct IntoIter<T> {
     opt: Option<T>,
 }
 
@@ -80,11 +80,11 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
 ///
 /// [`par_iter`]: IntoParallelRefIterator::par_iter()
 #[derive(Debug)]
-pub struct Iter<'a, T: Sync> {
+pub struct Iter<'a, T> {
     inner: IntoIter<&'a T>,
 }
 
-impl<'a, T: Sync> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Iter {
             inner: self.inner.clone(),
@@ -105,7 +105,7 @@ impl<'a, T: Sync> IntoParallelIterator for &'a Option<T> {
 
 delegate_indexed_iterator! {
     Iter<'a, T> => &'a T,
-    impl<'a, T: Sync + 'a>
+    impl<'a, T: Sync>
 }
 
 /// A parallel iterator over a mutable reference to the [`Some`] variant of an [`Option`].
@@ -116,7 +116,7 @@ delegate_indexed_iterator! {
 ///
 /// [`par_iter_mut`]: IntoParallelRefMutIterator::par_iter_mut()
 #[derive(Debug)]
-pub struct IterMut<'a, T: Send> {
+pub struct IterMut<'a, T> {
     inner: IntoIter<&'a mut T>,
 }
 
@@ -133,7 +133,7 @@ impl<'a, T: Send> IntoParallelIterator for &'a mut Option<T> {
 
 delegate_indexed_iterator! {
     IterMut<'a, T> => &'a mut T,
-    impl<'a, T: Send + 'a>
+    impl<'a, T: Send>
 }
 
 /// Private producer for an option

--- a/src/result.rs
+++ b/src/result.rs
@@ -13,7 +13,7 @@ use crate::option;
 
 /// Parallel iterator over a result
 #[derive(Debug, Clone)]
-pub struct IntoIter<T: Send> {
+pub struct IntoIter<T> {
     inner: option::IntoIter<T>,
 }
 
@@ -35,11 +35,11 @@ delegate_indexed_iterator! {
 
 /// Parallel iterator over an immutable reference to a result
 #[derive(Debug)]
-pub struct Iter<'a, T: Sync> {
+pub struct Iter<'a, T> {
     inner: option::IntoIter<&'a T>,
 }
 
-impl<'a, T: Sync> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Iter {
             inner: self.inner.clone(),
@@ -60,12 +60,12 @@ impl<'a, T: Sync, E> IntoParallelIterator for &'a Result<T, E> {
 
 delegate_indexed_iterator! {
     Iter<'a, T> => &'a T,
-    impl<'a, T: Sync + 'a>
+    impl<'a, T: Sync>
 }
 
 /// Parallel iterator over a mutable reference to a result
 #[derive(Debug)]
-pub struct IterMut<'a, T: Send> {
+pub struct IterMut<'a, T> {
     inner: option::IntoIter<&'a mut T>,
 }
 
@@ -82,7 +82,7 @@ impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
 
 delegate_indexed_iterator! {
     IterMut<'a, T> => &'a mut T,
-    impl<'a, T: Send + 'a>
+    impl<'a, T: Send>
 }
 
 /// Collect an arbitrary `Result`-wrapped collection.

--- a/src/slice/chunk_by.rs
+++ b/src/slice/chunk_by.rs
@@ -144,7 +144,7 @@ pub struct ChunkBy<'data, T, P> {
     slice: &'data [T],
 }
 
-impl<'data, T, P: Clone> Clone for ChunkBy<'data, T, P> {
+impl<T, P: Clone> Clone for ChunkBy<'_, T, P> {
     fn clone(&self) -> Self {
         ChunkBy {
             pred: self.pred.clone(),
@@ -153,7 +153,7 @@ impl<'data, T, P: Clone> Clone for ChunkBy<'data, T, P> {
     }
 }
 
-impl<'data, T: fmt::Debug, P> fmt::Debug for ChunkBy<'data, T, P> {
+impl<T: fmt::Debug, P> fmt::Debug for ChunkBy<'_, T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChunkBy")
             .field("slice", &self.slice)
@@ -201,7 +201,7 @@ pub struct ChunkByMut<'data, T, P> {
     slice: &'data mut [T],
 }
 
-impl<'data, T: fmt::Debug, P> fmt::Debug for ChunkByMut<'data, T, P> {
+impl<T: fmt::Debug, P> fmt::Debug for ChunkByMut<'_, T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChunkByMut")
             .field("slice", &self.slice)

--- a/src/slice/chunks.rs
+++ b/src/slice/chunks.rs
@@ -3,24 +3,24 @@ use crate::iter::*;
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice
 #[derive(Debug)]
-pub struct Chunks<'data, T: Sync> {
+pub struct Chunks<'data, T> {
     chunk_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: Sync> Chunks<'data, T> {
+impl<'data, T> Chunks<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data [T]) -> Self {
         Self { chunk_size, slice }
     }
 }
 
-impl<'data, T: Sync> Clone for Chunks<'data, T> {
+impl<T> Clone for Chunks<'_, T> {
     fn clone(&self) -> Self {
         Chunks { ..*self }
     }
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for Chunks<'data, T> {
+impl<'data, T: Sync> ParallelIterator for Chunks<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -35,7 +35,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for Chunks<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
+impl<T: Sync> IndexedParallelIterator for Chunks<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,
@@ -89,13 +89,13 @@ impl<'data, T: 'data + Sync> Producer for ChunksProducer<'data, T> {
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice
 #[derive(Debug)]
-pub struct ChunksExact<'data, T: Sync> {
+pub struct ChunksExact<'data, T> {
     chunk_size: usize,
     slice: &'data [T],
     rem: &'data [T],
 }
 
-impl<'data, T: Sync> ChunksExact<'data, T> {
+impl<'data, T> ChunksExact<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data [T]) -> Self {
         let rem_len = slice.len() % chunk_size;
         let len = slice.len() - rem_len;
@@ -115,13 +115,13 @@ impl<'data, T: Sync> ChunksExact<'data, T> {
     }
 }
 
-impl<'data, T: Sync> Clone for ChunksExact<'data, T> {
+impl<T> Clone for ChunksExact<'_, T> {
     fn clone(&self) -> Self {
         ChunksExact { ..*self }
     }
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for ChunksExact<'data, T> {
+impl<'data, T: Sync> ParallelIterator for ChunksExact<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -136,7 +136,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for ChunksExact<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for ChunksExact<'data, T> {
+impl<T: Sync> IndexedParallelIterator for ChunksExact<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,
@@ -190,18 +190,18 @@ impl<'data, T: 'data + Sync> Producer for ChunksExactProducer<'data, T> {
 
 /// Parallel iterator over mutable non-overlapping chunks of a slice
 #[derive(Debug)]
-pub struct ChunksMut<'data, T: Send> {
+pub struct ChunksMut<'data, T> {
     chunk_size: usize,
     slice: &'data mut [T],
 }
 
-impl<'data, T: Send> ChunksMut<'data, T> {
+impl<'data, T> ChunksMut<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data mut [T]) -> Self {
         Self { chunk_size, slice }
     }
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for ChunksMut<'data, T> {
+impl<'data, T: Send> ParallelIterator for ChunksMut<'data, T> {
     type Item = &'data mut [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -216,7 +216,7 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
+impl<T: Send> IndexedParallelIterator for ChunksMut<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,
@@ -270,13 +270,13 @@ impl<'data, T: 'data + Send> Producer for ChunksMutProducer<'data, T> {
 
 /// Parallel iterator over mutable non-overlapping chunks of a slice
 #[derive(Debug)]
-pub struct ChunksExactMut<'data, T: Send> {
+pub struct ChunksExactMut<'data, T> {
     chunk_size: usize,
     slice: &'data mut [T],
     rem: &'data mut [T],
 }
 
-impl<'data, T: Send> ChunksExactMut<'data, T> {
+impl<'data, T> ChunksExactMut<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data mut [T]) -> Self {
         let rem_len = slice.len() % chunk_size;
         let len = slice.len() - rem_len;
@@ -319,7 +319,7 @@ impl<'data, T: Send> ChunksExactMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for ChunksExactMut<'data, T> {
+impl<'data, T: Send> ParallelIterator for ChunksExactMut<'data, T> {
     type Item = &'data mut [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -334,7 +334,7 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksExactMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksExactMut<'data, T> {
+impl<T: Send> IndexedParallelIterator for ChunksExactMut<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,

--- a/src/slice/rchunks.rs
+++ b/src/slice/rchunks.rs
@@ -3,24 +3,24 @@ use crate::iter::*;
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice, starting at the end.
 #[derive(Debug)]
-pub struct RChunks<'data, T: Sync> {
+pub struct RChunks<'data, T> {
     chunk_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: Sync> RChunks<'data, T> {
+impl<'data, T> RChunks<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data [T]) -> Self {
         Self { chunk_size, slice }
     }
 }
 
-impl<'data, T: Sync> Clone for RChunks<'data, T> {
+impl<T> Clone for RChunks<'_, T> {
     fn clone(&self) -> Self {
         RChunks { ..*self }
     }
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for RChunks<'data, T> {
+impl<'data, T: Sync> ParallelIterator for RChunks<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -35,7 +35,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for RChunks<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for RChunks<'data, T> {
+impl<T: Sync> IndexedParallelIterator for RChunks<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,
@@ -89,13 +89,13 @@ impl<'data, T: 'data + Sync> Producer for RChunksProducer<'data, T> {
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice, starting at the end.
 #[derive(Debug)]
-pub struct RChunksExact<'data, T: Sync> {
+pub struct RChunksExact<'data, T> {
     chunk_size: usize,
     slice: &'data [T],
     rem: &'data [T],
 }
 
-impl<'data, T: Sync> RChunksExact<'data, T> {
+impl<'data, T> RChunksExact<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data [T]) -> Self {
         let rem_len = slice.len() % chunk_size;
         let (rem, slice) = slice.split_at(rem_len);
@@ -114,13 +114,13 @@ impl<'data, T: Sync> RChunksExact<'data, T> {
     }
 }
 
-impl<'data, T: Sync> Clone for RChunksExact<'data, T> {
+impl<T> Clone for RChunksExact<'_, T> {
     fn clone(&self) -> Self {
         RChunksExact { ..*self }
     }
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for RChunksExact<'data, T> {
+impl<'data, T: Sync> ParallelIterator for RChunksExact<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -135,7 +135,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for RChunksExact<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for RChunksExact<'data, T> {
+impl<T: Sync> IndexedParallelIterator for RChunksExact<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,
@@ -189,18 +189,18 @@ impl<'data, T: 'data + Sync> Producer for RChunksExactProducer<'data, T> {
 
 /// Parallel iterator over mutable non-overlapping chunks of a slice, starting at the end.
 #[derive(Debug)]
-pub struct RChunksMut<'data, T: Send> {
+pub struct RChunksMut<'data, T> {
     chunk_size: usize,
     slice: &'data mut [T],
 }
 
-impl<'data, T: Send> RChunksMut<'data, T> {
+impl<'data, T> RChunksMut<'data, T> {
     pub(super) fn new(chunk_size: usize, slice: &'data mut [T]) -> Self {
         Self { chunk_size, slice }
     }
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for RChunksMut<'data, T> {
+impl<'data, T: Send> ParallelIterator for RChunksMut<'data, T> {
     type Item = &'data mut [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -215,7 +215,7 @@ impl<'data, T: Send + 'data> ParallelIterator for RChunksMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for RChunksMut<'data, T> {
+impl<T: Send> IndexedParallelIterator for RChunksMut<'_, T> {
     fn drive<C>(self, consumer: C) -> C::Result
     where
         C: Consumer<Self::Item>,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -35,7 +35,7 @@ impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut Vec<T> {
 
 /// Parallel iterator that moves out of a vector.
 #[derive(Debug, Clone)]
-pub struct IntoIter<T: Send> {
+pub struct IntoIter<T> {
     vec: Vec<T>,
 }
 


### PR DESCRIPTION
In many cases, there's no need for the struct itself to have any constraints, and it
lends flexibility to downstream implementations as well if they're relaxed.

This should not be a breaking change, because downstreams can't rely on having
these as implied bounds, pending [RFC 2089](https://rust-lang.github.io/rfcs/2089-implied-bounds.html).