### PR TITLE
ci: add more aarch64 runners for tier-1 test coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [
+          macos-latest,     # aarch64-apple-darwin
+          windows-11-arm,   # aarch64-pc-windows-msvc
+          ubuntu-24.04-arm, # aarch64-unknown-linux-gnu
+          windows-latest,   # x86_64-pc-windows-msvc
+          ubuntu-latest,    # x86_64-unknown-linux-gnu
+        ]
         rust: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
While `macos-latest` has already been aarch64 for a while, this adds
Linux and Windows coverage too, especially since these are [Tier 1]
supported platforms in Rust.

[Tier 1]: https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools
