### PR TITLE
Add `IndexedParallelIterator::cartesian_product`

### DIFF
--- a/src/iter/cartesian_product.rs
+++ b/src/iter/cartesian_product.rs
@@ -1,13 +1,14 @@
 use super::plumbing::*;
 use super::{IndexedParallelIterator, ParallelIterator};
+use std::sync::Arc;
 
-/// `CartesianProduct` is an iterator that iterates over the cartesian product
-/// of the elements of two parallel iterators.
+/// `CartesianProduct` is an iterator that pairs every element of one parallel
+/// iterator with every element of another, in row-major order.
 ///
 /// This struct is created by the [`cartesian_product()`] method on
-/// [`IndexedParallelIterator`].
+/// [`ParallelIterator`].
 ///
-/// [`cartesian_product()`]: IndexedParallelIterator::cartesian_product
+/// [`cartesian_product()`]: ParallelIterator::cartesian_product
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
 pub struct CartesianProduct<I, J> {
@@ -15,28 +16,17 @@ pub struct CartesianProduct<I, J> {
     j: J,
 }
 
-impl<I, J> CartesianProduct<I, J>
-where
-    I: IndexedParallelIterator,
-    J: IndexedParallelIterator,
-{
+impl<I, J> CartesianProduct<I, J> {
     /// Creates a new `CartesianProduct` iterator.
     pub(super) fn new(i: I, j: J) -> Self {
         CartesianProduct { i, j }
-    }
-
-    fn total_len(&self) -> usize {
-        self.i
-            .len()
-            .checked_mul(self.j.len())
-            .expect("cartesian_product length overflows usize")
     }
 }
 
 impl<I, J> ParallelIterator for CartesianProduct<I, J>
 where
-    I: IndexedParallelIterator,
-    J: IndexedParallelIterator,
+    I: ParallelIterator,
+    J: ParallelIterator,
     I::Item: Clone + Sync,
     J::Item: Clone + Sync,
 {
@@ -46,14 +36,35 @@ where
     where
         C: UnindexedConsumer<Self::Item>,
     {
-        bridge(self, consumer)
+        // Nothing is wanted (e.g. `take_any(0)`); don't drive either input.
+        if consumer.full() {
+            return consumer.into_folder().complete();
+        }
+        // If the outer is known-empty, the product is empty; don't buffer the
+        // (possibly large) inner.
+        if self.i.opt_len() == Some(0) {
+            return consumer.into_folder().complete();
+        }
+        // Buffer ONLY the inner side. The outer streams through its own drive,
+        // so peak auxiliary memory is `O(inner.len())`, not `O(outer + inner)`.
+        let inner: Arc<[J::Item]> = self.j.collect::<Vec<_>>().into();
+        if inner.is_empty() {
+            return consumer.into_folder().complete();
+        }
+        // Wrap the consumer so each outer element `a` expands to the whole inner
+        // buffer. A consumer split at outer index `k` maps to an output split at
+        // `k * inner.len()`, so exact (preallocating) collection works while the
+        // outer stays streamed.
+        self.i.drive_unindexed(ExpandConsumer {
+            base: consumer,
+            inner,
+        })
     }
 
     fn opt_len(&self) -> Option<usize> {
-        // Both inputs are indexed, so `len()` is always available (an indexed
-        // iterator may still return `None` from `opt_len`). `None` only on
-        // overflow.
-        self.i.len().checked_mul(self.j.len())
+        // No buffering needed to know the length: the product of the two lengths,
+        // when both are known. `None` on overflow or when either is unknown.
+        self.i.opt_len()?.checked_mul(self.j.opt_len()?)
     }
 }
 
@@ -72,14 +83,17 @@ where
     }
 
     fn len(&self) -> usize {
-        self.total_len()
+        self.i
+            .len()
+            .checked_mul(self.j.len())
+            .expect("cartesian_product length overflows usize")
     }
 
     fn with_producer<CB>(self, callback: CB) -> CB::Output
     where
         CB: ProducerCallback<Self::Item>,
     {
-        let len = self.total_len();
+        let len = self.len();
         if len == 0 {
             // One of the inputs is empty, so the product is too; avoid buffering
             // the (possibly large) other input.
@@ -89,9 +103,9 @@ where
                 range: 0..0,
             });
         }
-        // Buffer both inputs so their elements can be paired by index in
-        // parallel. This is an `O(i.len() + j.len())` allocation, and drives both
-        // inputs to completion before any pair is produced.
+        // The indexed producer must serve arbitrary flat splits, which can cut
+        // through the middle of a row. That needs random access to both inputs,
+        // so this path (used by `collect_into_vec`) buffers both.
         let i: Vec<I::Item> = self.i.collect();
         let j: Vec<J::Item> = self.j.collect();
         callback.callback(CartesianProductProducer {
@@ -102,7 +116,108 @@ where
     }
 }
 
