### PR TITLE
Make `CoreLatch::set` use `SeqCst` instead of `AcqRel`

### DIFF
--- a/rayon-core/src/latch.rs
+++ b/rayon-core/src/latch.rs
@@ -124,7 +124,7 @@ impl CoreLatch {
     /// latch code.
     #[inline]
     unsafe fn set(this: *const Self) -> bool {
-        let old_state = unsafe { (*this).state.swap(SET, Ordering::AcqRel) };
+        let old_state = unsafe { (*this).state.swap(SET, Ordering::SeqCst) };
         old_state == SLEEPING
     }
 


### PR DESCRIPTION
Every other modification of this variable uses `SeqCst`, which is justified in the sleep README. This particular choice of `AcqRel` was not discussed during its addition in #746, nor rayon-rs/rfcs#5, so I suspect was simply an oversight from earlier development. We probably do want this to participate in the same sequential consistency.

The only other ordering difference is `CoreLatch::probe`'s load with `Acquire`, which should be fine because this doesn't need consistency with the sleep counters.

Assisted-by: Claude Code