### PR TITLE
Implement `HashMap<K, Vec<V>>` Transpose

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub mod result;
 pub mod slice;
 pub mod str;
 pub mod string;
+pub mod transpose;
 pub mod vec;
 
 mod math;

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -58,7 +58,15 @@ where
 
     fn with_producer<CB: ProducerCallback<Self::Item>>(mut self, callback: CB) -> CB::Output {
         // Create the producer as the exclusive "owner" of the slice.
-        let producer = TransposeProducer::from_transpose(&mut self);
+        let producers = self
+            .vec
+            .into_iter()
+            .map(|iter| iter.into_par_iter().with_producer(callback))
+            .collect();
+        let producer = TransposeProducer {
+            producers,
+            len: self.len,
+        };
 
         // The producer will move or drop each item from the drained range.
         callback.callback(producer)
@@ -66,17 +74,17 @@ where
 }
 
 // ////////////////////////////////////////////////////////////////////////
-struct TransposeProducer<'data, T: Send> {
-    map: Vec<DrainProducer<'data, T>>,
+struct TransposeProducer<Pr> {
+    producers: Vec<Pr>,
     len: usize,
 }
 
-impl<'data, T: Send> TransposeProducer<'data, T> {
-    fn new(map: Vec<DrainProducer<'data, T>>, len: usize) -> Self {
-        Self { map, len }
+impl<Pr: Send> TransposeProducer<Pr> {
+    fn new(producers: Vec<Pr>, len: usize) -> Self {
+        Self { producers, len }
     }
 
-    fn from_transpose<P>(transpose: &'data mut Transpose<P>) -> Self
+    fn from_transpose<P>(transpose: &mut Transpose<P>) -> Self
     where
         P: Send,
         P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
@@ -97,19 +105,30 @@ impl<'data, T: Send> TransposeProducer<'data, T> {
     }
 }
 
-impl<'data, T: 'data + Send> Producer for TransposeProducer<'data, T> {
-    type Item = TransposeIterator<T>;
-    type IntoIter = TransposeSliceDrain<'data, T>;
+impl<Pr, T> Producer for TransposeProducer<Pr>
+where
+    Pr: Producer<Item = T>,
+{
+    type Item = T;
+    type IntoIter = TransposeSliceDrain<Pr::IntoIter>;
 
     fn into_iter(self) -> Self::IntoIter {
         let len = self.len;
-        let map = self.map.into_iter().map(IntoIterator::into_iter).collect();
+        let map = self
+            .producers
+            .into_iter()
+            .map(Producer::into_iter)
+            .collect();
         TransposeSliceDrain { map, len }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
         // TODO: figure out if there is a way to reuse the allocation of self
-        let (left, right) = self.map.into_iter().map(Producer::split_at).collect();
+        let (left, right) = self
+            .producers
+            .into_iter()
+            .map(|producer| producer.split_at(index))
+            .collect();
         (Self::new(left, index), Self::new(right, self.len - index))
     }
 }
@@ -117,12 +136,12 @@ impl<'data, T: 'data + Send> Producer for TransposeProducer<'data, T> {
 // ////////////////////////////////////////////////////////////////////////
 
 // like std::vec::Drain, without updating a source Vec
-struct TransposeSliceDrain<'data, T> {
-    map: Vec<SliceDrain<'data, T>>,
+struct TransposeSliceDrain<I> {
+    map: Vec<I>,
     len: usize,
 }
 
-impl<'data, T: 'data> Iterator for TransposeSliceDrain<'data, T> {
+impl<I> Iterator for TransposeSliceDrain<I> {
     type Item = TransposeIterator<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -138,16 +157,16 @@ impl<'data, T: 'data> Iterator for TransposeSliceDrain<'data, T> {
     }
 }
 
-impl<'data, T: 'data> DoubleEndedIterator for TransposeSliceDrain<'data, T> {
+impl<I> DoubleEndedIterator for TransposeSliceDrain<I> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.map.iter_mut().map(Iterator::next_back)
     }
 }
 
-impl<'data, T: 'data> ExactSizeIterator for TransposeSliceDrain<'data, T> {
+impl<I> ExactSizeIterator for TransposeSliceDrain<I> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'data, T: 'data> iter::FusedIterator for TransposeSliceDrain<'data, T> {}
+impl<I> iter::FusedIterator for TransposeSliceDrain<I> {}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,3 +1,7 @@
+//! This module contains the parallel iterator type for transposing a
+//! HashMap of Vecs into a Vec of HashMaps.  Use HashMapVecTranspose::new
+//! to operate the iterator.
+
 use crate::iter::plumbing::*;
 use crate::iter::*;
 use crate::vec::{DrainProducer, SliceDrain};
