### PR TITLE
Add `tracing` integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version.workspace = true
 #
 # Only useful on the `wasm32-unknown-unknown` target.
 web_spin_lock = ["dep:wasm_sync", "rayon-core/web_spin_lock"]
+tracing = ["rayon-core/tracing"]
 
 [dependencies]
 # These are both public dependencies!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 #
 # Only useful on the `wasm32-unknown-unknown` target.
 web_spin_lock = ["dep:wasm_sync", "rayon-core/web_spin_lock"]
+tracing = ["rayon-core/tracing"]
 
 [dependencies]
 # These are both public dependencies!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,9 @@ either = { version = "1", default-features = false }
 libc = "0.2"
 rand = "0.10"
 scoped-tls = "1.0"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "registry",
+] }
 wasm_sync = "0.1.0"

--- a/ci/compat-Cargo.lock
+++ b/ci/compat-Cargo.lock
@@ -1303,6 +1303,8 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
  "wasm_sync",
 ]
 
@@ -1460,6 +1462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1566,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1631,20 @@ name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "ttf-parser"

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -24,12 +24,19 @@ web_spin_lock = ["dep:wasm_sync"]
 [dependencies]
 crossbeam-deque.workspace = true
 crossbeam-utils.workspace = true
+tracing = { version = "0.1", default-features = false, features = [
+    "std",
+], optional = true }
 wasm_sync = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
 rand_xorshift.workspace = true
 scoped-tls.workspace = true
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "registry",
+] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc.workspace = true

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -27,18 +27,13 @@ web_spin_lock = ["dep:wasm_sync"]
 [dependencies]
 crossbeam-deque.workspace = true
 crossbeam-utils.workspace = true
-tracing = { version = "0.1", default-features = false, features = [
-    "std",
-], optional = true }
+tracing = { workspace = true, optional = true }
 wasm_sync = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
 scoped-tls.workspace = true
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "std",
-    "registry",
-] }
+tracing-subscriber.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
 libc.workspace = true

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -27,11 +27,18 @@ web_spin_lock = ["dep:wasm_sync"]
 [dependencies]
 crossbeam-deque.workspace = true
 crossbeam-utils.workspace = true
+tracing = { version = "0.1", default-features = false, features = [
+    "std",
+], optional = true }
 wasm_sync = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
 scoped-tls.workspace = true
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "registry",
+] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc.workspace = true

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -1,13 +1,34 @@
 //! Tracing instrumentation for rayon-core.
 //!
 //! This module provides optional tracing support, enabled via the `tracing` feature.
-//! When enabled, rayon emits events and spans for:
-//!
-//! - Thread lifecycle (start, exit, idle, active)
-//! - Work stealing
-//! - Job execution (as spans, enabling duration measurement)
-//!
 //! All instrumentation compiles to no-ops when the feature is disabled.
+//!
+//! # Spans
+//!
+//! - `rayon::worker_thread` (DEBUG) - Wraps the entire lifetime of a worker thread.
+//!   Fields: `worker` (thread index).
+//!
+//! - `rayon::job_execute` (DEBUG) - Wraps the execution of a job.
+//!   Fields: `job_id`, `worker` (executing thread index).
+//!   Parent: The span that was active when the job was created (enables cross-thread
+//!   context propagation).
+//!
+//! # Events
+//!
+//! - `thread_idle` (TRACE) - Emitted when a worker thread goes idle.
+//! - `thread_active` (TRACE) - Emitted when a worker thread wakes up.
+//! - `job_injected` (TRACE) - Emitted when a job is injected into the global queue.
+//!   Fields: `job_id`.
+//! - `job_stolen` (TRACE) - Emitted when a job is stolen from another thread.
+//!   Fields: `job_id`, `victim` (thread stolen from).
+//!
+//! # Context Propagation
+//!
+//! Jobs capture the current span context at creation time via [`JobContext`]. When
+//! a job executes (potentially on a different thread), it re-enters the captured
+//! context before creating the `job_execute` span. This allows tracing tools to
+//! correctly attribute work to the logical operation that spawned it, even when
+//! executed by a different worker thread.
 
 #[cfg(feature = "tracing")]
 #[macro_use]
@@ -114,8 +135,9 @@ mod tests {
     //! Note: These tests use a global subscriber because rayon's worker threads
     //! don't inherit thread-local subscribers.
 
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, OnceLock};
 
     use tracing::span::{Attributes, Id};
     use tracing::{Event, Subscriber};