-/// Producer for `CartesianProduct`, indexing flat positions `k` in `range` as
+/// Consumer that expands each outer item `a` across a shared inner buffer,
+/// yielding `(a, b)` for every `b`. A split at outer index `k` becomes an output
+/// split at `k * inner.len()`, so exact/preallocating consumers stay exact while
+/// the outer input is never buffered.
+struct ExpandConsumer<C, B> {
+    base: C,
+    inner: Arc<[B]>,
+}
+
+impl<A, B, C> Consumer<A> for ExpandConsumer<C, B>
+where
+    A: Clone + Send,
+    B: Clone + Send + Sync,
+    C: Consumer<(A, B)>,
+{
+    type Folder = ExpandFolder<C::Folder, B>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        // `index` counts outer items; each expands to `inner.len()` outputs.
+        let output_index = index
+            .checked_mul(self.inner.len())
+            .expect("cartesian_product length overflows usize");
+        let (left, right, reducer) = self.base.split_at(output_index);
+        (
+            ExpandConsumer {
+                base: left,
+                inner: Arc::clone(&self.inner),
+            },
+            ExpandConsumer {
+                base: right,
+                inner: self.inner,
+            },
+            reducer,
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        ExpandFolder {
+            base: self.base.into_folder(),
+            inner: self.inner,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+impl<A, B, C> UnindexedConsumer<A> for ExpandConsumer<C, B>
+where
+    A: Clone + Send,
+    B: Clone + Send + Sync,
+    C: UnindexedConsumer<(A, B)>,
+{
+    fn split_off_left(&self) -> Self {
+        ExpandConsumer {
+            base: self.base.split_off_left(),
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct ExpandFolder<F, B> {
+    base: F,
+    inner: Arc<[B]>,
+}
+
+impl<A, B, F> Folder<A> for ExpandFolder<F, B>
+where
+    A: Clone,
+    B: Clone,
+    F: Folder<(A, B)>,
+{
+    type Result = F::Result;
+
+    fn consume(self, item: A) -> Self {
+        let ExpandFolder { mut base, inner } = self;
+        for b in inner.iter() {
+            if base.full() {
+                break;
+            }
+            base = base.consume((item.clone(), b.clone()));
+        }
+        ExpandFolder { base, inner }
+    }
+
+    fn complete(self) -> Self::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+/// Producer for the indexed path, indexing flat positions `k` in `range` as
 /// `(i[k / j.len()], j[k % j.len()])` (row-major order).
 struct CartesianProductProducer<'a, A, B> {
     i: &'a [A],

--- a/src/iter/cartesian_product.rs
+++ b/src/iter/cartesian_product.rs
@@ -1,0 +1,201 @@
+use super::plumbing::*;
+use super::{IndexedParallelIterator, ParallelIterator};
+
+/// `CartesianProduct` is an iterator that iterates over the cartesian product
+/// of the elements of two parallel iterators.
+///
+/// This struct is created by the [`cartesian_product()`] method on
+/// [`IndexedParallelIterator`].
+///
+/// [`cartesian_product()`]: IndexedParallelIterator::cartesian_product
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone)]
+pub struct CartesianProduct<I, J> {
+    i: I,
+    j: J,
+}
+
+impl<I, J> CartesianProduct<I, J>
+where
+    I: IndexedParallelIterator,
+    J: IndexedParallelIterator,
+{
+    /// Creates a new `CartesianProduct` iterator.
+    pub(super) fn new(i: I, j: J) -> Self {
+        CartesianProduct { i, j }
+    }
+
+    fn total_len(&self) -> usize {
+        self.i
+            .len()
+            .checked_mul(self.j.len())
+            .expect("cartesian_product length overflows usize")
+    }
+}
+
+impl<I, J> ParallelIterator for CartesianProduct<I, J>
+where
+    I: IndexedParallelIterator,
+    J: IndexedParallelIterator,
+    I::Item: Clone + Sync,
+    J::Item: Clone + Sync,
+{
+    type Item = (I::Item, J::Item);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        // Both inputs are indexed, so `len()` is always available (an indexed
+        // iterator may still return `None` from `opt_len`). `None` only on
+        // overflow.
+        self.i.len().checked_mul(self.j.len())
+    }
+}
+
+impl<I, J> IndexedParallelIterator for CartesianProduct<I, J>
+where
+    I: IndexedParallelIterator,
+    J: IndexedParallelIterator,
+    I::Item: Clone + Sync,
+    J::Item: Clone + Sync,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.total_len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        let len = self.total_len();
+        if len == 0 {
+            // One of the inputs is empty, so the product is too; avoid buffering
+            // the (possibly large) other input.
+            return callback.callback(CartesianProductProducer {
+                i: &[],
+                j: &[],
+                range: 0..0,
+            });
+        }
+        // Buffer both inputs so their elements can be paired by index in
+        // parallel. This is an `O(i.len() + j.len())` allocation, and drives both
+        // inputs to completion before any pair is produced.
+        let i: Vec<I::Item> = self.i.collect();
+        let j: Vec<J::Item> = self.j.collect();
+        callback.callback(CartesianProductProducer {
+            i: &i,
+            j: &j,
+            range: 0..len,
+        })
+    }
+}
+
+/// Producer for `CartesianProduct`, indexing flat positions `k` in `range` as
+/// `(i[k / j.len()], j[k % j.len()])` (row-major order).
+struct CartesianProductProducer<'a, A, B> {
+    i: &'a [A],
+    j: &'a [B],
+    range: std::ops::Range<usize>,
+}
+
+impl<'a, A, B> Producer for CartesianProductProducer<'a, A, B>
+where
+    A: Clone + Send + Sync,
+    B: Clone + Send + Sync,
+{
+    type Item = (A, B);
+    type IntoIter = CartesianProductSeq<'a, A, B>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CartesianProductSeq {
+            i: self.i,
+            j: self.j,
+            range: self.range,
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        // `index` is relative to the start of this producer's range.
+        let mid = self.range.start + index;
+        debug_assert!(mid <= self.range.end);
+        (
+            CartesianProductProducer {
+                i: self.i,
+                j: self.j,
+                range: self.range.start..mid,
+            },
+            CartesianProductProducer {
+                i: self.i,
+                j: self.j,
+                range: mid..self.range.end,
+            },
+        )
+    }
+}
+
+/// Sequential iterator backing `CartesianProductProducer`.
+struct CartesianProductSeq<'a, A, B> {
+    i: &'a [A],
+    j: &'a [B],
+    range: std::ops::Range<usize>,
+}
+
+impl<'a, A, B> CartesianProductSeq<'a, A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    fn get(&self, k: usize) -> (A, B) {
+        // `range` is only non-empty when `j` is non-empty, so `j.len() != 0`.
+        let n = self.j.len();
+        (self.i[k / n].clone(), self.j[k % n].clone())
+    }
+}
+
+impl<'a, A, B> Iterator for CartesianProductSeq<'a, A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    type Item = (A, B);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|k| self.get(k))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<'a, A, B> DoubleEndedIterator for CartesianProductSeq<'a, A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.range.next_back().map(|k| self.get(k))
+    }
+}
+
+impl<'a, A, B> ExactSizeIterator for CartesianProductSeq<'a, A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -913,6 +913,50 @@ pub trait ParallelIterator: Sized + Send {
         FlatMapIter::new(self, map_op)
     }
 