@@ -13,7 +17,7 @@ pub struct HashMapVecTranspose<K, V, S> {
 }
 
 impl<K, V, S> HashMapVecTranspose<K, V, S> {
-	/// Create a new HashMapVecTranspose.
+    /// Create a new HashMapVecTranspose.  All Vecs must be the same length.
     pub fn new(map: HashMap<K, Vec<V>, S>, len: usize) -> Self {
         Self { map, len }
     }

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,0 +1,190 @@
+use crate::iter::plumbing::*;
+use crate::iter::*;
+use crate::vec::{DrainProducer, SliceDrain};
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+use std::iter;
+
+/// Parallel iterator that clones K and moves V and yields `HashMap<K, V>` out of a hashmap of vectors.
+#[derive(Debug, Clone)]
+pub struct HashMapVecTranspose<K, V, S> {
+    map: HashMap<K, Vec<V>, S>,
+    len: usize,
+}
+
+impl<K, V, S> HashMapVecTranspose<K, V, S> {
+	/// Create a new HashMapVecTranspose.
+    pub fn new(map: HashMap<K, Vec<V>, S>, len: usize) -> Self {
+        Self { map, len }
+    }
+}
+
+impl<K, V, S> ParallelIterator for HashMapVecTranspose<K, V, S>
+where
+    K: Send + Clone + Eq + Hash,
+    V: Send,
+    S: Send + BuildHasher + Default,
+{
+    type Item = HashMap<K, V, S>;
+
+    fn drive_unindexed<C: UnindexedConsumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.len)
+    }
+}
+
+impl<K, V, S> IndexedParallelIterator for HashMapVecTranspose<K, V, S>
+where
+    K: Send + Clone + Eq + Hash,
+    V: Send,
+    S: Send + BuildHasher + Default,
+{
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn with_producer<CB: ProducerCallback<Self::Item>>(mut self, callback: CB) -> CB::Output {
+        // Create the producer as the exclusive "owner" of the slice.
+        let producer = TransposeProducer::from_transpose(&mut self);
+
+        // The producer will move or drop each item from the drained range.
+        callback.callback(producer)
+    }
+}
+
+// ////////////////////////////////////////////////////////////////////////
+struct TransposeProducer<'data, K, V: Send, S> {
+    map: HashMap<K, DrainProducer<'data, V>, S>,
+    len: usize,
+}
+
+impl<'data, K, V, S> TransposeProducer<'data, K, V, S>
+where
+    K: Clone + Eq + Hash,
+    V: Send,
+    S: BuildHasher + Default,
+{
+    fn new(map: HashMap<K, DrainProducer<'data, V>, S>, len: usize) -> Self {
+        Self { map, len }
+    }
+
+    fn from_transpose(transpose: &'data mut HashMapVecTranspose<K, V, S>) -> Self {
+        let len = transpose.len;
+        let map = transpose
+            .map
+            .iter_mut()
+            .map(|(key, vec)| {
+                (key.clone(), unsafe {
+                    vec.set_len(0);
+                    DrainProducer::from_vec(vec, len)
+                })
+            })
+            .collect();
+        Self::new(map, len)
+    }
+}
+
+impl<'data, K, V, S> Producer for TransposeProducer<'data, K, V, S>
+where
+    K: 'data + Send + Clone + Eq + Hash,
+    V: 'data + Send,
+    S: 'data + Send + BuildHasher + Default,
+{
+    type Item = HashMap<K, V, S>;
+    type IntoIter = TransposeSliceDrain<'data, K, V, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len;
+        let map = self
+            .map
+            .into_iter()
+            .map(|(key, drain_producer)| (key, drain_producer.into_iter()))
+            .collect();
+        TransposeSliceDrain { map, len }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        // TODO: figure out if there is a way to reuse the allocation of self
+        let (left, right) = self
+            .map
+            .into_iter()
+            .map(|(key, drain_producer)| {
+                let (left, right) = drain_producer.split_at(index);
+                ((key.clone(), left), (key, right))
+            })
+            .collect();
+        (Self::new(left, index), Self::new(right, self.len - index))
+    }
+}
+
+// ////////////////////////////////////////////////////////////////////////
+
+// like std::vec::Drain, without updating a source Vec
+struct TransposeSliceDrain<'data, K, V, S> {
+    map: HashMap<K, SliceDrain<'data, V>, S>,
+    len: usize,
+}
+
+impl<'data, K, V, S> Iterator for TransposeSliceDrain<'data, K, V, S>
+where
+    K: Clone + Eq + Hash,
+    V: 'data,
+    S: BuildHasher + Default,
+{
+    type Item = HashMap<K, V, S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.map
+            .iter_mut()
+            .map(|(key, iter)| Some((key.clone(), iter.next()?)))
+            .collect()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+
+    fn count(self) -> usize {
+        self.len
+    }
+}
+
+impl<'data, K, V, S> DoubleEndedIterator for TransposeSliceDrain<'data, K, V, S>
+where
+    K: Clone + Eq + Hash,
+    V: 'data,
+    S: BuildHasher + Default,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.map
+            .iter_mut()
+            .map(|(key, iter)| Some((key.clone(), iter.next_back()?)))
+            .collect()
+    }
+}
+
+impl<'data, K, V, S> ExactSizeIterator for TransposeSliceDrain<'data, K, V, S>
+where
+    K: Clone + Eq + Hash,
+    V: 'data,
+    S: BuildHasher + Default,
+{
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<'data, K, V, S> iter::FusedIterator for TransposeSliceDrain<'data, K, V, S>
+where
+    K: Clone + Eq + Hash,
+    V: 'data,
+    S: BuildHasher + Default,
+{
+}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -61,7 +61,10 @@ where
         let producers = self
             .vec
             .into_iter()
-            .map(|iter| iter.into_par_iter().with_producer(callback))
+            .map(|iter| {
+                // I don't know how to get the Producer from the iter here.
+                iter.into_par_iter().with_producer(callback)
+            })
             .collect();
         let producer = TransposeProducer {
             producers,

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -5,32 +5,32 @@
 use crate::iter::plumbing::*;
 use crate::iter::*;
 use crate::vec::{DrainProducer, SliceDrain};
-use std::collections::HashMap;
-use std::hash::{BuildHasher, Hash};
 use std::iter;
-use std::marker::PhantomData;
 
-/// Parallel iterator that clones K and moves V and yields `HashMap<K, V>` out of a hashmap of vectors.
+/// Parallel transposing iterator
 #[derive(Debug, Clone)]
-pub struct HashMapVecTranspose<K, V, S> {
-    map: HashMap<K, Vec<V>, S>,
+pub struct Transpose<T> {
+    vec: Vec<Vec<T>>,
     len: usize,
 }
 
-impl<K, V, S> HashMapVecTranspose<K, V, S> {
-    /// Create a new HashMapVecTranspose.  All Vecs must be the same length.
-    pub fn new(map: HashMap<K, Vec<V>, S>, len: usize) -> Self {
-        Self { map, len }
-    }
+/// An iterator which yields the transposed items.
+#[derive(Debug, Clone)]
+pub struct TransposeIterator<T> {
+	/* ??? */
 }
 
-impl<K, V, S> ParallelIterator for HashMapVecTranspose<K, V, S>
+pub fn transpose<T, P, I>(iter: I, len: usize) -> Transpose<P>
 where
-    K: Send + Clone + Eq + Hash,
-    V: Send,
-    S: Send + BuildHasher + Default,
+    I: IntoIterator<Item = Vec<T>>,
+    P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
 {
-    type Item = HashMap<K, V, S>;
+    let vec = iter.into_iter().collect();
+    Transpose { vec, len }
+}
+
+impl<T: Send> ParallelIterator for Transpose<T> {
+    type Item = TransposeIterator<T>;
 
     fn drive_unindexed<C: UnindexedConsumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
@@ -41,12 +41,7 @@ where
     }
 }
 
-impl<K, V, S> IndexedParallelIterator for HashMapVecTranspose<K, V, S>
-where
-    K: Send + Clone + Eq + Hash,
-    V: Send,
-    S: Send + BuildHasher + Default,
-{
+impl<T: Send> IndexedParallelIterator for Transpose<T> {
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
     }
@@ -65,75 +60,49 @@ where
 }
 
 // ////////////////////////////////////////////////////////////////////////
-struct TransposeProducer<'data, K, V: Send, S> {
-    map: Vec<(K, DrainProducer<'data, V>)>,
+struct TransposeProducer<'data, T: Send> {
+    map: Vec<DrainProducer<'data, T>>,
     len: usize,
-    _randomstate: PhantomData<S>,
 }
 
-impl<'data, K, V, S> TransposeProducer<'data, K, V, S>
+impl<'data, T> TransposeProducer<'data, T>
 where
-    K: Clone + Eq + Hash,
-    V: Send,
+    T: Send,
 {
-    fn new(map: Vec<(K, DrainProducer<'data, V>)>, len: usize) -> Self {
-        Self {
-            map,
-            len,
-            _randomstate: PhantomData,
-        }
+    fn new(map: Vec<DrainProducer<'data, T>>, len: usize) -> Self {
+        Self { map, len }
     }
 
-    fn from_transpose<S2>(transpose: &'data mut HashMapVecTranspose<K, V, S2>) -> Self {
+    fn from_transpose(transpose: &'data mut Transpose<T>) -> Self {
         let len = transpose.len;
         let map = transpose
-            .map
+            .vec
             .iter_mut()
-            .map(|(key, vec)| {
+            .map(|vec| {
                 assert_eq!(vec.len(), len);
-                (key.clone(), unsafe {
+                unsafe {
                     vec.set_len(0);
                     DrainProducer::from_vec(vec, len)
-                })
+                }
             })
             .collect();
         Self::new(map, len)
     }
 }
 
-impl<'data, K, V, S> Producer for TransposeProducer<'data, K, V, S>
-where
-    K: 'data + Send + Clone + Eq + Hash,
-    V: 'data + Send,
-    S: 'data + Send + BuildHasher + Default,
-{
-    type Item = HashMap<K, V, S>;
-    type IntoIter = TransposeSliceDrain<'data, K, V, S>;
+impl<'data, T: 'data + Send> Producer for TransposeProducer<'data, T> {
+    type Item = TransposeIterator<T>;
+    type IntoIter = TransposeSliceDrain<'data, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         let len = self.len;
-        let map = self
-            .map
-            .into_iter()
-            .map(|(key, drain_producer)| (key, drain_producer.into_iter()))
-            .collect();
-        TransposeSliceDrain {
-            map,
-            len,
-            _randomstate: PhantomData,
-        }
+        let map = self.map.into_iter().map(IntoIterator::into_iter).collect();
+        TransposeSliceDrain { map, len }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
         // TODO: figure out if there is a way to reuse the allocation of self
-        let (left, right) = self
-            .map
-            .into_iter()
-            .map(|(key, drain_producer)| {
-                let (left, right) = drain_producer.split_at(index);
-                ((key.clone(), left), (key, right))
-            })
-            .collect();
+        let (left, right) = self.map.into_iter().map(Producer::split_at).collect();
         (Self::new(left, index), Self::new(right, self.len - index))
     }
 }
@@ -141,25 +110,16 @@ where
 // ////////////////////////////////////////////////////////////////////////
 
 // like std::vec::Drain, without updating a source Vec
-struct TransposeSliceDrain<'data, K, V, S> {
-    map: Vec<(K, SliceDrain<'data, V>)>,
+struct TransposeSliceDrain<'data, T> {
+    map: Vec<SliceDrain<'data, T>>,
     len: usize,
-    _randomstate: PhantomData<S>,
 }
 
-impl<'data, K, V, S> Iterator for TransposeSliceDrain<'data, K, V, S>
-where
-    K: Clone + Eq + Hash,
-    V: 'data,
-    S: BuildHasher + Default,
-{
-    type Item = HashMap<K, V, S>;
+impl<'data, T: 'data> Iterator for TransposeSliceDrain<'data, T> {
+    type Item = TransposeIterator<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.map
-            .iter_mut()
-            .map(|(key, iter)| Some((key.clone(), iter.next()?)))
-            .collect()
+        self.map.iter_mut().map(Iterator::next)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -171,35 +131,16 @@ where
     }
 }
 
-impl<'data, K, V, S> DoubleEndedIterator for TransposeSliceDrain<'data, K, V, S>
-where
-    K: Clone + Eq + Hash,
-    V: 'data,
-    S: BuildHasher + Default,
-{
+impl<'data, T: 'data> DoubleEndedIterator for TransposeSliceDrain<'data, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.map
-            .iter_mut()
-            .map(|(key, iter)| Some((key.clone(), iter.next_back()?)))
-            .collect()
+        self.map.iter_mut().map(Iterator::next_back)
     }
 }
 
-impl<'data, K, V, S> ExactSizeIterator for TransposeSliceDrain<'data, K, V, S>
-where
-    K: Clone + Eq + Hash,
-    V: 'data,
-    S: BuildHasher + Default,
-{
+impl<'data, T: 'data> ExactSizeIterator for TransposeSliceDrain<'data, T> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'data, K, V, S> iter::FusedIterator for TransposeSliceDrain<'data, K, V, S>
-where
-    K: Clone + Eq + Hash,
-    V: 'data,
-    S: BuildHasher + Default,
-{
-}
+impl<'data, T: 'data> iter::FusedIterator for TransposeSliceDrain<'data, T> {}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -26,8 +26,8 @@ impl<K, V, S> HashMapVecTranspose<K, V, S> {
 impl<K, V, S> ParallelIterator for HashMapVecTranspose<K, V, S>
 where
     K: Send + Clone + Eq + Hash,
-    V: Send + Clone,
-    S: Send + Clone + BuildHasher + Default,
+    V: Send,
+    S: Send + BuildHasher + Default,
 {
     type Item = HashMap<K, V, S>;
 
@@ -43,8 +43,8 @@ where
 impl<K, V, S> IndexedParallelIterator for HashMapVecTranspose<K, V, S>
 where
     K: Send + Clone + Eq + Hash,
-    V: Send + Clone,
-    S: Send + Clone + BuildHasher + Default,
+    V: Send,
+    S: Send + BuildHasher + Default,
 {
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
@@ -55,12 +55,8 @@ where
     }
 
     fn with_producer<CB: ProducerCallback<Self::Item>>(mut self, callback: CB) -> CB::Output {
-        // Allocate the HashMaps single-threaded to avoid allocator lock contention
-        let mut hash_maps =
-            vec![HashMap::with_capacity_and_hasher(self.map.len(), S::default()); self.len];
-
         // Create the producer as the exclusive "owner" of the slice.
-        let producer = TransposeProducer::from_transpose(&mut self, &mut hash_maps);
+        let producer = TransposeProducer::from_transpose(&mut self);
 
         // The producer will move or drop each item from the drained range.
         callback.callback(producer)
@@ -68,28 +64,22 @@ where
 }
 
 // ////////////////////////////////////////////////////////////////////////
-struct TransposeProducer<'data, K: Send, V: Send, S: Send> {
+struct TransposeProducer<'data, K, V: Send, S> {
     map: HashMap<K, DrainProducer<'data, V>, S>,
-    hash_maps: DrainProducer<'data, HashMap<K, V, S>>,
+    len: usize,
 }
 
 impl<'data, K, V, S> TransposeProducer<'data, K, V, S>
 where
-    K: Send + Clone + Eq + Hash,
+    K: Clone + Eq + Hash,
     V: Send,
-    S: Send + BuildHasher + Default,
+    S: BuildHasher + Default,
 {
-    fn new(
-        map: HashMap<K, DrainProducer<'data, V>, S>,
-        hash_maps: DrainProducer<'data, HashMap<K, V, S>>,
-    ) -> Self {
-        Self { map, hash_maps }
+    fn new(map: HashMap<K, DrainProducer<'data, V>, S>, len: usize) -> Self {
+        Self { map, len }
     }
 
-    fn from_transpose(
-        transpose: &'data mut HashMapVecTranspose<K, V, S>,
-        hash_maps: &'data mut Vec<HashMap<K, V, S>>,
-    ) -> Self {
+    fn from_transpose(transpose: &'data mut HashMapVecTranspose<K, V, S>) -> Self {
         let len = transpose.len;
         let map = transpose
             .map
@@ -102,11 +92,7 @@ where
                 })
             })
             .collect();
-        let hash_maps = unsafe {
-            hash_maps.set_len(0);
-            DrainProducer::from_vec(hash_maps, len)
-        };
-        Self::new(map, hash_maps)
+        Self::new(map, len)
     }
 }
 
@@ -120,18 +106,18 @@ where
     type IntoIter = TransposeSliceDrain<'data, K, V, S>;
 
     fn into_iter(self) -> Self::IntoIter {
+        let len = self.len;
         let map = self
             .map
             .into_iter()
             .map(|(key, drain_producer)| (key, drain_producer.into_iter()))
             .collect();
-        let hash_maps = self.hash_maps.into_iter();
-        TransposeSliceDrain { map, hash_maps }
+        TransposeSliceDrain { map, len }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
         // TODO: figure out if there is a way to reuse the allocation of self
-        let (m_left, m_right) = self
+        let (left, right) = self
             .map
             .into_iter()
             .map(|(key, drain_producer)| {
@@ -139,8 +125,7 @@ where
                 ((key.clone(), left), (key, right))
             })
             .collect();
-        let (h_left, h_right) = self.hash_maps.split_at(index);
-        (Self::new(m_left, h_left), Self::new(m_right, h_right))
+        (Self::new(left, index), Self::new(right, self.len - index))
     }
 }
 
@@ -149,7 +134,7 @@ where
 // like std::vec::Drain, without updating a source Vec
 struct TransposeSliceDrain<'data, K, V, S> {
     map: HashMap<K, SliceDrain<'data, V>, S>,
-    hash_maps: SliceDrain<'data, HashMap<K, V, S>>,
+    len: usize,
 }
 
 impl<'data, K, V, S> Iterator for TransposeSliceDrain<'data, K, V, S>
@@ -161,19 +146,18 @@ where
     type Item = HashMap<K, V, S>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut hash_map = self.hash_maps.next()?;
-        for (key, iter) in &mut self.map {
-            hash_map.insert(key.clone(), iter.next()?);
-        }
-        Some(hash_map)
+        self.map
+            .iter_mut()
+            .map(|(key, iter)| Some((key.clone(), iter.next()?)))
+            .collect()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
+        (self.len, Some(self.len))
     }
 
     fn count(self) -> usize {
-        self.len()
+        self.len
     }
 }
 
