### PR TITLE
Delegate parallel unstable sort leaves to the standard library

### DIFF
--- a/src/slice/mod.rs
+++ b/src/slice/mod.rs
@@ -642,8 +642,8 @@ pub trait ParallelSliceMut<T: Send> {
     /// (i.e., does not allocate), and *O*(*n* \* log(*n*)) worst-case.
     ///
     /// The comparator function must define a total ordering for the elements in the slice. If
-    /// the ordering is not total, the order of the elements is unspecified. An order is a
-    /// total order if it is (for all `a`, `b` and `c`):
+    /// the ordering is not total, the sort may panic; if it returns, the order of the elements is
+    /// unspecified. An order is a total order if it is (for all `a`, `b` and `c`):
     ///
     /// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
     /// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.

--- a/src/slice/sort.rs
+++ b/src/slice/sort.rs
@@ -259,50 +259,28 @@ where
     false
 }
 
-/// Sorts `v` using heapsort, which guarantees *O*(*n* \* log(*n*)) worst-case.
-#[cold]
-fn heapsort<T, F>(v: &mut [T], is_less: F)
+/// Sequentially sorts `v`, used for the leaves of the parallel recursion.
+///
+/// This delegates to the standard library's [`sort_unstable_by`](slice::sort_unstable_by) (an
+/// `ipnsort` implementation) rather than reimplementing a base-case sort. The `is_less` predicate
+/// is turned into a total [`Ordering`](cmp::Ordering) exactly once here, so the conversion is not
+/// duplicated across call sites.
+///
+/// Note that `sort_unstable_by` panics if `is_less` does not implement a total order, whereas the
+/// old hand-written fallback would merely produce an unspecified permutation.
+fn sort_leaf<T, F>(v: &mut [T], is_less: &F)
 where
     F: Fn(&T, &T) -> bool,
 {
-    // This binary heap respects the invariant `parent >= child`.
-    let sift_down = |v: &mut [T], mut node| {
-        loop {
-            // Children of `node`.
-            let mut child = 2 * node + 1;
-            if child >= v.len() {
-                break;
-            }
-
-            // Choose the greater child.
-            if child + 1 < v.len() {
-                // We need a branch to be sure not to out-of-bounds index,
-                // but it's highly predictable.  The comparison, however,
-                // is better done branchless, especially for primitives.
-                child += is_less(&v[child], &v[child + 1]) as usize;
-            }
-
-            // Stop if the invariant holds at `node`.
-            if !is_less(&v[node], &v[child]) {
-                break;
-            }
-
-            // Swap `node` with the greater child, move one step down, and continue sifting.
-            v.swap(node, child);
-            node = child;
+    v.sort_unstable_by(|a, b| {
+        if is_less(a, b) {
+            cmp::Ordering::Less
+        } else if is_less(b, a) {
+            cmp::Ordering::Greater
+        } else {
+            cmp::Ordering::Equal
         }
-    };
-
-    // Build the heap in linear time.
-    for i in (0..v.len() / 2).rev() {
-        sift_down(v, i);
-    }
-
-    // Pop maximal elements from the heap.
-    for i in (1..v.len()).rev() {
-        v.swap(0, i);
-        sift_down(&mut v[..i], 0);
-    }
+    });
 }
 
 /// Partitions `v` into elements smaller than `pivot`, followed by elements greater than or equal
@@ -824,14 +802,14 @@ where
 ///
 /// If the slice had a predecessor in the original array, it is specified as `pred`.
 ///
-/// `limit` is the number of allowed imbalanced partitions before switching to `heapsort`. If zero,
-/// this function will immediately switch to heapsort.
+/// `limit` is the number of allowed imbalanced partitions before falling back to a sequential
+/// sort. If zero, this function will immediately fall back.
 fn recurse<'a, T, F>(mut v: &'a mut [T], is_less: &F, mut pred: Option<&'a mut T>, mut limit: u32)
 where
     T: Send,
     F: Fn(&T, &T) -> bool + Sync,
 {
-    // Slices of up to this length get sorted using insertion sort.
+    // Slices of up to this length get sorted sequentially by the standard library.
     const MAX_INSERTION: usize = 20;
 
     // If both partitions are up to this length, we continue sequentially. This number is as small
@@ -846,18 +824,17 @@ where
     loop {
         let len = v.len();
 
-        // Very short slices get sorted using insertion sort.
+        // Very short slices get sorted sequentially by the standard library.
         if len <= MAX_INSERTION {
-            if len >= 2 {
-                insertion_sort_shift_left(v, 1, is_less);
-            }
+            sort_leaf(v, is_less);
             return;
         }
 
-        // If too many bad pivot choices were made, simply fall back to heapsort in order to
-        // guarantee `O(n * log(n))` worst-case.
+        // If too many bad pivot choices were made, fall back to a sequential sort. The standard
+        // library's `sort_unstable_by` guarantees `O(n * log(n))` worst-case, so it preserves the
+        // overall worst-case bound just as the old heapsort fallback did.
         if limit == 0 {
-            heapsort(v, is_less);
+            sort_leaf(v, is_less);
             return;
         }
 
@@ -1613,44 +1590,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::heapsort;
     use super::split_for_merge;
     use rand::distr::Uniform;
     use rand::{RngExt, rng};
-
-    #[test]
-    fn test_heapsort() {
-        let rng = &mut rng();
-
-        for len in (0..25).chain(500..501) {
-            for &modulus in &[5, 10, 100] {
-                let dist = Uniform::new(0, modulus).unwrap();
-                for _ in 0..100 {
-                    let v: Vec<i32> = rng.sample_iter(&dist).take(len).collect();
-
-                    // Test heapsort using `<` operator.
-                    let mut tmp = v.clone();
-                    heapsort(&mut tmp, |a, b| a < b);
-                    assert!(tmp.is_sorted());
-
-                    // Test heapsort using `>` operator.
-                    let mut tmp = v.clone();
-                    heapsort(&mut tmp, |a, b| a > b);
-                    assert!(tmp.is_sorted_by(|a, b| a >= b));
-                }
-            }
-        }
-
-        // Sort using a completely random comparison function.
-        // This will reorder the elements *somehow*, but won't panic.
-        let mut v: Vec<_> = (0..100).collect();
-        heapsort(&mut v, |_, _| rand::rng().random());
-        heapsort(&mut v, |a, b| a < b);
-
-        for (i, &entry) in v.iter().enumerate() {
-            assert_eq!(entry, i);
-        }
-    }
 
     #[test]
     fn test_split_for_merge() {

--- a/src/slice/test.rs
+++ b/src/slice/test.rs
@@ -68,10 +68,15 @@ macro_rules! sort {
                 }
             }
 
-            // Sort using a completely random comparison function.
-            // This will reorder the elements *somehow*, but won't panic.
+            // Sort using a completely random comparison function. This reorders the elements
+            // *somehow* and may panic -- the unstable sort delegates its leaves to the standard
+            // library, which panics when the comparator does not implement a total order -- but it
+            // must never lose elements or cause undefined behavior. After re-sorting with a valid
+            // comparator we must recover the original `0..100` permutation.
             let mut v: Vec<_> = (0..100).collect();
-            v.$f(|_, _| *[Less, Equal, Greater].choose(&mut rand::rng()).unwrap());
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                v.$f(|_, _| *[Less, Equal, Greater].choose(&mut rand::rng()).unwrap());
+            }));
             v.$f(|a, b| a.cmp(b));
             for i in 0..v.len() {
                 assert_eq!(v[i], i);


### PR DESCRIPTION
Closes #1233.

## What this does

rayon's parallel unstable sort (`par_sort_unstable` and friends) is a copy of the old
`core::slice::sort` quicksort, including a hand-written `heapsort` used as the worst-case
fallback. The standard library has since moved its own unstable sort to `ipnsort`, so this
copied code is now behind.

This change makes rayon hand off the small, sequential parts of the sort to the standard
library's `slice::sort_unstable_by` (which is `ipnsort`), while rayon keeps doing all the
parallel work itself. Two spots change:

- the base case for short slices
- the fallback that runs when too many bad pivots have been picked (this used `heapsort` before)

Everything that makes the sort parallel and pattern-defeating stays the same: pivot choice,
block partitioning, the `was_balanced` / `was_partitioned` tracking, the cutoff for going
sequential, and the `join`. A small new `sort_leaf` helper does the `bool` to `Ordering`
conversion in one place so it isn't repeated.

`heapsort` and its test are removed because nothing uses them anymore.

## Why do it this way

There was an earlier attempt in #1283. It also removed the sequential branch and always called
`join`, which meant `was_balanced` and `was_partitioned` were always `true` and no longer did
anything. That quietly turned off the pattern-defeating behavior, which is what @cuviper pointed
out in the review.

Here only the leaves change, so those flags and the rest of the algorithm still do their job and
the `O(n log n)` worst case is kept (`ipnsort` is also `O(n log n)` worst case, same as the old
`heapsort`). Because `par_quicksort` keeps taking a `Fn(&T, &T) -> bool`, nothing in
`src/slice/mod.rs` or the public API needs to change.

## One behavior change to be aware of

The modern `sort_unstable_by` panics if the comparison function isn't a valid total order. The
old fallback just produced some arbitrary order instead. I checked this: a random
`Less/Equal/Greater` comparator panics on a 100 element slice but not on a slice of 20 or fewer,
since the small-sort code tolerates it.

The shared sort test used to say the random comparator "won't panic". It now wraps that call in
`catch_unwind` and still checks that no elements were lost (sorting again with a real comparator
has to give back `0..100`). That is the property that actually matters for safety.

## Benchmarks

I ran `cargo +nightly bench -p rayon-demo par_sort_unstable`. My machine is WSL2 and pretty
noisy, so single runs jump around a lot. Taking the best of 5 runs of
`par_sort_unstable_random` (50k `u64`) as the cleanest estimate:

| | min ns/iter |
|---|---|
| main | ~1,635,000 |
| this branch | ~1,461,000 |

The branch was consistently a bit faster and much steadier (1.46 to 1.51M, versus 1.63 to 3.78M
on main). I would read this as "no regression, maybe a small win" rather than a firm number, and
a run on quieter hardware would be welcome. The main point of the change is really maintenance:
dropping a copy of superseded std code and getting future `ipnsort` improvements for free.

## Left for later

The stable sort (`par_mergesort`) is not touched. Switching its per-chunk sort to `driftsort`
needs some thought about per-call allocation versus rayon's single shared buffer, so that is
better as a separate PR.

## Testing

- `cargo test -p rayon` passes, including `test_par_sort_unstable`, `test_par_sort`, and
  `test_par_sort_stability`.
- `cargo clippy --all-targets` is clean.
- `cargo test --doc` passes.
