### PR TITLE
Clarify `in_place_scope` docs on thread-pool selection

### DIFF
--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -384,13 +384,13 @@ where
 /// This is just like `scope()` except the closure runs on the same thread
 /// that calls `in_place_scope()`.
 ///
-/// Only tasks spawned into the scope -- with [`Scope::spawn()`] or
-/// [`Scope::spawn_broadcast()`] -- run in the scope's thread pool. Other Rayon
-/// operations called inside the closure, such as [`join()`](crate::join),
-/// [`spawn()`](crate::spawn), or parallel iterators, do not inherit that pool;
-/// any work they hand off to Rayon runs in the current thread pool -- the
-/// calling worker's pool, or the global pool when `in_place_scope()` is not
-/// called from within a worker thread.
+/// Only tasks spawned through the scope handle -- with [`Scope::spawn()`] or
+/// [`Scope::spawn_broadcast()`] -- are directed to the scope's thread pool.
+/// Rayon operations that use the ambient pool, such as [`join()`](crate::join),
+/// [`spawn()`](crate::spawn), or parallel iterators, do not inherit that pool.
+/// They use the calling worker's pool, or the global pool when
+/// `in_place_scope()` is called outside a Rayon worker. Calls on an explicit
+/// `ThreadPool` select that pool instead.
 ///
 /// # Panics
 ///
@@ -442,13 +442,13 @@ fn get_in_place_thread_registry(
 /// This is just like `scope_fifo()` except the closure runs on the same thread
 /// that calls `in_place_scope_fifo()`.
 ///
-/// Only tasks spawned into the scope -- with [`ScopeFifo::spawn_fifo()`] or
-/// [`ScopeFifo::spawn_broadcast()`] -- run in the scope's thread pool. Other
-/// Rayon operations called inside the closure, such as [`join()`](crate::join),
-/// [`spawn()`](crate::spawn), or parallel iterators, do not inherit that pool;
-/// any work they hand off to Rayon runs in the current thread pool -- the
-/// calling worker's pool, or the global pool when `in_place_scope_fifo()` is
-/// not called from within a worker thread.
+/// Only tasks spawned through the scope handle -- with
+/// [`ScopeFifo::spawn_fifo()`] or [`ScopeFifo::spawn_broadcast()`] -- are
+/// directed to the scope's thread pool. Rayon operations that use the ambient
+/// pool, such as [`join()`](crate::join), [`spawn()`](crate::spawn), or
+/// parallel iterators, do not inherit that pool. They use the calling worker's
+/// pool, or the global pool when `in_place_scope_fifo()` is called outside a
+/// Rayon worker. Calls on an explicit `ThreadPool` select that pool instead.
 ///
 /// # Panics
 ///

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -382,8 +382,15 @@ where
 /// spawned into `s` complete.
 ///
 /// This is just like `scope()` except the closure runs on the same thread
-/// that calls `in_place_scope()`. Only work that it spawns runs in the
-/// thread pool.
+/// that calls `in_place_scope()`.
+///
+/// Only tasks spawned into the scope -- with [`Scope::spawn()`] or
+/// [`Scope::spawn_broadcast()`] -- run in the scope's thread pool. Other Rayon
+/// operations called inside the closure, such as [`join()`](crate::join),
+/// [`spawn()`](crate::spawn), or parallel iterators, do not inherit that pool;
+/// any work they hand off to Rayon runs in the current thread pool -- the
+/// calling worker's pool, or the global pool when `in_place_scope()` is not
+/// called from within a worker thread.
 ///
 /// # Panics
 ///
@@ -433,8 +440,15 @@ fn get_in_place_thread_registry(
 /// that have been spawned into `s` complete.
 ///
 /// This is just like `scope_fifo()` except the closure runs on the same thread
-/// that calls `in_place_scope_fifo()`. Only work that it spawns runs in the
-/// thread pool.
+/// that calls `in_place_scope_fifo()`.
+///
+/// Only tasks spawned into the scope -- with [`ScopeFifo::spawn_fifo()`] or
+/// [`ScopeFifo::spawn_broadcast()`] -- run in the scope's thread pool. Other
+/// Rayon operations called inside the closure, such as [`join()`](crate::join),
+/// [`spawn()`](crate::spawn), or parallel iterators, do not inherit that pool;
+/// any work they hand off to Rayon runs in the current thread pool -- the
+/// calling worker's pool, or the global pool when `in_place_scope_fifo()` is
+/// not called from within a worker thread.
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Clarifies #1165. Tasks spawned through the scope handle use the scope's pool. Ambient Rayon operations inside the closure, including free join, free spawn, and parallel iterators, do not inherit that pool: they use the caller's current worker pool or the global pool when the caller is outside Rayon. Explicit ThreadPool operations select their own pool. Applies equally to in_place_scope_fifo. Docs-only; no behavior change.