@@ -184,11 +168,10 @@ where
     S: BuildHasher + Default,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let mut hash_map = self.hash_maps.next_back()?;
-        for (key, iter) in &mut self.map {
-            hash_map.insert(key.clone(), iter.next_back()?);
-        }
-        Some(hash_map)
+        self.map
+            .iter_mut()
+            .map(|(key, iter)| Some((key.clone(), iter.next_back()?)))
+            .collect()
     }
 }
 
@@ -199,7 +182,7 @@ where
     S: BuildHasher + Default,
 {
     fn len(&self) -> usize {
-        self.hash_maps.len()
+        self.len
     }
 }
 

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -95,6 +95,7 @@ where
             .map
             .iter_mut()
             .map(|(key, vec)| {
+                assert_eq!(vec.len(), len);
                 (key.clone(), unsafe {
                     vec.set_len(0);
                     DrainProducer::from_vec(vec, len)

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -84,7 +84,7 @@ where
         }
     }
 
-    fn from_transpose(transpose: &'data mut HashMapVecTranspose<K, V, S>) -> Self {
+    fn from_transpose<S2>(transpose: &'data mut HashMapVecTranspose<K, V, S2>) -> Self {
         let len = transpose.len;
         let map = transpose
             .map

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -22,8 +22,8 @@ impl<K, V, S> HashMapVecTranspose<K, V, S> {
 impl<K, V, S> ParallelIterator for HashMapVecTranspose<K, V, S>
 where
     K: Send + Clone + Eq + Hash,
-    V: Send,
-    S: Send + BuildHasher + Default,
+    V: Send + Clone,
+    S: Send + Clone + BuildHasher + Default,
 {
     type Item = HashMap<K, V, S>;
 
@@ -39,8 +39,8 @@ where
 impl<K, V, S> IndexedParallelIterator for HashMapVecTranspose<K, V, S>
 where
     K: Send + Clone + Eq + Hash,
-    V: Send,
-    S: Send + BuildHasher + Default,
+    V: Send + Clone,
+    S: Send + Clone + BuildHasher + Default,
 {
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
@@ -51,8 +51,12 @@ where
     }
 
     fn with_producer<CB: ProducerCallback<Self::Item>>(mut self, callback: CB) -> CB::Output {
+        // Allocate the HashMaps single-threaded to avoid allocator lock contention
+        let mut hash_maps =
+            vec![HashMap::with_capacity_and_hasher(self.map.len(), S::default()); self.len];
+
         // Create the producer as the exclusive "owner" of the slice.
-        let producer = TransposeProducer::from_transpose(&mut self);
+        let producer = TransposeProducer::from_transpose(&mut self, &mut hash_maps);
 
         // The producer will move or drop each item from the drained range.
         callback.callback(producer)
@@ -60,22 +64,28 @@ where
 }
 
 // ////////////////////////////////////////////////////////////////////////
-struct TransposeProducer<'data, K, V: Send, S> {
+struct TransposeProducer<'data, K: Send, V: Send, S: Send> {
     map: HashMap<K, DrainProducer<'data, V>, S>,
-    len: usize,
+    hash_maps: DrainProducer<'data, HashMap<K, V, S>>,
 }
 
 impl<'data, K, V, S> TransposeProducer<'data, K, V, S>
 where
-    K: Clone + Eq + Hash,
+    K: Send + Clone + Eq + Hash,
     V: Send,
-    S: BuildHasher + Default,
+    S: Send + BuildHasher + Default,
 {
-    fn new(map: HashMap<K, DrainProducer<'data, V>, S>, len: usize) -> Self {
-        Self { map, len }
+    fn new(
+        map: HashMap<K, DrainProducer<'data, V>, S>,
+        hash_maps: DrainProducer<'data, HashMap<K, V, S>>,
+    ) -> Self {
+        Self { map, hash_maps }
     }
 
-    fn from_transpose(transpose: &'data mut HashMapVecTranspose<K, V, S>) -> Self {
+    fn from_transpose(
+        transpose: &'data mut HashMapVecTranspose<K, V, S>,
+        hash_maps: &'data mut Vec<HashMap<K, V, S>>,
+    ) -> Self {
         let len = transpose.len;
         let map = transpose
             .map
@@ -87,7 +97,11 @@ where
                 })
             })
             .collect();
-        Self::new(map, len)
+        let hash_maps = unsafe {
+            hash_maps.set_len(0);
+            DrainProducer::from_vec(hash_maps, len)
+        };
+        Self::new(map, hash_maps)
     }
 }
 
@@ -101,18 +115,18 @@ where
     type IntoIter = TransposeSliceDrain<'data, K, V, S>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let len = self.len;
         let map = self
             .map
             .into_iter()
             .map(|(key, drain_producer)| (key, drain_producer.into_iter()))
             .collect();
-        TransposeSliceDrain { map, len }
+        let hash_maps = self.hash_maps.into_iter();
+        TransposeSliceDrain { map, hash_maps }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
         // TODO: figure out if there is a way to reuse the allocation of self
-        let (left, right) = self
+        let (m_left, m_right) = self
             .map
             .into_iter()
             .map(|(key, drain_producer)| {
@@ -120,7 +134,8 @@ where
                 ((key.clone(), left), (key, right))
             })
             .collect();
-        (Self::new(left, index), Self::new(right, self.len - index))
+        let (h_left, h_right) = self.hash_maps.split_at(index);
+        (Self::new(m_left, h_left), Self::new(m_right, h_right))
     }
 }
 
@@ -129,7 +144,7 @@ where
 // like std::vec::Drain, without updating a source Vec
 struct TransposeSliceDrain<'data, K, V, S> {
     map: HashMap<K, SliceDrain<'data, V>, S>,
-    len: usize,
+    hash_maps: SliceDrain<'data, HashMap<K, V, S>>,
 }
 
 impl<'data, K, V, S> Iterator for TransposeSliceDrain<'data, K, V, S>