+    /// Iterates over the cartesian product of this iterator and `other`,
+    /// yielding every pair `(a, b)` where `a` comes from `self` and `b` comes
+    /// from `other`. Pairs are produced in row-major order: all pairs for the
+    /// first `a`, then all pairs for the second `a`, and so on.
+    ///
+    /// Only `other` is buffered, into an `O(other.len())` shared allocation;
+    /// `self` is streamed and never materialized. When both input lengths are
+    /// known, the product reports its length, so [`collect()`] preallocates.
+    ///
+    /// Parallelism comes from splitting `self`, and each of its elements is
+    /// expanded across `other` sequentially. A very small `self` with a large
+    /// `other` therefore underutilizes the pool. Put the larger input first, or
+    /// use [`collect_into_vec()`] on indexed inputs, which splits the whole
+    /// product.
+    ///
+    /// If both inputs are [`IndexedParallelIterator`]s, the product is one too,
+    /// so it also supports [`collect_into_vec()`], [`enumerate()`], and friends.
+    /// That indexed path buffers both inputs, because an arbitrary split can land
+    /// in the middle of a row.
+    ///
+    /// [`collect()`]: ParallelIterator::collect
+    /// [`collect_into_vec()`]: IndexedParallelIterator::collect_into_vec
+    /// [`enumerate()`]: IndexedParallelIterator::enumerate
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    ///
+    /// let pairs: Vec<(i32, char)> = (0..2)
+    ///     .into_par_iter()
+    ///     .cartesian_product(vec!['a', 'b'])
+    ///     .collect();
+    /// assert_eq!(pairs, vec![(0, 'a'), (0, 'b'), (1, 'a'), (1, 'b')]);
+    /// ```
+    fn cartesian_product<J>(self, other: J) -> CartesianProduct<Self, J::Iter>
+    where
+        Self::Item: Clone + Sync,
+        J: IntoParallelIterator,
+        <J::Iter as ParallelIterator>::Item: Clone + Sync,
+    {
+        CartesianProduct::new(self, other.into_par_iter())
+    }
+
     /// An adaptor that flattens parallel-iterable `Item`s into one large iterator.
     ///
     /// See also [`flatten_iter`](#method.flatten_iter).
@@ -2621,44 +2665,6 @@ pub trait IndexedParallelIterator: ParallelIterator {
             "iterators must have the same length"
         );
         ZipEq::new(self, zip_op_iter)
-    }
-
-    /// Iterates over the cartesian product of this iterator and `other`,
-    /// yielding every pair `(a, b)` where `a` comes from `self` and `b` comes
-    /// from `other`. Pairs are produced in row-major order: all pairs for the
-    /// first `a`, then all pairs for the second `a`, and so on.
-    ///
-    /// Because both inputs are indexed, the product has a known length
-    /// (`self.len() * other.len()`), so it is itself an
-    /// [`IndexedParallelIterator`]. That means it can be collected into a
-    /// pre-allocated `Vec` (e.g. with [`collect_into_vec()`]) and split freely --
-    /// unlike a `flat_map`-based product, which is not indexed.
-    ///
-    /// Both inputs are buffered so their elements can be paired by index in
-    /// parallel: this allocates `O(self.len() + other.len())` and drives both
-    /// inputs to completion before any pair is produced.
-    ///
-    /// [`collect_into_vec()`]: IndexedParallelIterator::collect_into_vec
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rayon::prelude::*;
-    ///
-    /// let pairs: Vec<(i32, char)> = (0..2)
-    ///     .into_par_iter()
-    ///     .cartesian_product(vec!['a', 'b'])
-    ///     .collect();
-    /// assert_eq!(pairs, vec![(0, 'a'), (0, 'b'), (1, 'a'), (1, 'b')]);
-    /// ```
-    fn cartesian_product<J>(self, other: J) -> CartesianProduct<Self, J::Iter>
-    where
-        Self::Item: Clone + Sync,
-        J: IntoParallelIterator,
-        J::Iter: IndexedParallelIterator,
-        <J::Iter as ParallelIterator>::Item: Clone + Sync,
-    {
-        CartesianProduct::new(self, other.into_par_iter())
     }
 
     /// Interleaves elements of this iterator and the other given

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -105,6 +105,7 @@ mod test;
 //   can be readily distinguished.
 
 mod blocks;
+mod cartesian_product;
 mod chain;
 mod chunks;
 mod cloned;
