### PR TITLE
Document order preservation in parallel iterators

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -62,7 +62,7 @@
 //!
 //! For parallel iterators over data with a meaningful order, order-preserving
 //! adaptors -- such as [`map`], [`filter`], [`enumerate`], and [`zip`] -- retain
-//! the source order when their results are collected into a [`Vec`]. Provided
+//! the source order when their results are collected into a [`Vec`], for example. Provided
 //! their closures do not depend on how work is scheduled, this produces the
 //! same sequence that the equivalent sequential [`Iterator`] would, even
 //! though the work is split across threads:

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -58,6 +58,55 @@
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
 //! traits.
 //!
+//! # Ordering
+//!
+//! For parallel iterators over data with a meaningful order, order-dependent
+//! adaptors and consumers -- such as [`map`], [`filter`], [`enumerate`],
+//! [`zip`], and collecting into an ordered container like [`Vec`] -- produce
+//! exactly the same sequence that the equivalent sequential [`Iterator`] would,
+//! even though the work is split across threads:
+//!
+//! ```rust
+//! use rayon::prelude::*;
+//! let par: Vec<i32> = (0..1000).into_par_iter().map(|x| x * 2).collect();
+//! let seq: Vec<i32> = (0..1000).map(|x| x * 2).collect();
+//! assert_eq!(par, seq);
+//! ```
+//!
+//! There are important exceptions and caveats:
+//!
+//! - Not every parallel iterator has a meaningful order to begin with -- much
+//!   like sequential [`HashMap`] iteration -- and some, such as [`walk_tree`],
+//!   guarantee no ordering at all.
+//! - [`ParallelBridge`] is not guaranteed to preserve the order of the source
+//!   iterator.
+//! - The `*_any` methods, such as [`find_any`], return an arbitrary matching
+//!   item rather than a positional one; use [`find_first`] or [`find_last`]
+//!   when position matters.
+//! - Reductions such as [`reduce`], [`sum`], and [`product`] combine items in
+//!   an unspecified order, so their operation should be [associative] for
+//!   deterministic results.
+//! - Side effects happen in an unspecified order: the closure given to
+//!   [`for_each`] may observe items in any order and run on any thread, even
+//!   though an order-dependent consumer like [`collect`] still yields ordered
+//!   results.
+//!
+//! [`map`]: ParallelIterator::map
+//! [`filter`]: ParallelIterator::filter
+//! [`enumerate`]: IndexedParallelIterator::enumerate
+//! [`zip`]: IndexedParallelIterator::zip
+//! [`for_each`]: ParallelIterator::for_each
+//! [`collect`]: ParallelIterator::collect
+//! [`find_any`]: ParallelIterator::find_any
+//! [`find_first`]: ParallelIterator::find_first
+//! [`find_last`]: ParallelIterator::find_last
+//! [`reduce`]: ParallelIterator::reduce
+//! [`sum`]: ParallelIterator::sum
+//! [`product`]: ParallelIterator::product
+//! [`HashMap`]: std::collections::HashMap
+//! [`walk_tree`]: crate::iter::walk_tree()
+//! [associative]: https://en.wikipedia.org/wiki/Associative_property
+//!
 //! If you'd like to build a custom parallel iterator, or to write your own
 //! combinator, then check out the [split] function and the [plumbing] module.
 //!

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -58,6 +58,26 @@
 //! check out the [`ParallelIterator`] and [`IndexedParallelIterator`]
 //! traits.
 //!
+//! If you'd like to build a custom parallel iterator, or to write your own
+//! combinator, then check out the [split] function and the [plumbing] module.
+//!
+//! [regular iterator]: Iterator
+//! [split]: split()
+//! [plumbing]: plumbing
+//!
+//! Note: Several of the `ParallelIterator` methods rely on a `Try` trait which
+//! has been deliberately obscured from the public API.  This trait is intended
+//! to mirror the unstable `std::ops::Try` with implementations for `Option` and
+//! `Result`, where `Some`/`Ok` values will let those iterators continue, but
+//! `None`/`Err` values will exit early.
+//!
+//! A note about
+//! [dyn compatiblity](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility):
+//! It is currently _not_ possible to wrap a `ParallelIterator` (or any trait
+//! that depends on it) using a `Box<dyn ParallelIterator>` or other kind of
+//! dynamic allocation, because `ParallelIterator` is **not dyn-compatible**.
+//! (This keeps the implementation simpler and allows extra optimizations.)
+//!
 //! # Ordering
 //!
 //! For parallel iterators over data with a meaningful order, order-preserving
@@ -120,26 +140,6 @@
 //! [`ParallelBridge`]: crate::iter::ParallelBridge
 //! [`walk_tree`]: crate::iter::walk_tree()
 //! [associative]: https://en.wikipedia.org/wiki/Associative_property