@@ -141,18 +156,19 @@ where
     type Item = HashMap<K, V, S>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.map
-            .iter_mut()
-            .map(|(key, iter)| Some((key.clone(), iter.next()?)))
-            .collect()
+        let mut hash_map = self.hash_maps.next()?;
+        for (key, iter) in &mut self.map {
+            hash_map.insert(key.clone(), iter.next()?);
+        }
+        Some(hash_map)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
+        (self.len(), Some(self.len()))
     }
 
     fn count(self) -> usize {
-        self.len
+        self.len()
     }
 }
 
@@ -163,10 +179,11 @@ where
     S: BuildHasher + Default,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.map
-            .iter_mut()
-            .map(|(key, iter)| Some((key.clone(), iter.next_back()?)))
-            .collect()
+        let mut hash_map = self.hash_maps.next_back()?;
+        for (key, iter) in &mut self.map {
+            hash_map.insert(key.clone(), iter.next_back()?);
+        }
+        Some(hash_map)
     }
 }
 
@@ -177,7 +194,7 @@ where
     S: BuildHasher + Default,
 {
     fn len(&self) -> usize {
-        self.len
+        self.hash_maps.len()
     }
 }
 

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -8,6 +8,7 @@ use crate::vec::{DrainProducer, SliceDrain};
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 use std::iter;
+use std::marker::PhantomData;
 
 /// Parallel iterator that clones K and moves V and yields `HashMap<K, V>` out of a hashmap of vectors.
 #[derive(Debug, Clone)]
