### PR TITLE
Fix unused plumbing imports

### DIFF
--- a/src/iter/blocks.rs
+++ b/src/iter/blocks.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 struct BlocksCallback<S, C> {

--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use rayon_core::join;
 use std::iter;

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `Chunks` is an iterator that groups elements of an underlying iterator.

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::iter;

--- a/src/iter/copied.rs
+++ b/src/iter/copied.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::iter;

--- a/src/iter/empty.rs
+++ b/src/iter/empty.rs
@@ -1,4 +1,3 @@
-use crate::iter::plumbing::*;
 use crate::iter::*;
 
 use std::fmt;

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::iter;
 use std::ops::Range;

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/find.rs
+++ b/src/iter/find.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/iter/find_first_last/mod.rs
+++ b/src/iter/find_first_last/mod.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/flat_map_iter.rs
+++ b/src/iter/flat_map_iter.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/flatten.rs
+++ b/src/iter/flatten.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `Flatten` turns each element to a parallel iterator, then flattens these iterators

--- a/src/iter/flatten_iter.rs
+++ b/src/iter/flatten_iter.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `FlattenIter` turns each element to a serial iterator, then flattens these iterators

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/fold_chunks.rs
+++ b/src/iter/fold_chunks.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Debug};
 
 use super::chunks::ChunkProducer;
-use super::plumbing::*;
 use super::*;
 
 /// `FoldChunks` is an iterator that groups elements of an underlying iterator and applies a

--- a/src/iter/fold_chunks_with.rs
+++ b/src/iter/fold_chunks_with.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Debug};
 
 use super::chunks::ChunkProducer;
-use super::plumbing::*;
 use super::*;
 
 /// `FoldChunksWith` is an iterator that groups elements of an underlying iterator and applies a

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::iter::Fuse;
 

--- a/src/iter/interleave_shortest.rs
+++ b/src/iter/interleave_shortest.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `InterleaveShortest` is an iterator that works similarly to

--- a/src/iter/intersperse.rs
+++ b/src/iter/intersperse.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::cell::Cell;
 use std::iter::{self, Fuse};

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `MinLen` is an iterator that imposes a minimum length on iterator splits.

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/multizip.rs
+++ b/src/iter/multizip.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `MultiZip` is an iterator that zips up a tuple of parallel iterators to

--- a/src/iter/once.rs
+++ b/src/iter/once.rs
@@ -1,4 +1,3 @@
-use crate::iter::plumbing::*;
 use crate::iter::*;
 
 /// Creates a parallel iterator that produces an element exactly once.

--- a/src/iter/panic_fuse.rs
+++ b/src/iter/panic_fuse.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;

--- a/src/iter/positions.rs
+++ b/src/iter/positions.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/repeat.rs
+++ b/src/iter/repeat.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::num::NonZeroUsize;
 use std::{fmt, iter};

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::iter;
 

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -1,5 +1,4 @@
 use super::noop::NoopConsumer;
-use super::plumbing::*;
 use super::*;
 
 /// `Skip` is an iterator that skips over the first `n` elements.

--- a/src/iter/skip_any.rs
+++ b/src/iter/skip_any.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/iter/skip_any_while.rs
+++ b/src/iter/skip_any_while.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/step_by.rs
+++ b/src/iter/step_by.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::iter;
 

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// `Take` is an iterator that iterates over the first `n` elements.

--- a/src/iter/take_any.rs
+++ b/src/iter/take_any.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/iter/take_any_while.rs
+++ b/src/iter/take_any_while.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/iter/unzip.rs
+++ b/src/iter/unzip.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// This trait abstracts the different ways we can "unzip" one parallel

--- a/src/iter/update.rs
+++ b/src/iter/update.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 use std::fmt::{self, Debug};

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 use std::iter;
 

--- a/src/iter/zip_eq.rs
+++ b/src/iter/zip_eq.rs
@@ -1,4 +1,3 @@
-use super::plumbing::*;
 use super::*;
 
 /// An [`IndexedParallelIterator`] that iterates over two parallel iterators of equal


### PR DESCRIPTION
These `use super::plumbing::*` are redundant with `use super::*` where the plumbing items are also already imported. Only 1.98-nightly is warning about this, but it works without all the way back to the MSRV.