### PR TITLE
feat: add unsafe spawn_unchecked version of spawn without 'static bound

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -90,7 +90,7 @@ pub use self::join::{join, join_context};
 pub use self::registry::ThreadBuilder;
 pub use self::scope::{in_place_scope, scope, Scope};
 pub use self::scope::{in_place_scope_fifo, scope_fifo, ScopeFifo};
-pub use self::spawn::{spawn, spawn_fifo};
+pub use self::spawn::{spawn, spawn_fifo, spawn_unchecked};
 pub use self::thread_pool::current_thread_has_pending_tasks;
 pub use self::thread_pool::current_thread_index;
 pub use self::thread_pool::ThreadPool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub use rayon_core::{current_num_threads, current_thread_index, max_num_threads}
 pub use rayon_core::{in_place_scope, scope, Scope};
 pub use rayon_core::{in_place_scope_fifo, scope_fifo, ScopeFifo};
 pub use rayon_core::{join, join_context};
-pub use rayon_core::{spawn, spawn_fifo};
+pub use rayon_core::{spawn, spawn_fifo, spawn_unchecked};
 pub use rayon_core::{yield_local, yield_now, Yield};
 
 /// We need to transmit raw pointers across threads. It is possible to do this


### PR DESCRIPTION
This allows downstream crates to implement scoped tasks. While these implementations would have to be unsafe, it's an incredibly useful potential pattern if it could take advantage of rayon's threadpool.