### PR TITLE
Use `hint::spin_loop` for retry loops

### DIFF
--- a/rayon-core/src/job.rs
+++ b/rayon-core/src/job.rs
@@ -270,7 +270,7 @@ impl Job for JobFifo {
                 match this.inner.steal() {
                     Steal::Success(job_ref) => break job_ref.execute(),
                     Steal::Empty => panic!("FIFO is empty"),
-                    Steal::Retry => {}
+                    Steal::Retry => std::hint::spin_loop(),
                 }
             }
         }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -450,7 +450,7 @@ impl Registry {
             match self.injected_jobs.steal() {
                 Steal::Success(job) => return Some(job),
                 Steal::Empty => return None,
-                Steal::Retry => {}
+                Steal::Retry => std::hint::spin_loop(),
             }
         }
     }
@@ -757,7 +757,7 @@ impl WorkerThread {
             match self.stealer.steal() {
                 Steal::Success(job) => return Some(job),
                 Steal::Empty => return None,
-                Steal::Retry => {}
+                Steal::Retry => std::hint::spin_loop(),
             }
         }
     }
@@ -903,6 +903,7 @@ impl WorkerThread {
             if job.is_some() || !retry {
                 return job;
             }
+            std::hint::spin_loop();
         }
     }
 }

--- a/rayon-core/src/sleep/counters.rs
+++ b/rayon-core/src/sleep/counters.rs
@@ -136,6 +136,7 @@ impl AtomicCounters {
                 if self.try_exchange(old_value, new_value, Ordering::SeqCst) {
                     return new_value;
                 }
+                std::hint::spin_loop();
             } else {
                 return old_value;
             }


### PR DESCRIPTION
This hint may improve CPU usage under contention, but otherwise won't have any effect on algorithm correctness.