@@ -126,118 +148,151 @@ mod tests {
 
     use crate::ThreadPoolBuilder;
 
-    /// Counters for tracking events and spans.
-    struct Counters {
+    /// Shared test state for tracking spans and events.
+    struct TestState {
+        // Span/event counters
         worker_thread_spans: AtomicUsize,
-        thread_idle: AtomicUsize,
-        thread_active: AtomicUsize,
-        job_stolen: AtomicUsize,
         job_execute_spans: AtomicUsize,
         total_events: AtomicUsize,
+
+        // Parent tracking for context propagation tests
+        parents: Mutex<HashMap<Id, Option<Id>>>,
+        user_span_id: Mutex<Option<Id>>,
+        job_spans_with_user_parent: AtomicUsize,
     }
 
-    impl Counters {
+    impl TestState {
         fn new() -> Arc<Self> {
             Arc::new(Self {
                 worker_thread_spans: AtomicUsize::new(0),
-                thread_idle: AtomicUsize::new(0),
-                thread_active: AtomicUsize::new(0),
-                job_stolen: AtomicUsize::new(0),
                 job_execute_spans: AtomicUsize::new(0),
                 total_events: AtomicUsize::new(0),
+                parents: Mutex::new(HashMap::new()),
+                user_span_id: Mutex::new(None),
+                job_spans_with_user_parent: AtomicUsize::new(0),
             })
+        }
+
+        /// Check if `span_id` has `ancestor_id` as an ancestor.
+        fn has_ancestor(&self, span_id: &Id, ancestor_id: &Id) -> bool {
+            let parents = self.parents.lock().unwrap();
+            let mut current = Some(span_id.clone());
+            while let Some(id) = current {
+                if &id == ancestor_id {
+                    return true;
+                }
+                current = parents.get(&id).and_then(|p| p.clone());
+            }
+            false
         }
     }
 
-    /// A simple layer that counts events and spans by name.
-    struct CountingLayer(Arc<Counters>);
+    /// Layer that tracks spans and events for testing.
+    struct TestLayer(Arc<TestState>);
 
-    impl<S> Layer<S> for CountingLayer
+    impl<S> Layer<S> for TestLayer
     where
         S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     {
-        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        fn on_event(&self, _event: &Event<'_>, _ctx: Context<'_, S>) {
             self.0.total_events.fetch_add(1, Ordering::Relaxed);
-
-            // Extract the message field to check event type
-            struct MessageVisitor<'a>(&'a Counters);
-
-            impl tracing::field::Visit for MessageVisitor<'_> {
-                fn record_debug(
-                    &mut self,
-                    field: &tracing::field::Field,
-                    value: &dyn std::fmt::Debug,
-                ) {
-                    if field.name() == "message" {
-                        let msg = format!("{:?}", value);
-                        if msg.contains("thread_idle") {
-                            self.0.thread_idle.fetch_add(1, Ordering::Relaxed);
-                        } else if msg.contains("thread_active") {
-                            self.0.thread_active.fetch_add(1, Ordering::Relaxed);
-                        } else if msg.contains("job_stolen") {
-                            self.0.job_stolen.fetch_add(1, Ordering::Relaxed);
-                        }
-                    }
-                }
-            }
-
-            event.record(&mut MessageVisitor(&self.0));
         }
 
-        fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
             let name = attrs.metadata().name();
+
+            // Record parent relationship
+            let parent_id = ctx.span(id).and_then(|span| span.parent()).map(|p| p.id());
+            self.0.parents.lock().unwrap().insert(id.clone(), parent_id);
+
+            // Count span types
             if name.contains("worker_thread") {
                 self.0.worker_thread_spans.fetch_add(1, Ordering::Relaxed);
             } else if name.contains("job_execute") {
                 self.0.job_execute_spans.fetch_add(1, Ordering::Relaxed);
+
+                // Check if this job_execute has user_operation as ancestor
+                if let Some(ref user_id) = *self.0.user_span_id.lock().unwrap() {
+                    if self.0.has_ancestor(id, user_id) {
+                        self.0
+                            .job_spans_with_user_parent
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            } else if name == "user_operation" {
+                *self.0.user_span_id.lock().unwrap() = Some(id.clone());
             }
         }
     }
 
-    /// Single test that covers all instrumentation points
+    /// Returns the shared test state, initializing the global subscriber on first call.
+    fn test_state() -> Arc<TestState> {
+        static STATE: OnceLock<Arc<TestState>> = OnceLock::new();
+        STATE
+            .get_or_init(|| {
+                let state = TestState::new();
+                tracing_subscriber::registry()
+                    .with(TestLayer(Arc::clone(&state)))
+                    .init();
+                state
+            })
+            .clone()
+    }
+
+    /// Test that worker thread and job execution spans are created.
     #[test]
     fn test_tracing_instrumentation() {
-        // Global counters initialized once
-        let counters = Counters::new();
-        tracing_subscriber::registry()
-            .with(CountingLayer(Arc::clone(&counters)))
-            .init();
+        let state = test_state();
 
-        // Create a pool and do some work
         let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-
-        // Clone the registry so we can wait for threads to stop after pool is dropped
         let registry = Arc::clone(pool.registry());
 
         pool.install(|| {
-            // Do parallel work to trigger events
-            crate::join(
-                || {
-                    // Force some actual work
-                    (0..100).sum::<i32>()
-                },
-                || (100..200).sum::<i32>(),
-            );
+            crate::join(|| (0..100).sum::<i32>(), || (100..200).sum::<i32>());
         });
 
         drop(pool);
-
-        // Wait for all threads to stop.
         registry.wait_until_stopped();
 
         // Verify worker thread spans
-        let worker_spans = counters.worker_thread_spans.load(Ordering::Relaxed);
+        let worker_spans = state.worker_thread_spans.load(Ordering::Relaxed);
         assert!(
             worker_spans >= 2,
             "Expected at least 2 worker_thread spans, got {worker_spans}",
         );
 
         // Verify job execution spans
-        let job_spans = counters.job_execute_spans.load(Ordering::Relaxed);
+        let job_spans = state.job_execute_spans.load(Ordering::Relaxed);
         assert!(
             job_spans > 0,
-            "Expected some job_execute spans, got {}",
-            job_spans
+            "Expected some job_execute spans, got {job_spans}"
+        );
+    }
+
+    /// Test that span context is propagated from job creation site to execution site.
+    #[test]
+    fn test_context_propagation() {
+        let state = test_state();
+
+        let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+        let registry = Arc::clone(pool.registry());
+
+        // Create a user span and spawn work inside it
+        let user_span = tracing::span!(tracing::Level::INFO, "user_operation");
+        let _enter = user_span.enter();
+
+        pool.install(|| {
+            crate::join(|| (0..100).sum::<i32>(), || (100..200).sum::<i32>());
+        });
+
+        drop(pool);
+        registry.wait_until_stopped();
+
+        // Verify that job_execute spans have user_operation as ancestor
+        let jobs_with_parent = state.job_spans_with_user_parent.load(Ordering::Relaxed);
+        assert!(
+            jobs_with_parent > 0,
+            "Expected job_execute spans to have user_operation as ancestor, got {jobs_with_parent}",
         );
     }
 }

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -1,0 +1,179 @@
+//! Tracing instrumentation for rayon-core.
+//!
+//! This module provides optional tracing support, enabled via the `tracing` feature.
+//! When enabled, rayon emits events and spans for:
+//!
+//! - Thread lifecycle (start, exit, idle, active)
+//! - Work stealing
+//! - Job execution (as spans, enabling duration measurement)
+//!
+//! All instrumentation compiles to no-ops when the feature is disabled.
+
+/// Emits a tracing event when the `tracing` feature is enabled.
+/// Compiles to nothing when disabled.
+#[cfg(feature = "tracing")]
+macro_rules! trace_event {
+    ($($arg:tt)*) => {
+        tracing::event!($($arg)*)
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_event {
+    ($($arg:tt)*) => {};
+}
+
+/// Creates and enters a tracing span when the `tracing` feature is enabled.
+/// Returns an `EnteredSpan` that will exit when dropped.
+/// Compiles to nothing when disabled.
+#[cfg(feature = "tracing")]
+macro_rules! trace_span {
+    ($($arg:tt)*) => {
+        tracing::span!($($arg)*).entered()
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_span {
+    ($($arg:tt)*) => {
+        ()
+    };
+}
+
+#[cfg(all(test, feature = "tracing"))]
+mod tests {
+    //! Note: These tests use a global subscriber because rayon's worker threads
+    //! don't inherit thread-local subscribers.
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use tracing::span::{Attributes, Id};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::Layer;
+
+    use crate::ThreadPoolBuilder;
+
+    /// Counters for tracking events and spans.
+    struct Counters {
+        thread_start: AtomicUsize,
+        thread_exit: AtomicUsize,
+        thread_idle: AtomicUsize,
+        thread_active: AtomicUsize,
+        job_stolen: AtomicUsize,
+        job_execute_spans: AtomicUsize,
+        total_events: AtomicUsize,
+    }
+
+    impl Counters {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                thread_start: AtomicUsize::new(0),
+                thread_exit: AtomicUsize::new(0),
+                thread_idle: AtomicUsize::new(0),
+                thread_active: AtomicUsize::new(0),
+                job_stolen: AtomicUsize::new(0),
+                job_execute_spans: AtomicUsize::new(0),
+                total_events: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    /// A simple layer that counts events and spans by name.
+    struct CountingLayer(Arc<Counters>);
+
+    impl<S> Layer<S> for CountingLayer
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            self.0.total_events.fetch_add(1, Ordering::Relaxed);
+
+            // Extract the message field to check event type
+            struct MessageVisitor<'a>(&'a Counters);
+
+            impl tracing::field::Visit for MessageVisitor<'_> {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        let msg = format!("{:?}", value);
+                        if msg.contains("thread_start") {
+                            self.0.thread_start.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_exit") {
+                            self.0.thread_exit.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_idle") {
+                            self.0.thread_idle.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_active") {
+                            self.0.thread_active.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("job_stolen") {
+                            self.0.job_stolen.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
+
+            event.record(&mut MessageVisitor(&self.0));
+        }
+
+        fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+            if attrs.metadata().name().contains("job_execute") {
+                self.0.job_execute_spans.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Single test that covers all instrumentation points
+    #[test]
+    fn test_tracing_instrumentation() {
+        // Global counters initialized once
+        let counters = Counters::new();
+        tracing_subscriber::registry()
+            .with(CountingLayer(Arc::clone(&counters)))
+            .init();
+
+        // Create a pool and do some work
+        let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+
+        // Clone the registry so we can wait for threads to stop after pool is dropped
+        let registry = Arc::clone(pool.registry());
+
+        pool.install(|| {
+            // Do parallel work to trigger events
+            crate::join(
+                || {
+                    // Force some actual work
+                    (0..100).sum::<i32>()
+                },
+                || (100..200).sum::<i32>(),
+            );
+        });
+
+        drop(pool);
+
+        // Wait for all threads to stop. Since thread_exit events are emitted
+        // before the stopped latch is set, this guarantees all events are captured.
+        registry.wait_until_stopped();
+
+        // Verify thread lifecycle events
+        let starts = counters.thread_start.load(Ordering::Relaxed);
+        let exits = counters.thread_exit.load(Ordering::Relaxed);
+        assert!(
+            starts >= 2,
+            "Expected at least 2 thread_start events, got {starts}",
+        );
+        assert!(
+            exits >= 2,
+            "Expected at least 2 thread_exit events, got {exits}",
+        );
+
+        // Verify job execution spans
+        let spans = counters.job_execute_spans.load(Ordering::Relaxed);
+        assert!(spans > 0, "Expected some job_execute spans, got {}", spans);
+    }
+}

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -5,21 +5,21 @@
 //!
 //! # Spans
 //!
-//! - `rayon::worker_thread` (DEBUG) - Wraps the entire lifetime of a worker thread.
-//!   Fields: `worker` (thread index).
+//! - `rayon::worker_thread` (INFO) - Wraps the entire lifetime of a worker thread.
+//!   Fields: `worker` (thread index), `pool_id`.
 //!
-//! - `rayon::job_execute` (DEBUG) - Wraps the execution of a job.
+//! - `rayon::job_execute` (INFO) - Wraps the execution of a job.
 //!   Fields: `job_id`, `worker` (executing thread index).
 //!   Parent: The span that was active when the job was created (enables cross-thread
 //!   context propagation).
 //!
 //! # Events
 //!
-//! - `thread_idle` (TRACE) - Emitted when a worker thread goes idle.
-//! - `thread_active` (TRACE) - Emitted when a worker thread wakes up.
-//! - `job_injected` (TRACE) - Emitted when a job is injected into the global queue.
-//!   Fields: `job_id`.
-//! - `job_stolen` (TRACE) - Emitted when a job is stolen from another thread.
+//! - `rayon::thread_idle` (DEBUG) - Emitted when a worker thread goes idle.
+//! - `rayon::thread_active` (DEBUG) - Emitted when a worker thread wakes up.
+//! - `rayon::job_injected` (DEBUG) - Emitted when a job is injected into the global queue.
+//!   Fields: `job_id`, `pool_id`.
+//! - `rayon::job_stolen` (DEBUG) - Emitted when a job is stolen from another thread.
 //!   Fields: `job_id`, `victim` (thread stolen from).
 //!
 //! # Context Propagation

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -90,7 +90,12 @@ mod inner {
             Self
         }
 
-        /// Returns a placeholder job ID (no-op).
+        /// Returns a placeholder job ID.
+        ///
+        /// This method exists for API compatibility with the tracing-enabled
+        /// version. The value is never used because trace macros expand to
+        /// nothing when the feature is disabled.
+        #[allow(dead_code)]
         pub(crate) fn id(&self) -> u64 {
             0
         }

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -33,6 +33,9 @@ mod inner {
 
     static NEXT_JOB_ID: AtomicU64 = AtomicU64::new(0);
 
+    /// Guard returned by entering a job context.
+    pub(crate) type ContextGuard<'a> = tracing::span::Entered<'a>;
+
     /// Captured context for a job, used to propagate span context across threads.
     #[derive(Clone)]
     pub(crate) struct JobContext {
@@ -49,14 +52,14 @@ mod inner {
             }
         }
 
-        /// Returns a reference to the captured span.
-        pub(crate) fn span(&self) -> &tracing::Span {
-            &self.span
-        }
-
         /// Returns the unique job ID.
         pub(crate) fn id(&self) -> u64 {
             self.id
+        }
+
+        /// Enters the captured span context.
+        pub(crate) fn enter(&self) -> ContextGuard<'_> {
+            self.span.enter()
         }
     }
 }
@@ -74,6 +77,9 @@ mod inner {
         };
     }
 
+    /// Guard returned by entering a job context (no-op).
+    pub(crate) struct ContextGuard;
+
     /// Captured context for a job (no-op when tracing is disabled).
     #[derive(Clone)]
     pub(crate) struct JobContext;
@@ -87,6 +93,11 @@ mod inner {
         /// Returns a placeholder job ID (no-op).
         pub(crate) fn id(&self) -> u64 {
             0
+        }
+
+        /// No-op context entry.
+        pub(crate) fn enter(&self) -> ContextGuard {
+            ContextGuard
         }
     }
 }

--- a/rayon-core/src/instrumentation.rs
+++ b/rayon-core/src/instrumentation.rs
@@ -1,0 +1,179 @@
+//! Tracing instrumentation for rayon-core.
+//!
+//! This module provides optional tracing support, enabled via the `tracing` feature.
+//! When enabled, rayon emits events and spans for:
+//!
+//! - Thread lifecycle (start, exit, idle, active)
+//! - Work stealing
+//! - Job execution (as spans, enabling duration measurement)
+//!
+//! All instrumentation compiles to no-ops when the feature is disabled.
+
+/// Emits a tracing event when the `tracing` feature is enabled.
+/// Compiles to nothing when disabled.
+#[cfg(feature = "tracing")]
+macro_rules! trace_event {
+    ($($arg:tt)*) => {
+        tracing::event!($($arg)*)
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_event {
+    ($($arg:tt)*) => {};
+}
+
+/// Creates and enters a tracing span when the `tracing` feature is enabled.
+/// Returns an `EnteredSpan` that will exit when dropped.
+/// Compiles to nothing when disabled.
+#[cfg(feature = "tracing")]
+macro_rules! trace_span {
+    ($($arg:tt)*) => {
+        tracing::span!($($arg)*).entered()
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace_span {
+    ($($arg:tt)*) => {
+        ()
+    };
+}
+
+#[cfg(all(test, feature = "tracing"))]
+mod tests {
+    //! Note: These tests use a global subscriber because rayon's worker threads
+    //! don't inherit thread-local subscribers.
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use tracing::span::{Attributes, Id};
+    use tracing::{Event, Subscriber};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    use crate::ThreadPoolBuilder;
+
+    /// Counters for tracking events and spans.
+    struct Counters {
+        thread_start: AtomicUsize,
+        thread_exit: AtomicUsize,
+        thread_idle: AtomicUsize,
+        thread_active: AtomicUsize,
+        job_stolen: AtomicUsize,
+        job_execute_spans: AtomicUsize,
+        total_events: AtomicUsize,
+    }
+
+    impl Counters {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                thread_start: AtomicUsize::new(0),
+                thread_exit: AtomicUsize::new(0),
+                thread_idle: AtomicUsize::new(0),
+                thread_active: AtomicUsize::new(0),
+                job_stolen: AtomicUsize::new(0),
+                job_execute_spans: AtomicUsize::new(0),
+                total_events: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    /// A simple layer that counts events and spans by name.
+    struct CountingLayer(Arc<Counters>);
+
+    impl<S> Layer<S> for CountingLayer
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            self.0.total_events.fetch_add(1, Ordering::Relaxed);
+
+            // Extract the message field to check event type
+            struct MessageVisitor<'a>(&'a Counters);
+
+            impl tracing::field::Visit for MessageVisitor<'_> {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        let msg = format!("{:?}", value);
+                        if msg.contains("thread_start") {
+                            self.0.thread_start.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_exit") {
+                            self.0.thread_exit.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_idle") {
+                            self.0.thread_idle.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("thread_active") {
+                            self.0.thread_active.fetch_add(1, Ordering::Relaxed);
+                        } else if msg.contains("job_stolen") {
+                            self.0.job_stolen.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+            }
+
+            event.record(&mut MessageVisitor(&self.0));
+        }
+
+        fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+            if attrs.metadata().name().contains("job_execute") {
+                self.0.job_execute_spans.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Single test that covers all instrumentation points
+    #[test]
+    fn test_tracing_instrumentation() {
+        // Global counters initialized once
+        let counters = Counters::new();
+        tracing_subscriber::registry()
+            .with(CountingLayer(Arc::clone(&counters)))
+            .init();
+
+        // Create a pool and do some work
+        let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+
+        // Clone the registry so we can wait for threads to stop after pool is dropped
+        let registry = Arc::clone(pool.registry());
+
+        pool.install(|| {
+            // Do parallel work to trigger events
+            crate::join(
+                || {
+                    // Force some actual work
+                    (0..100).sum::<i32>()
+                },
+                || (100..200).sum::<i32>(),
+            );
+        });
+
+        drop(pool);
+
+        // Wait for all threads to stop. Since thread_exit events are emitted
+        // before the stopped latch is set, this guarantees all events are captured.
+        registry.wait_until_stopped();
+
+        // Verify thread lifecycle events
+        let starts = counters.thread_start.load(Ordering::Relaxed);
+        let exits = counters.thread_exit.load(Ordering::Relaxed);
+        assert!(
+            starts >= 2,
+            "Expected at least 2 thread_start events, got {starts}",
+        );
+        assert!(
+            exits >= 2,
+            "Expected at least 2 thread_exit events, got {exits}",
+        );
+
+        // Verify job execution spans
+        let spans = counters.job_execute_spans.load(Ordering::Relaxed);
+        assert!(spans > 0, "Expected some job_execute spans, got {}", spans);
+    }
+}

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -82,7 +82,7 @@ impl JobRef {
         // recorded. If the span is filtered out (e.g., max level set
         // to WARN), context would be lost.
         let _span = trace_span!(
-            tracing::Level::DEBUG,
+            tracing::Level::INFO,
             "rayon::job_execute",
             job_id = self.context.id(),
             worker = {

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -62,6 +62,7 @@ impl JobRef {
     }
 
     #[inline]
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     pub(super) fn context(&self) -> &JobContext {
         &self.context
     }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -68,6 +68,15 @@ impl JobRef {
 
     #[inline]
     pub(super) unsafe fn execute(self) {
+        let _context_guard = self.context.enter();
+        // We don't use `parent: ...` to track the parent span, because
+        // if the logging level is above DEBUG, the following span won't
+        // be registered, and context will not be preserved correctly.
+        let _span = trace_span!(
+            tracing::Level::DEBUG,
+            "rayon::job_execute",
+            job_id = self.context.id(),
+        );
         (self.execute_fn)(self.pointer)
     }
 }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -77,6 +77,16 @@ impl JobRef {
             tracing::Level::DEBUG,
             "rayon::job_execute",
             job_id = self.context.id(),
+            worker = {
+                // We find the worker id in the macro to prevent
+                // overhead when the `tracing` feature is disabled.
+                let worker = crate::registry::WorkerThread::current();
+                if worker.is_null() {
+                    0
+                } else {
+                    (*worker).index()
+                }
+            }
         );
         (self.execute_fn)(self.pointer)
     }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -68,6 +68,15 @@ impl JobRef {
 
     #[inline]
     pub(super) unsafe fn execute(self) {
+        let _context_guard = self.context.enter();
+        // We don't use `parent: ...` to track the parent span, because
+        // if the logging level is above DEBUG, the following span won't
+        // be registered, and context will not be preserved correctly.
+        let _span = trace_span!(
+            tracing::Level::DEBUG,
+            "rayon::job_execute",
+            job_id = self.context.id(),
+        );
         unsafe { (self.execute_fn)(self.pointer) }
     }
 }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -77,6 +77,16 @@ impl JobRef {
             tracing::Level::DEBUG,
             "rayon::job_execute",
             job_id = self.context.id(),
+            worker = {
+                // We find the worker id in the macro to prevent
+                // overhead when the `tracing` feature is disabled.
+                let worker = crate::registry::WorkerThread::current();
+                if worker.is_null() {
+                    0
+                } else {
+                    (*worker).index()
+                }
+            }
         );
         unsafe { (self.execute_fn)(self.pointer) }
     }

--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -1,3 +1,4 @@
+use crate::instrumentation::JobContext;
 use crate::latch::Latch;
 use crate::unwind;
 use crossbeam_deque::{Injector, Steal};
@@ -24,14 +25,14 @@ pub(super) trait Job {
     unsafe fn execute(this: *const ());
 }
 
-/// Effectively a Job trait object. Each JobRef **must** be executed
-/// exactly once, or else data may leak.
+/// Effectively a decorated Job trait object. Each JobRef **must** be executed exactly once, or else
+/// data may leak.
 ///
-/// Internally, we store the job's data in a `*const ()` pointer.  The
-/// true type is something like `*const StackJob<...>`, but we hide
-/// it. We also carry the "execute fn" from the `Job` trait.
+/// Internally, we store the job's data in a `*const ()` pointer.  The true type is something like
+/// `*const StackJob<...>`, but we hide it. We also carry the "execute fn" from the `Job` trait.
 pub(super) struct JobRef {
     pointer: *const (),
+    context: JobContext,
     execute_fn: unsafe fn(*const ()),
 }
 
@@ -48,6 +49,7 @@ impl JobRef {
         // erase types:
         JobRef {
             pointer: data as *const (),
+            context: JobContext::current(),
             execute_fn: <T as Job>::execute,
         }
     }
@@ -57,6 +59,11 @@ impl JobRef {
     #[inline]
     pub(super) fn id(&self) -> impl Eq + use<> {
         (self.pointer, self.execute_fn)
+    }
+
+    #[inline]
+    pub(super) fn context(&self) -> &JobContext {
+        &self.context
     }
 
     #[inline]

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -70,6 +70,8 @@ use std::thread;
 
 #[macro_use]
 mod private;
+#[macro_use]
+mod instrumentation;
 
 mod broadcast;
 mod job;

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -53,6 +53,34 @@
 //! restrictive tilde or inequality requirements for `rayon-core`.  The
 //! conflicting requirements will need to be resolved before the build will
 //! succeed.
+//!
+//! # Tracing
+//!
+//! Rayon supports the [`tracing`](https://docs.rs/tracing) crate for instrumentation,
+//! enabled via the `tracing` Cargo feature. This provides visibility into the runtime
+//! behavior of the thread pool.
+//!
+//! ## Spans (INFO level)
+//!
+//! - `rayon::worker_thread` - Wraps the lifetime of each worker thread.
+//!   Fields: `worker` (thread index), `pool_id`.
+//!
+//! - `rayon::job_execute` - Wraps each job execution.
+//!   Fields: `job_id`, `worker`.
+//!   Parent: The span active when the job was created (enables cross-thread context propagation).
+//!
+//! ## Events (DEBUG level)
+//!
+//! - `rayon::thread_idle` - Worker thread going idle.
+//! - `rayon::thread_active` - Worker thread waking up.
+//! - `rayon::job_injected` - Job injected into global queue. Fields: `job_id`, `pool_id`.
+//! - `rayon::job_stolen` - Job stolen from another thread. Fields: `job_id`, `victim`.
+//!
+//! ## Context Propagation
+//!
+//! Jobs automatically capture the current span context when created. When executed
+//! (potentially on a different thread), they restore this context, so `job_execute`
+//! spans appear as children of the span that spawned the work.
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -66,6 +66,9 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 use std::thread;
 
+#[macro_use]
+mod instrumentation;
+
 mod broadcast;
 mod job;
 mod join;

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -870,13 +870,6 @@ impl WorkerThread {
 
     #[inline]
     pub(super) unsafe fn execute(&self, job: JobRef) {
-        let _span = trace_span!(
-            parent: job.context().span(),
-            tracing::Level::DEBUG,
-            "rayon::job_execute",
-            worker = self.index,
-            job_id = job.context().id(),
-        );
         job.execute();
     }
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -833,13 +833,6 @@ impl WorkerThread {
         // Should not be any work left in our queue.
         debug_assert!(self.take_local_job().is_none());
 
-        trace_event!(
-            tracing::Level::DEBUG,
-            worker = index,
-            pool_id = registry.id().addr,
-            "rayon::thread_exit"
-        );
-
         // Let registry know we are done
         Latch::set(&registry.thread_infos[index].stopped);
     }
@@ -956,11 +949,11 @@ unsafe fn main_loop(thread: ThreadBuilder) {
         registry.catch_unwind(|| handler(index));
     }
 
-    trace_event!(
+    let _span = trace_span!(
         tracing::Level::DEBUG,
+        "rayon::worker_thread",
         worker = index,
         pool_id = registry.id().addr,
-        "rayon::thread_start"
     );
 
     worker_thread.wait_until_out_of_work();

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -440,6 +440,7 @@ impl Registry {
         trace_event!(
             tracing::Level::DEBUG,
             pool_id = self.id().addr,
+            job_id = injected_job.context().id(),
             "rayon::job_injected"
         );
 
@@ -881,6 +882,7 @@ impl WorkerThread {
             tracing::Level::DEBUG,
             "rayon::job_execute",
             worker = self.index,
+            job_id = job.context().id(),
         );
         job.execute();
     }
@@ -914,6 +916,7 @@ impl WorkerThread {
                                 tracing::Level::DEBUG,
                                 worker = self.index,
                                 victim = victim_index,
+                                job_id = job.context().id(),
                                 "rayon::job_stolen"
                             );
                             Some(job)

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -942,7 +942,7 @@ unsafe fn main_loop(thread: ThreadBuilder) {
     }
 
     let _span = trace_span!(
-        tracing::Level::DEBUG,
+        tracing::Level::INFO,
         "rayon::worker_thread",
         worker = index,
         pool_id = registry.id().addr,

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -877,6 +877,7 @@ impl WorkerThread {
     #[inline]
     pub(super) unsafe fn execute(&self, job: JobRef) {
         let _span = trace_span!(
+            parent: job.context().span(),
             tracing::Level::DEBUG,
             "rayon::job_execute",
             worker = self.index,

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -900,7 +900,6 @@ impl WorkerThread {
                         Steal::Success(job) => {
                             trace_event!(
                                 tracing::Level::DEBUG,
-                                worker = self.index,
                                 victim = victim_index,
                                 job_id = job.context().id(),
                                 "rayon::job_stolen"

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -872,13 +872,6 @@ impl WorkerThread {
 
     #[inline]
     pub(super) unsafe fn execute(&self, job: JobRef) {
-        let _span = trace_span!(
-            parent: job.context().span(),
-            tracing::Level::DEBUG,
-            "rayon::job_execute",
-            worker = self.index,
-            job_id = job.context().id(),
-        );
         unsafe { job.execute() };
     }
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -435,6 +435,12 @@ impl Registry {
             "inject() sees state.terminate as true"
         );
 
+        trace_event!(
+            tracing::Level::DEBUG,
+            pool_id = self.id().addr,
+            "rayon::job_injected"
+        );
+
         let queue_was_empty = self.injected_jobs.is_empty();
 
         self.injected_jobs.push(injected_job);
@@ -830,6 +836,13 @@ impl WorkerThread {
             // Let registry know we are done
             Latch::set(&registry.thread_infos[index].stopped);
         }
+
+        trace_event!(
+            tracing::Level::DEBUG,
+            worker = index,
+            pool_id = registry.id().addr,
+            "rayon::thread_exit"
+        );
     }
 
     fn find_work(&self) -> Option<JobRef> {
@@ -865,6 +878,11 @@ impl WorkerThread {
 
     #[inline]
     pub(super) unsafe fn execute(&self, job: JobRef) {
+        let _span = trace_span!(
+            tracing::Level::DEBUG,
+            "rayon::job_execute",
+            worker = self.index,
+        );
         unsafe { job.execute() };
     }
 
@@ -892,7 +910,15 @@ impl WorkerThread {
                 .find_map(|victim_index| {
                     let victim = &thread_infos[victim_index];
                     match victim.stealer.steal() {
-                        Steal::Success(job) => Some(job),
+                        Steal::Success(job) => {
+                            trace_event!(
+                                tracing::Level::DEBUG,
+                                worker = self.index,
+                                victim = victim_index,
+                                "rayon::job_stolen"
+                            );
+                            Some(job)
+                        }
                         Steal::Empty => None,
                         Steal::Retry => {
                             retry = true;
@@ -929,6 +955,13 @@ unsafe fn main_loop(thread: ThreadBuilder) {
         if let Some(ref handler) = registry.start_handler {
             registry.catch_unwind(|| handler(index));
         }
+
+        trace_event!(
+            tracing::Level::DEBUG,
+            worker = index,
+            pool_id = registry.id().addr,
+            "rayon::thread_start"
+        );
 
         worker_thread.wait_until_out_of_work();
 

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -902,7 +902,6 @@ impl WorkerThread {
                         Steal::Success(job) => {
                             trace_event!(
                                 tracing::Level::DEBUG,
-                                worker = self.index,
                                 victim = victim_index,
                                 job_id = job.context().id(),
                                 "rayon::job_stolen"

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -946,7 +946,7 @@ unsafe fn main_loop(thread: ThreadBuilder) {
         }
 
         let _span = trace_span!(
-            tracing::Level::DEBUG,
+            tracing::Level::INFO,
             "rayon::worker_thread",
             worker = index,
             pool_id = registry.id().addr,

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -438,6 +438,7 @@ impl Registry {
         trace_event!(
             tracing::Level::DEBUG,
             pool_id = self.id().addr,
+            job_id = injected_job.context().id(),
             "rayon::job_injected"
         );
 
@@ -883,6 +884,7 @@ impl WorkerThread {
             tracing::Level::DEBUG,
             "rayon::job_execute",
             worker = self.index,
+            job_id = job.context().id(),
         );
         unsafe { job.execute() };
     }
@@ -916,6 +918,7 @@ impl WorkerThread {
                                 tracing::Level::DEBUG,
                                 worker = self.index,
                                 victim = victim_index,
+                                job_id = job.context().id(),
                                 "rayon::job_stolen"
                             );
                             Some(job)

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -837,13 +837,6 @@ impl WorkerThread {
             // Let registry know we are done
             Latch::set(&registry.thread_infos[index].stopped);
         }
-
-        trace_event!(
-            tracing::Level::DEBUG,
-            worker = index,
-            pool_id = registry.id().addr,
-            "rayon::thread_exit"
-        );
     }
 
     fn find_work(&self) -> Option<JobRef> {
@@ -960,11 +953,11 @@ unsafe fn main_loop(thread: ThreadBuilder) {
             registry.catch_unwind(|| handler(index));
         }
 
-        trace_event!(
+        let _span = trace_span!(
             tracing::Level::DEBUG,
+            "rayon::worker_thread",
             worker = index,
             pool_id = registry.id().addr,
-            "rayon::thread_start"
         );
 
         worker_thread.wait_until_out_of_work();

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -879,6 +879,7 @@ impl WorkerThread {
     #[inline]
     pub(super) unsafe fn execute(&self, job: JobRef) {
         let _span = trace_span!(
+            parent: job.context().span(),
             tracing::Level::DEBUG,
             "rayon::job_execute",
             worker = self.index,

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -69,11 +69,7 @@ impl Sleep {
     pub(super) fn start_looking(&self, worker_index: usize) -> IdleState {
         self.counters.add_inactive_thread();
 
-        trace_event!(
-            tracing::Level::DEBUG,
-            worker = worker_index,
-            "rayon::thread_idle"
-        );
+        trace_event!(tracing::Level::DEBUG, "rayon::thread_idle");
 
         IdleState {
             worker_index,

--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -69,6 +69,12 @@ impl Sleep {
     pub(super) fn start_looking(&self, worker_index: usize) -> IdleState {
         self.counters.add_inactive_thread();
 
+        trace_event!(
+            tracing::Level::DEBUG,
+            worker = worker_index,
+            "rayon::thread_idle"
+        );
+
         IdleState {
             worker_index,
             rounds: 0,
@@ -78,6 +84,8 @@ impl Sleep {
 
     #[inline]
     pub(super) fn work_found(&self) {
+        trace_event!(tracing::Level::DEBUG, "rayon::thread_active");
+
         // If we were the last idle thread and other threads are still sleeping,
         // then we should wake up another thread.
         let threads_to_wake = self.counters.sub_inactive_thread();

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -394,6 +394,12 @@ impl ThreadPool {
         let curr = self.registry.current_thread()?;
         Some(curr.yield_local())
     }
+
+    /// Returns the registry for this thread pool. Only available for tests.
+    #[cfg(test)]
+    pub(crate) fn registry(&self) -> &Arc<Registry> {
+        &self.registry
+    }
 }
 
 impl Drop for ThreadPool {

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -397,6 +397,7 @@ impl ThreadPool {
 
     /// Returns the registry for this thread pool. Only available for tests.
     #[cfg(test)]
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     pub(crate) fn registry(&self) -> &Arc<Registry> {
         &self.registry
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,26 @@
 //!
 //! # Targets without threading
 //!
-//! Rayon has limited support for targets without `std` threading implementations.
-//! See the [`rayon_core`] documentation for more information about its global fallback.
+//! Rayon has limited support for targets without `std` threading
+//! implementations. See the [`rayon_core`] documentation for more
+//! information about its global fallback.
+//!
+//! # Tracing
+//!
+//! Rayon has optional support for the [`tracing`] crate, enabled via
+//! the `tracing` Cargo feature. When enabled, Rayon emits spans and
+//! events for observability:
+//!
+//! - **Spans**: `rayon::worker_thread` (per-thread lifetime),
+//!   `rayon::job_execute` (per-job)
+//! - **Events**: `rayon::thread_idle`, `rayon::thread_active`,
+//!   `rayon::job_injected`, `rayon::job_stolen`
+//!
+//! Job spans automatically propagate context across thread boundaries,
+//! so jobs appear as children of the span that created them, even when
+//! executed by a different worker.
+//!
+//! [`tracing`]: https://docs.rs/tracing
 //!
 //! # Other questions?
 //!


### PR DESCRIPTION
This PR adds optional support for the tracing crate, as mentioned in #915 (especially https://github.com/rayon-rs/rayon/issues/915#issuecomment-3100117320).

Spans (INFO level):
- rayon::worker_thread -- Wraps each worker thread's lifetime. Fields: worker, pool_id
- rayon::job_execute -- Wraps each job execution. Fields: job_id, worker

Events (DEBUG level):
- rayon::thread_idle -- Worker going idle
- rayon::thread_active -- Worker waking up
- rayon::job_injected -- Job injected into global queue. Fields: job_id, pool_id
- rayon::job_stolen -- Job stolen from another thread. Fields: job_id, victim

Jobs capture the current span context when created. When executed (potentially on a different thread), they restore this context so job_execute spans appear as children of the span that spawned the work. This enables proper distributed tracing across thread boundaries.

Furthermore, all instrumentation compiles to no-ops when the feature is disabled, `JobContext` is zero-sized when tracing is off, and field values are computed inside macros to avoid overhead when filtered out.