### PR TITLE
Document `Drop`ping behavior of `_{with|init}` fns

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -382,7 +382,8 @@ pub trait ParallelIterator: Sized + Send {
     ///
     /// The `init` value will be cloned only as needed to be paired with
     /// the group of items in each rayon job.  It does not require the type
-    /// to be `Sync`.
+    /// to be `Sync`. All cloned values get dropped before this function
+    /// returns.
     ///
     /// # Examples
     ///
@@ -413,7 +414,8 @@ pub trait ParallelIterator: Sized + Send {
     ///
     /// The `init` function will be called only as needed for a value to be
     /// paired with the group of items in each rayon job.  There is no
-    /// constraint on that returned type at all!
+    /// constraint on that returned type at all! The initialized values all
+    /// get dropped before this function returns.
     ///
     /// # Examples
     ///
@@ -602,7 +604,8 @@ pub trait ParallelIterator: Sized + Send {
     ///
     /// The `init` value will be cloned only as needed to be paired with
     /// the group of items in each rayon job.  It does not require the type
-    /// to be `Sync`.
+    /// to be `Sync`. All cloned values get dropped before this function
+    /// returns.
     ///
     /// # Examples
     ///
@@ -640,7 +643,8 @@ pub trait ParallelIterator: Sized + Send {
     ///
     /// The `init` function will be called only as needed for a value to be
     /// paired with the group of items in each rayon job.  There is no
-    /// constraint on that returned type at all!
+    /// constraint on that returned type at all! The initialized values all
+    /// get dropped before this function returns.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Had to try out the dropping behavior in the playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=f725ccf90f9148c937de42e4e570a515
I hope someone can chime in with developer knowledge and confirm all the initialized/cloned values are dropped before the respective functions return.
Felt the need to document it in order to save other users time :)