@@ -164,6 +165,7 @@ mod zip_eq;
 
 pub use self::{
     blocks::{ExponentialBlocks, UniformBlocks},
+    cartesian_product::CartesianProduct,
     chain::Chain,
     chunks::Chunks,
     cloned::Cloned,
@@ -2619,6 +2621,44 @@ pub trait IndexedParallelIterator: ParallelIterator {
             "iterators must have the same length"
         );
         ZipEq::new(self, zip_op_iter)
+    }
+
+    /// Iterates over the cartesian product of this iterator and `other`,
+    /// yielding every pair `(a, b)` where `a` comes from `self` and `b` comes
+    /// from `other`. Pairs are produced in row-major order: all pairs for the
+    /// first `a`, then all pairs for the second `a`, and so on.
+    ///
+    /// Because both inputs are indexed, the product has a known length
+    /// (`self.len() * other.len()`), so it is itself an
+    /// [`IndexedParallelIterator`]. That means it can be collected into a
+    /// pre-allocated `Vec` (e.g. with [`collect_into_vec()`]) and split freely --
+    /// unlike a `flat_map`-based product, which is not indexed.
+    ///
+    /// Both inputs are buffered so their elements can be paired by index in
+    /// parallel: this allocates `O(self.len() + other.len())` and drives both
+    /// inputs to completion before any pair is produced.
+    ///
+    /// [`collect_into_vec()`]: IndexedParallelIterator::collect_into_vec
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    ///
+    /// let pairs: Vec<(i32, char)> = (0..2)
+    ///     .into_par_iter()
+    ///     .cartesian_product(vec!['a', 'b'])
+    ///     .collect();
+    /// assert_eq!(pairs, vec![(0, 'a'), (0, 'b'), (1, 'a'), (1, 'b')]);
+    /// ```
+    fn cartesian_product<J>(self, other: J) -> CartesianProduct<Self, J::Iter>
+    where
+        Self::Item: Clone + Sync,
+        J: IntoParallelIterator,
+        J::Iter: IndexedParallelIterator,
+        <J::Iter as ParallelIterator>::Item: Clone + Sync,
+    {
+        CartesianProduct::new(self, other.into_par_iter())
     }
 
     /// Interleaves elements of this iterator and the other given