@@ -65,18 +66,22 @@ where
 
 // ////////////////////////////////////////////////////////////////////////
 struct TransposeProducer<'data, K, V: Send, S> {
-    map: HashMap<K, DrainProducer<'data, V>, S>,
+    map: Vec<(K, DrainProducer<'data, V>)>,
     len: usize,
+    _randomstate: PhantomData<S>,
 }
 
 impl<'data, K, V, S> TransposeProducer<'data, K, V, S>
 where
     K: Clone + Eq + Hash,
     V: Send,
-    S: BuildHasher + Default,
 {
-    fn new(map: HashMap<K, DrainProducer<'data, V>, S>, len: usize) -> Self {
-        Self { map, len }
+    fn new(map: Vec<(K, DrainProducer<'data, V>)>, len: usize) -> Self {
+        Self {
+            map,
+            len,
+            _randomstate: PhantomData,
+        }
     }
 
     fn from_transpose(transpose: &'data mut HashMapVecTranspose<K, V, S>) -> Self {
@@ -112,7 +117,11 @@ where
             .into_iter()
             .map(|(key, drain_producer)| (key, drain_producer.into_iter()))
             .collect();
-        TransposeSliceDrain { map, len }
+        TransposeSliceDrain {
+            map,
+            len,
+            _randomstate: PhantomData,
+        }
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
@@ -133,8 +142,9 @@ where
 
 // like std::vec::Drain, without updating a source Vec
 struct TransposeSliceDrain<'data, K, V, S> {
-    map: HashMap<K, SliceDrain<'data, V>, S>,
+    map: Vec<(K, SliceDrain<'data, V>)>,
     len: usize,
+    _randomstate: PhantomData<S>,
 }
 
 impl<'data, K, V, S> Iterator for TransposeSliceDrain<'data, K, V, S>

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -9,27 +9,29 @@ use std::iter;
 
 /// Parallel transposing iterator
 #[derive(Debug, Clone)]
-pub struct Transpose<T> {
-    vec: Vec<Vec<T>>,
+pub struct Transpose<P> {
+    vec: Vec<P>,
     len: usize,
 }
 
 /// An iterator which yields the transposed items.
 #[derive(Debug, Clone)]
-pub struct TransposeIterator<T> {
-	/* ??? */
-}
+pub struct TransposeIterator<T> {/* ??? */}
 
 pub fn transpose<T, P, I>(iter: I, len: usize) -> Transpose<P>
 where
-    I: IntoIterator<Item = Vec<T>>,
+    I: IntoIterator<Item = P>,
     P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
 {
     let vec = iter.into_iter().collect();
     Transpose { vec, len }
 }
 
-impl<T: Send> ParallelIterator for Transpose<T> {
+impl<T, P> ParallelIterator for Transpose<P>
+where
+    P: Send,
+    P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
+{
     type Item = TransposeIterator<T>;
 
     fn drive_unindexed<C: UnindexedConsumer<Self::Item>>(self, consumer: C) -> C::Result {
@@ -41,7 +43,11 @@ impl<T: Send> ParallelIterator for Transpose<T> {
     }
 }
 
-impl<T: Send> IndexedParallelIterator for Transpose<T> {
+impl<T, P> IndexedParallelIterator for Transpose<P>
+where
+    P: Send,
+    P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
+{
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
     }
@@ -65,15 +71,16 @@ struct TransposeProducer<'data, T: Send> {
     len: usize,
 }
 
-impl<'data, T> TransposeProducer<'data, T>
-where
-    T: Send,
-{
+impl<'data, T: Send> TransposeProducer<'data, T> {
     fn new(map: Vec<DrainProducer<'data, T>>, len: usize) -> Self {
         Self { map, len }
     }
 
-    fn from_transpose(transpose: &'data mut Transpose<T>) -> Self {
+    fn from_transpose<P>(transpose: &'data mut Transpose<P>) -> Self
+    where
+        P: Send,
+        P: IntoParallelIterator<Iter: IndexedParallelIterator<Item = T>>,
+    {
         let len = transpose.len;
         let map = transpose
             .vec

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -201,7 +201,7 @@ impl<T: Send> DrainProducer<'_, T> {
     ///
     /// Unsafe because we're moving from beyond `vec.len()`, so the caller must ensure
     /// that data is initialized and not read after the borrow is released.
-    unsafe fn from_vec(vec: &mut Vec<T>, len: usize) -> DrainProducer<'_, T> {
+    pub(crate) unsafe fn from_vec(vec: &mut Vec<T>, len: usize) -> DrainProducer<'_, T> {
         let start = vec.len();
         assert!(vec.capacity() - start >= len);
 


### PR DESCRIPTION
Closes #1304.

I wrote some code to implement the operation, but it kind of sucks.  I'd appreciate feedback on how to make an upstreamable version of this idea.

As a side note, I'm looking at how every callsite for DrainProducer::from_vec calls set_len and I'm thinking that should be part of the function.