-//!
-//! If you'd like to build a custom parallel iterator, or to write your own
-//! combinator, then check out the [split] function and the [plumbing] module.
-//!
-//! [regular iterator]: Iterator
-//! [split]: split()
-//! [plumbing]: plumbing
-//!
-//! Note: Several of the `ParallelIterator` methods rely on a `Try` trait which
-//! has been deliberately obscured from the public API.  This trait is intended
-//! to mirror the unstable `std::ops::Try` with implementations for `Option` and
-//! `Result`, where `Some`/`Ok` values will let those iterators continue, but
-//! `None`/`Err` values will exit early.
-//!
-//! A note about
-//! [dyn compatiblity](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility):
-//! It is currently _not_ possible to wrap a `ParallelIterator` (or any trait
-//! that depends on it) using a `Box<dyn ParallelIterator>` or other kind of
-//! dynamic allocation, because `ParallelIterator` is **not dyn-compatible**.
-//! (This keeps the implementation simpler and allows extra optimizations.)
 
 use self::plumbing::*;
 pub use either::Either;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -60,16 +60,24 @@
 //!
 //! # Ordering
 //!
-//! For parallel iterators over data with a meaningful order, order-dependent
-//! adaptors and consumers -- such as [`map`], [`filter`], [`enumerate`],
-//! [`zip`], and collecting into an ordered container like [`Vec`] -- produce
-//! exactly the same sequence that the equivalent sequential [`Iterator`] would,
-//! even though the work is split across threads:
+//! For parallel iterators over data with a meaningful order, order-preserving
+//! adaptors -- such as [`map`], [`filter`], [`enumerate`], and [`zip`] -- retain
+//! the source order when their results are collected into a [`Vec`]. Provided
+//! their closures do not depend on how work is scheduled, this produces the
+//! same sequence that the equivalent sequential [`Iterator`] would, even
+//! though the work is split across threads:
 //!
 //! ```rust
 //! use rayon::prelude::*;
-//! let par: Vec<i32> = (0..1000).into_par_iter().map(|x| x * 2).collect();
-//! let seq: Vec<i32> = (0..1000).map(|x| x * 2).collect();
+//! let par: Vec<i32> = (0..1000)
+//!     .into_par_iter()
+//!     .filter(|x| *x % 3 == 0)
+//!     .map(|x| x * 2)
+//!     .collect();
+//! let seq: Vec<i32> = (0..1000)
+//!     .filter(|x| *x % 3 == 0)
+//!     .map(|x| x * 2)
+//!     .collect();
 //! assert_eq!(par, seq);
 //! ```
 //!
@@ -80,30 +88,36 @@
 //!   guarantee no ordering at all.
 //! - [`ParallelBridge`] is not guaranteed to preserve the order of the source
 //!   iterator.
-//! - The `*_any` methods, such as [`find_any`], return an arbitrary matching
-//!   item rather than a positional one; use [`find_first`] or [`find_last`]
-//!   when position matters.
+//! - `*_any` methods deliberately relax positional selection. Search methods
+//!   such as [`find_any`] may return any matching item; use [`find_first`] or
+//!   [`find_last`] for a positional search. [`take_any`] and [`skip_any`],
+//!   including their `*_while` variants, select or discard items from anywhere
+//!   in the source. Retained items still preserve their relative order when
+//!   collected into a [`Vec`].
 //! - Reductions such as [`reduce`], [`sum`], and [`product`] combine items in
 //!   an unspecified order, so their operation should be [associative] for
 //!   deterministic results.
-//! - Side effects happen in an unspecified order: the closure given to
-//!   [`for_each`] may observe items in any order and run on any thread, even
-//!   though an order-dependent consumer like [`collect`] still yields ordered
-//!   results.
+//! - Closures may run concurrently and in an unspecified temporal order. Side
+//!   effects or other scheduling-sensitive state can therefore produce different
+//!   values from a sequential iterator, even when `collect::<Vec<_>>()`
+//!   preserves the resulting items' source order.
 //!
 //! [`map`]: ParallelIterator::map
 //! [`filter`]: ParallelIterator::filter
 //! [`enumerate`]: IndexedParallelIterator::enumerate
 //! [`zip`]: IndexedParallelIterator::zip
-//! [`for_each`]: ParallelIterator::for_each
-//! [`collect`]: ParallelIterator::collect
 //! [`find_any`]: ParallelIterator::find_any
 //! [`find_first`]: ParallelIterator::find_first
 //! [`find_last`]: ParallelIterator::find_last
+//! [`take_any`]: ParallelIterator::take_any
+//! [`skip_any`]: ParallelIterator::skip_any
 //! [`reduce`]: ParallelIterator::reduce
 //! [`sum`]: ParallelIterator::sum
 //! [`product`]: ParallelIterator::product
+//! [`Vec`]: std::vec::Vec
+//! [`Iterator`]: std::iter::Iterator
 //! [`HashMap`]: std::collections::HashMap
+//! [`ParallelBridge`]: crate::iter::ParallelBridge
 //! [`walk_tree`]: crate::iter::walk_tree()
 //! [associative]: https://en.wikipedia.org/wiki/Associative_property
 //!


### PR DESCRIPTION
Fixes #669. Documents when parallel iterators preserve source order: ordered sources plus order-preserving adaptors and collection into Vec produce the sequential output sequence, provided closures do not depend on scheduling. The doctest covers map and filter. It also distinguishes find_any from find_first/find_last, and take_any/skip_any (including their while variants) from order-preserving forms; retained items still keep their relative order. Documents unordered sources, ParallelBridge, reductions, and side-effect scheduling caveats. Docs-only; no behavior change.