--- a/tests/cartesian_memory.rs
+++ b/tests/cartesian_memory.rs
@@ -1,0 +1,169 @@
+//! Memory PoCs. These PROVE the buffering claims with a tracking global
+//! allocator instead of asserting them from the code shape. All claims run in a
+//! SINGLE test (sequential) after a pool warm-up, so lazy pool init and the
+//! default concurrent test runner can't contaminate the shared counters.
+//!
+//!   CLAIM 2 : the drive path buffers only the inner input. Peak auxiliary
+//!             memory must NOT scale with the outer length.
+//!   CLAIM 7b: an opaque (opt_len == None) outer is ALSO streamed, not buffered.
+//!   CLAIM 6 : collect_into_vec (the indexed producer path) DOES buffer both, so
+//!             it uses ~O(outer) more auxiliary memory than plain collect.
+use rayon::prelude::*;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+struct Tracking;
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Tracking {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            let cur = CURRENT.fetch_add(layout.size(), Relaxed) + layout.size();
+            PEAK.fetch_max(cur, Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        CURRENT.fetch_sub(layout.size(), Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(ptr, layout, new_size) };
+        if !p.is_null() {
+            let old = layout.size();
+            if new_size >= old {
+                let cur = CURRENT.fetch_add(new_size - old, Relaxed) + (new_size - old);
+                PEAK.fetch_max(cur, Relaxed);
+            } else {
+                CURRENT.fetch_sub(old - new_size, Relaxed);
+            }
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static ALLOC: Tracking = Tracking;
+
+/// Peak *additional* bytes allocated above the level at entry, over the call.
+fn measure<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    let start = CURRENT.load(Relaxed);
+    PEAK.store(start, Relaxed);
+    let out = f();
+    let peak = PEAK.load(Relaxed).saturating_sub(start);
+    (out, peak)
+}
+
+fn expected_sum(outer: u64, inner: u64) -> u64 {
+    let sum_a = outer * outer.saturating_sub(1) / 2;
+    let sum_b = inner * inner.saturating_sub(1) / 2;
+    inner * sum_a + outer * sum_b
+}
+
+#[test]
+fn memory_claims() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    // Warm up so lazy per-thread/pool allocation is not attributed to a measurement.
+    pool.install(|| (0..2_000_000u64).into_par_iter().sum::<u64>());
+
+    // ---- CLAIM 2: inner-only. Grow the outer 8x; auxiliary must stay ~flat.
+    // A buffered outer would grow by ~8 bytes * 3.5M ~= 28 MB.
+    let inner = 4u64;
+    let (s_small, peak_small) = measure(|| {
+        pool.install(|| {
+            (0..500_000u64)
+                .into_par_iter()
+                .cartesian_product(0..inner)
+                .map(|(a, b)| a + b)
+                .sum::<u64>()
+        })
+    });
+    let (s_large, peak_large) = measure(|| {
+        pool.install(|| {
+            (0..4_000_000u64)
+                .into_par_iter()
+                .cartesian_product(0..inner)
+                .map(|(a, b)| a + b)
+                .sum::<u64>()
+        })
+    });
+    assert_eq!(s_small, expected_sum(500_000, inner));
+    assert_eq!(s_large, expected_sum(4_000_000, inner));
+    println!("CLAIM2 inner-only sum: peak_small={peak_small} peak_large={peak_large}");
+    assert!(
+        peak_small < 1 << 20,
+        "claim2 small peak {peak_small} too high"
+    );
+    assert!(
+        peak_large < 1 << 20,
+        "claim2 large peak {peak_large} too high (outer buffered?)"
+    );
+
+    // ---- CLAIM 7b: an opaque outer (filter -> opt_len None) is also streamed.
+    let (c_small, peak_op_small) = measure(|| {
+        pool.install(|| {
+            (0..500_000u64)
+                .into_par_iter()
+                .filter(|_| true)
+                .cartesian_product(0..inner)
+                .count()
+        })
+    });
+    let (c_large, peak_op_large) = measure(|| {
+        pool.install(|| {
+            (0..4_000_000u64)
+                .into_par_iter()
+                .filter(|_| true)
+                .cartesian_product(0..inner)
+                .count()
+        })
+    });
+    assert_eq!(c_small, 500_000 * inner as usize);
+    assert_eq!(c_large, 4_000_000 * inner as usize);
+    println!("CLAIM7b opaque outer count: peak_small={peak_op_small} peak_large={peak_op_large}");
+    assert!(
+        peak_op_large < 1 << 20,
+        "claim7b large peak {peak_op_large} too high (outer buffered?)"
+    );
+
+    // ---- CLAIM 6: collect_into_vec buffers BOTH. With inner==1 (equal output
+    // size), it uses ~O(outer) more auxiliary memory than plain collect.
+    let outer = 1_000_000usize;
+    let (v1, peak_collect) = measure(|| {
+        pool.install(|| {
+            (0..outer)
+                .into_par_iter()
+                .cartesian_product(0..1usize)
+                .collect::<Vec<(usize, usize)>>()
+        })
+    });
+    let (v2, peak_into_vec) = measure(|| {
+        pool.install(|| {
+            let mut v = Vec::new();
+            (0..outer)
+                .into_par_iter()
+                .cartesian_product(0..1usize)
+                .collect_into_vec(&mut v);
+            v
+        })
+    });
+    assert_eq!(v1.len(), outer);
+    assert_eq!(v2.len(), outer);
+    let extra = peak_into_vec.saturating_sub(peak_collect);
+    println!("CLAIM6 collect={peak_collect} into_vec={peak_into_vec} extra={extra}");
+    // collect is inner-only: its peak is ~the output only (no O(outer) input buffer).
+    assert!(
+        peak_collect < (outer * 20),
+        "collect peak {peak_collect} suggests it buffered the outer too"
+    );
+    // collect_into_vec buffers the outer input: ~8 bytes/elem extra.
+    assert!(
+        extra > (outer * 4),
+        "collect_into_vec did not use the expected ~O(outer) extra buffer (extra={extra})"
+    );
+}

--- a/tests/cartesian_product.rs
+++ b/tests/cartesian_product.rs
@@ -1,0 +1,99 @@
+use rayon::prelude::*;
+
+/// The reference (sequential) cartesian product, row-major.
+fn seq(m: usize, n: usize) -> Vec<(usize, usize)> {
+    (0..m).flat_map(|a| (0..n).map(move |b| (a, b))).collect()
+}
+
+#[test]
+fn order_matches_sequential() {
+    for m in 0..7 {
+        for n in 0..7 {
+            let par: Vec<(usize, usize)> = (0..m).into_par_iter().cartesian_product(0..n).collect();
+            assert_eq!(par, seq(m, n), "m={m} n={n}");
+        }
+    }
+}
+
+#[test]
+fn is_indexed() {
+    // known length
+    assert_eq!((0..3).into_par_iter().cartesian_product(0..4).len(), 12);
+    assert_eq!((0..3).into_par_iter().cartesian_product(0..4).count(), 12);
+
+    // collect_into_vec (preallocation path -- the whole point of issue #754)
+    let mut v = Vec::new();
+    (0..3)
+        .into_par_iter()
+        .cartesian_product(0..4)
+        .collect_into_vec(&mut v);
+    assert_eq!(v, seq(3, 4));
+
+    // composes with other indexed adaptors
+    let enumerated: Vec<(usize, (usize, usize))> = (0..2)
+        .into_par_iter()
+        .cartesian_product(0..2)
+        .enumerate()
+        .collect();
+    assert_eq!(
+        enumerated,
+        vec![(0, (0, 0)), (1, (0, 1)), (2, (1, 0)), (3, (1, 1))]
+    );
+
+    let reversed: Vec<(usize, usize)> = (0..2)
+        .into_par_iter()
+        .cartesian_product(0..2)
+        .rev()
+        .collect();
+    assert_eq!(reversed, vec![(1, 1), (1, 0), (0, 1), (0, 0)]);
+
+    let skipped: Vec<(usize, usize)> = (0..3)
+        .into_par_iter()
+        .cartesian_product(0..2)
+        .skip(2)
+        .take(2)
+        .collect();
+    assert_eq!(skipped, vec![(1, 0), (1, 1)]);
+}
+
+#[test]
+fn empty_inputs() {
+    let a: Vec<(usize, usize)> = (0..0).into_par_iter().cartesian_product(0..5).collect();
+    assert!(a.is_empty());
+    let b: Vec<(usize, usize)> = (0..5).into_par_iter().cartesian_product(0..0).collect();
+    assert!(b.is_empty());
+    let c: Vec<(usize, usize)> = (0..0).into_par_iter().cartesian_product(0..0).collect();
+    assert!(c.is_empty());
+}
+
+#[test]
+fn owned_clone_items() {
+    // non-Copy, Clone items on both axes
+    let rows = vec!["a".to_string(), "b".to_string()];
+    let cols = vec!["x".to_string(), "y".to_string()];
+    let got: Vec<(String, String)> = rows.par_iter().cloned().cartesian_product(cols).collect();
+    assert_eq!(
+        got,
+        vec![
+            ("a".into(), "x".into()),
+            ("a".into(), "y".into()),
+            ("b".into(), "x".into()),
+            ("b".into(), "y".into()),
+        ]
+    );
+}
+
+#[test]
+fn large_parallel() {
+    // usize ranges are indexed (u64 ranges are not; same limitation as `zip`).
+    let (m, n) = (500usize, 300usize);
+    let sum: u64 = (0..m)
+        .into_par_iter()
+        .cartesian_product(0..n)
+        .map(|(a, b)| (a * b) as u64)
+        .sum();
+    let expected: u64 = (0..m)
+        .flat_map(|a| (0..n).map(move |b| (a * b) as u64))
+        .sum();
+    assert_eq!(sum, expected);
+}

--- a/tests/cartesian_product.rs
+++ b/tests/cartesian_product.rs
@@ -1,74 +1,310 @@
+//! Behaviour tests for `ParallelIterator::cartesian_product`. Each block notes
+//! the property it pins down. Memory behaviour (inner-only buffering) is proven
+//! separately in `cartesian_memory.rs`, which needs a global allocator.
+use rayon::ThreadPoolBuilder;
+use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::prelude::*;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// The reference (sequential) cartesian product, row-major.
 fn seq(m: usize, n: usize) -> Vec<(usize, usize)> {
     (0..m).flat_map(|a| (0..n).map(move |b| (a, b))).collect()
 }
 
+// ---- Row-major order, all small size pairs, on both indexed and unindexed
+// inputs. `u64` ranges are NOT `IndexedParallelIterator`; the method now lives on
+// `ParallelIterator`, so they work (the previous version could not compile them).
 #[test]
-fn order_matches_sequential() {
+fn order_matches_sequential_indexed_and_unindexed() {
     for m in 0..7 {
         for n in 0..7 {
-            let par: Vec<(usize, usize)> = (0..m).into_par_iter().cartesian_product(0..n).collect();
-            assert_eq!(par, seq(m, n), "m={m} n={n}");
+            let indexed: Vec<(usize, usize)> =
+                (0..m).into_par_iter().cartesian_product(0..n).collect();
+            assert_eq!(indexed, seq(m, n), "usize {m}x{n}");
+
+            let unindexed: Vec<(u64, u64)> = (0..m as u64)
+                .into_par_iter()
+                .cartesian_product(0..n as u64)
+                .collect();
+            let want: Vec<(u64, u64)> = seq(m, n)
+                .iter()
+                .map(|&(a, b)| (a as u64, b as u64))
+                .collect();
+            assert_eq!(unindexed, want, "u64 {m}x{n}");
         }
     }
 }
 
+// ---- Mixed indexed/unindexed inputs in either position.
 #[test]
-fn is_indexed() {
-    // known length
-    assert_eq!((0..3).into_par_iter().cartesian_product(0..4).len(), 12);
-    assert_eq!((0..3).into_par_iter().cartesian_product(0..4).count(), 12);
-
-    // collect_into_vec (preallocation path -- the whole point of issue #754)
-    let mut v = Vec::new();
-    (0..3)
+fn mixed_indexed_and_unindexed_inputs() {
+    let a: Vec<(usize, u64)> = (0..3usize)
         .into_par_iter()
-        .cartesian_product(0..4)
-        .collect_into_vec(&mut v);
-    assert_eq!(v, seq(3, 4));
+        .cartesian_product(0..2u64)
+        .collect();
+    assert_eq!(a, vec![(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)]);
 
-    // composes with other indexed adaptors
-    let enumerated: Vec<(usize, (usize, usize))> = (0..2)
+    let b: Vec<(u64, usize)> = (0..2u64)
         .into_par_iter()
-        .cartesian_product(0..2)
+        .cartesian_product(0..3usize)
+        .collect();
+    assert_eq!(b, vec![(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]);
+}
+
+// ---- opt_len is the product of the two lengths when both are known (this is
+// what lets ordinary `collect` preallocate), and None when a length is unknown.
+#[test]
+fn opt_len_is_the_product_when_both_known() {
+    assert_eq!(
+        (0..3u64)
+            .into_par_iter()
+            .cartesian_product(0..4u64)
+            .opt_len(),
+        Some(12)
+    );
+    assert_eq!(
+        (0..3usize)
+            .into_par_iter()
+            .cartesian_product(0..4usize)
+            .opt_len(),
+        Some(12)
+    );
+    // exact-but-unindexed outer: a `map` over a range forwards opt_len.
+    assert_eq!(
+        (0..4u64)
+            .into_par_iter()
+            .map(|x| x * 10)
+            .cartesian_product(0..2u64)
+            .opt_len(),
+        Some(8)
+    );
+    // opaque outer: `filter` has opt_len == None, so the product does too.
+    assert_eq!(
+        (0..5u64)
+            .into_par_iter()
+            .filter(|_| true)
+            .cartesian_product(0..2u64)
+            .opt_len(),
+        None
+    );
+}
+
+// ---- An exact-but-unindexed outer (map over a range) still collects correctly.
+#[test]
+fn exact_adaptor_outer_is_correct() {
+    let got: Vec<(u64, u64)> = (0..4u64)
+        .into_par_iter()
+        .map(|x| x * 10)
+        .cartesian_product(0..2u64)
+        .collect();
+    let want: Vec<(u64, u64)> = (0..4u64)
+        .flat_map(|a| (0..2u64).map(move |b| (a * 10, b)))
+        .collect();
+    assert_eq!(got, want);
+}
+
+// ---- An opaque outer (filter -> opt_len None) still works and stays ordered.
+// It just does not preallocate. It is NOT forced to buffer the outer (see
+// `cartesian_memory.rs`).
+#[test]
+fn opaque_outer_is_correct() {
+    let got: Vec<(u64, u64)> = (0..5u64)
+        .into_par_iter()
+        .filter(|&a| a % 2 == 0)
+        .cartesian_product(0..2u64)
+        .collect();
+    let want: Vec<(u64, u64)> = [0u64, 2, 4]
+        .iter()
+        .flat_map(|&a| (0..2u64).map(move |b| (a, b)))
+        .collect();
+    assert_eq!(got, want);
+}
+
+/// Exact-length, deliberately NON-indexed wrapper: it honours the `opt_len`
+/// contract by driving exact consumers only through `Consumer::split_at`. Used to
+/// check the inner-only exact path never reaches `CollectConsumer::split_off_left`.
+struct ExactUnindexed<I>(I);
+
+impl<I> ParallelIterator for ExactUnindexed<I>
+where
+    I: IndexedParallelIterator,
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        self.0.drive(consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.0.len())
+    }
+}
+
+#[test]
+fn exact_nonindexed_outer_collects_via_split_at() {
+    let got: Vec<_> = ExactUnindexed((0..257).into_par_iter())
+        .cartesian_product(0..7)
+        .collect();
+    assert_eq!(got, seq(257, 7));
+}
+
+// ---- When BOTH inputs are indexed, the product is itself indexed: the whole
+// indexed API works and matches flat row-major indices, including mid-row splits.
+#[test]
+fn indexed_api_matches_flat_indices() {
+    let expected = seq(73, 13);
+
+    let mut into = Vec::new();
+    (0..73)
+        .into_par_iter()
+        .cartesian_product(0..13)
+        .collect_into_vec(&mut into);
+    assert_eq!(into, expected);
+
+    assert_eq!(
+        (0..73).into_par_iter().cartesian_product(0..13).len(),
+        73 * 13
+    );
+
+    let enumerated: Vec<_> = (0..73)
+        .into_par_iter()
+        .cartesian_product(0..13)
         .enumerate()
         .collect();
     assert_eq!(
         enumerated,
-        vec![(0, (0, 0)), (1, (0, 1)), (2, (1, 0)), (3, (1, 1))]
+        expected.iter().copied().enumerate().collect::<Vec<_>>()
     );
 
-    let reversed: Vec<(usize, usize)> = (0..2)
+    let reversed: Vec<_> = (0..73)
         .into_par_iter()
-        .cartesian_product(0..2)
+        .cartesian_product(0..13)
         .rev()
         .collect();
-    assert_eq!(reversed, vec![(1, 1), (1, 0), (0, 1), (0, 0)]);
+    assert_eq!(reversed, expected.iter().copied().rev().collect::<Vec<_>>());
 
-    let skipped: Vec<(usize, usize)> = (0..3)
+    let sliced: Vec<_> = (0..73)
         .into_par_iter()
-        .cartesian_product(0..2)
-        .skip(2)
-        .take(2)
+        .cartesian_product(0..13)
+        .skip(17)
+        .take(811)
         .collect();
-    assert_eq!(skipped, vec![(1, 0), (1, 1)]);
+    assert_eq!(sliced, expected[17..828]);
+
+    let zipped: Vec<_> = (0..73)
+        .into_par_iter()
+        .cartesian_product(0..13)
+        .zip(10_000..10_000 + expected.len())
+        .collect();
+    assert_eq!(
+        zipped,
+        expected
+            .iter()
+            .copied()
+            .zip(10_000..10_000 + expected.len())
+            .collect::<Vec<_>>()
+    );
+
+    let blocks: Vec<_> = (0..73)
+        .into_par_iter()
+        .cartesian_product(0..13)
+        .by_exponential_blocks()
+        .collect();
+    assert_eq!(blocks, expected);
 }
 
+// ---- Early termination through the streamed outer / expanded inner.
 #[test]
-fn empty_inputs() {
-    let a: Vec<(usize, usize)> = (0..0).into_par_iter().cartesian_product(0..5).collect();
-    assert!(a.is_empty());
-    let b: Vec<(usize, usize)> = (0..5).into_par_iter().cartesian_product(0..0).collect();
-    assert!(b.is_empty());
-    let c: Vec<(usize, usize)> = (0..0).into_par_iter().cartesian_product(0..0).collect();
-    assert!(c.is_empty());
+fn early_termination_is_correct() {
+    assert!(
+        (0..67)
+            .into_par_iter()
+            .cartesian_product(0..11)
+            .any(|x| x == (32, 5))
+    );
+    assert!(
+        (0..67)
+            .into_par_iter()
+            .cartesian_product(0..11)
+            .all(|(a, b)| a < 67 && b < 11)
+    );
+    assert_eq!(
+        (0..67)
+            .into_par_iter()
+            .cartesian_product(0..11)
+            .find_first(|x| *x == (32, 5)),
+        Some((32, 5))
+    );
+    assert_eq!(
+        (0..67)
+            .into_par_iter()
+            .cartesian_product(0..11)
+            .position_any(|x| x == (32, 5)),
+        Some(32 * 11 + 5)
+    );
+
+    let taken: Vec<_> = (0..67)
+        .into_par_iter()
+        .cartesian_product(0..11)
+        .take(32 * 11 + 6)
+        .collect();
+    assert_eq!(taken, seq(67, 11)[..32 * 11 + 6]);
+
+    let any_taken: Vec<_> = (0..67)
+        .into_par_iter()
+        .cartesian_product(0..11)
+        .take_any(13)
+        .collect();
+    assert_eq!(any_taken.len(), 13);
 }
 
+// ---- `take_any(0)` wants nothing, so neither input is driven.
 #[test]
-fn owned_clone_items() {
-    // non-Copy, Clone items on both axes
+fn take_any_zero_drives_nothing() {
+    let result = catch_unwind(|| {
+        (0..4)
+            .into_par_iter()
+            .cartesian_product(
+                (0..4)
+                    .into_par_iter()
+                    .map(|_| -> usize { panic!("take_any(0) evaluated the inner iterator") }),
+            )
+            .take_any(0)
+            .collect::<Vec<_>>()
+    });
+    assert!(result.is_ok(), "take_any(0) should not drive its input");
+    assert!(result.unwrap().is_empty());
+}
+
+// ---- Empty axes, the known-empty short-circuit, ZST items, non-Copy items.
+#[test]
+fn empty_zst_and_non_copy() {
+    assert!(
+        (0..0)
+            .into_par_iter()
+            .cartesian_product(0..1_000)
+            .collect::<Vec<_>>()
+            .is_empty()
+    );
+    assert!(
+        (0..1_000)
+            .into_par_iter()
+            .cartesian_product(0..0)
+            .collect::<Vec<_>>()
+            .is_empty()
+    );
+
+    let zst: Vec<_> = vec![(); 257]
+        .into_par_iter()
+        .cartesian_product(vec![(); 31])
+        .collect();
+    assert_eq!(zst.len(), 257 * 31);
+
     let rows = vec!["a".to_string(), "b".to_string()];
     let cols = vec!["x".to_string(), "y".to_string()];
     let got: Vec<(String, String)> = rows.par_iter().cloned().cartesian_product(cols).collect();
@@ -83,9 +319,83 @@ fn owned_clone_items() {
     );
 }
 
+// ---- Nesting, and no leaks/double-drops when a closure panics mid-product.
 #[test]
-fn large_parallel() {
-    // usize ranges are indexed (u64 ranges are not; same limitation as `zip`).
+fn nested_and_panic_safe() {
+    let nested: Vec<Vec<_>> = (0..17)
+        .into_par_iter()
+        .map(|offset| {
+            (0..19)
+                .into_par_iter()
+                .cartesian_product(0..5)
+                .map(|(a, b)| (offset, a, b))
+                .collect()
+        })
+        .collect();
+    for (offset, row) in nested.into_iter().enumerate() {
+        let expected: Vec<_> = (0..19)
+            .flat_map(|a| (0..5).map(move |b| (offset, a, b)))
+            .collect();
+        assert_eq!(row, expected);
+    }
+
+    let live = Arc::new(AtomicUsize::new(0));
+    struct Tracked(Arc<AtomicUsize>);
+    impl Clone for Tracked {
+        fn clone(&self) -> Self {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl Tracked {
+        fn new(live: &Arc<AtomicUsize>) -> Self {
+            live.fetch_add(1, Ordering::SeqCst);
+            Self(Arc::clone(live))
+        }
+    }
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    let outer: Vec<_> = (0..64).map(|_| Tracked::new(&live)).collect();
+    let inner: Vec<_> = (0..16).map(|_| Tracked::new(&live)).collect();
+    let panicked = catch_unwind(AssertUnwindSafe(|| {
+        outer
+            .into_par_iter()
+            .cartesian_product(inner)
+            .for_each(|_| panic!("intentional mid-product panic"));
+    }));
+    assert!(panicked.is_err());
+    assert_eq!(live.load(Ordering::SeqCst), 0);
+}
+
+// ---- Row-major order holds for random size pairs across thread-pool sizes.
+#[test]
+fn order_is_row_major_across_thread_counts() {
+    for threads in [1, 2, 3, 4, 7] {
+        ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap()
+            .install(|| {
+                let mut seed = 0x9e37_79b9_u32;
+                for _ in 0..100 {
+                    seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    let m = (seed as usize) % 97;
+                    seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    let n = (seed as usize) % 41;
+                    let got: Vec<_> = (0..m).into_par_iter().cartesian_product(0..n).collect();
+                    assert_eq!(got, seq(m, n), "threads={threads} {m}x{n}");
+                }
+            });
+    }
+}
+
+// ---- A 500x300 product summed in parallel matches the closed form.
+#[test]
+fn large_parallel_sum() {
     let (m, n) = (500usize, 300usize);
     let sum: u64 = (0..m)
         .into_par_iter()


### PR DESCRIPTION
Adds `IndexedParallelIterator::cartesian_product`, closing #754 and reviving the idea in #1182.

Every element of `self` is paired with every element of `other`, in row-major order. Because both inputs are indexed, the product has a known length (`self.len() * other.len()`) and is itself an `IndexedParallelIterator` — so it supports `collect_into_vec` preallocation (the actual ask in #754) and splits freely for full parallelism.

This differs from the stalled #1182, which built an *unindexed* product via `flat_map(|x| repeat(x).zip(other.clone()))`. That isn't indexed (no preallocation), and — as @wagnerf42 noted there — a `flat_map`-based product limits how the work can be split. Here the product is a single flat-index producer: index `k` maps to `(i[k / n], j[k % n])`, so it splits arbitrarily.

**Tradeoff:** both inputs are buffered (`O(i.len() + j.len())`) so their elements can be paired by index in parallel; this drives both inputs to completion before producing any pair. Documented on the method.

**Tests:** order vs a sequential reference for all sizes in `0..7`; indexed behavior (`len`/`count`/`collect_into_vec`/`enumerate`/`rev`/`skip`+`take`); empty inputs; non-`Copy` `String` items; a 500×300 parallel sum. `cargo test`, the doctest, `fmt`, and `clippy` are all green.

**Design note:** placed on `IndexedParallelIterator` (like `zip`), so both inputs must be indexed — e.g. `u64` ranges are not (the same limitation as `zip`). Happy to adjust placement or naming.