### PR TITLE
Add ParallelExtend impls for &mut references to collections

### DIFF
--- a/src/iter/extend.rs
+++ b/src/iter/extend.rs
@@ -170,6 +170,34 @@ where
     }
 }
 
+/// Extends a binary heap with items from a parallel iterator, through a
+/// mutable reference.
+impl<T> ParallelExtend<T> for &mut BinaryHeap<T>
+where
+    T: Ord + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a binary heap with copied items from a parallel iterator, through
+/// a mutable reference.
+impl<'a, T> ParallelExtend<&'a T> for &mut BinaryHeap<T>
+where
+    T: 'a + Copy + Ord + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
 /// Extends a B-tree map with items from a parallel iterator.
 impl<K, V> ParallelExtend<(K, V)> for BTreeMap<K, V>
 where
@@ -198,6 +226,36 @@ where
     }
 }
 
+/// Extends a B-tree map with items from a parallel iterator, through a
+/// mutable reference.
+impl<K, V> ParallelExtend<(K, V)> for &mut BTreeMap<K, V>
+where
+    K: Ord + Send,
+    V: Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = (K, V)>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a B-tree map with copied items from a parallel iterator, through
+/// a mutable reference.
+impl<'a, K: 'a, V: 'a> ParallelExtend<(&'a K, &'a V)> for &mut BTreeMap<K, V>
+where
+    K: Copy + Ord + Send + Sync,
+    V: Copy + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = (&'a K, &'a V)>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
 /// Extends a B-tree set with items from a parallel iterator.
 impl<T> ParallelExtend<T> for BTreeSet<T>
 where
@@ -221,6 +279,34 @@ where
         I: IntoParallelIterator<Item = &'a T>,
     {
         extend!(self, par_iter);
+    }
+}
+
+/// Extends a B-tree set with items from a parallel iterator, through a
+/// mutable reference.
+impl<T> ParallelExtend<T> for &mut BTreeSet<T>
+where
+    T: Ord + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a B-tree set with copied items from a parallel iterator, through
+/// a mutable reference.
+impl<'a, T> ParallelExtend<&'a T> for &mut BTreeSet<T>
+where
+    T: 'a + Copy + Ord + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
     }
 }
 
@@ -255,6 +341,38 @@ where
     }
 }
 
+/// Extends a hash map with items from a parallel iterator, through a mutable
+/// reference.
+impl<K, V, S> ParallelExtend<(K, V)> for &mut HashMap<K, V, S>
+where
+    K: Eq + Hash + Send,
+    V: Send,
+    S: BuildHasher + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = (K, V)>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a hash map with copied items from a parallel iterator, through a
+/// mutable reference.
+impl<'a, K: 'a, V: 'a, S> ParallelExtend<(&'a K, &'a V)> for &mut HashMap<K, V, S>
+where
+    K: Copy + Eq + Hash + Send + Sync,
+    V: Copy + Send + Sync,
+    S: BuildHasher + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = (&'a K, &'a V)>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
 /// Extends a hash set with items from a parallel iterator.
 impl<T, S> ParallelExtend<T> for HashSet<T, S>
 where
@@ -283,6 +401,36 @@ where
     }
 }
 
+/// Extends a hash set with items from a parallel iterator, through a mutable
+/// reference.
+impl<T, S> ParallelExtend<T> for &mut HashSet<T, S>
+where
+    T: Eq + Hash + Send,
+    S: BuildHasher + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a hash set with copied items from a parallel iterator, through a
+/// mutable reference.
+impl<'a, T, S> ParallelExtend<&'a T> for &mut HashSet<T, S>
+where
+    T: 'a + Copy + Eq + Hash + Send + Sync,
+    S: BuildHasher + Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
 /// Extends a linked list with items from a parallel iterator.
 impl<T> ParallelExtend<T> for LinkedList<T>
 where
@@ -307,6 +455,34 @@ where
         I: IntoParallelIterator<Item = &'a T>,
     {
         self.par_extend(par_iter.into_par_iter().copied())
+    }
+}
+
+/// Extends a linked list with items from a parallel iterator, through a
+/// mutable reference.
+impl<T> ParallelExtend<T> for &mut LinkedList<T>
+where
+    T: Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a linked list with copied items from a parallel iterator, through
+/// a mutable reference.
+impl<'a, T> ParallelExtend<&'a T> for &mut LinkedList<T>
+where
+    T: 'a + Copy + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
     }
 }
 
@@ -407,6 +583,39 @@ impl<'a> ParallelExtend<Cow<'a, OsStr>> for OsString {
         I: IntoParallelIterator<Item = Cow<'a, OsStr>>,
     {
         extend_reserved!(self, par_iter, osstring_len);
+    }
+}
+
+/// Extends an OS-string with string slices from a parallel iterator, through
+/// a mutable reference.
+impl<'a> ParallelExtend<&'a OsStr> for &mut OsString {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a OsStr>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends an OS-string with strings from a parallel iterator, through a
+/// mutable reference.
+impl ParallelExtend<OsString> for &mut OsString {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = OsString>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends an OS-string with string slices from a parallel iterator, through
+/// a mutable reference.
+impl<'a> ParallelExtend<Cow<'a, OsStr>> for &mut OsString {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = Cow<'a, OsStr>>,
+    {
+        (**self).par_extend(par_iter)
     }
 }
 
@@ -539,6 +748,72 @@ impl<'a> ParallelExtend<Cow<'a, str>> for String {
     }
 }
 
+/// Extends a string with characters from a parallel iterator, through a
+/// mutable reference.
+impl ParallelExtend<char> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = char>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a string with copied characters from a parallel iterator, through
+/// a mutable reference.
+impl<'a> ParallelExtend<&'a char> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a char>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a string with string slices from a parallel iterator, through a
+/// mutable reference.
+impl<'a> ParallelExtend<&'a str> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a str>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a string with strings from a parallel iterator, through a mutable
+/// reference.
+impl ParallelExtend<String> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = String>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a string with boxed strings from a parallel iterator, through a
+/// mutable reference.
+impl ParallelExtend<Box<str>> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = Box<str>>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a string with string slices from a parallel iterator, through a
+/// mutable reference.
+impl<'a> ParallelExtend<Cow<'a, str>> for &mut String {
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = Cow<'a, str>>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
 /// Extends a deque with items from a parallel iterator.
 impl<T> ParallelExtend<T> for VecDeque<T>
 where
@@ -562,6 +837,34 @@ where
         I: IntoParallelIterator<Item = &'a T>,
     {
         extend_reserved!(self, par_iter);
+    }
+}
+
+/// Extends a deque with items from a parallel iterator, through a mutable
+/// reference.
+impl<T> ParallelExtend<T> for &mut VecDeque<T>
+where
+    T: Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a deque with copied items from a parallel iterator, through a
+/// mutable reference.
+impl<'a, T> ParallelExtend<&'a T> for &mut VecDeque<T>
+where
+    T: 'a + Copy + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
     }
 }
 
@@ -605,6 +908,34 @@ where
         I: IntoParallelIterator<Item = &'a T>,
     {
         self.par_extend(par_iter.into_par_iter().copied())
+    }
+}
+
+/// Extends a vector with items from a parallel iterator, through a mutable
+/// reference.
+impl<T> ParallelExtend<T> for &mut Vec<T>
+where
+    T: Send,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = T>,
+    {
+        (**self).par_extend(par_iter)
+    }
+}
+
+/// Extends a vector with copied items from a parallel iterator, through a
+/// mutable reference.
+impl<'a, T> ParallelExtend<&'a T> for &mut Vec<T>
+where
+    T: 'a + Copy + Send + Sync,
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+    where
+        I: IntoParallelIterator<Item = &'a T>,
+    {
+        (**self).par_extend(par_iter)
     }
 }
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -7,9 +7,10 @@ use rayon_core::*;
 use rand::distr::StandardUniform;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Debug;
 use std::sync::mpsc;
 
@@ -1844,6 +1845,127 @@ fn check_extend_pairs() {
 
     check::<BTreeMap<usize, i32>>();
     check::<HashMap<usize, i32>>();
+}
+
+/// Calls `par_extend` through the `&mut C` forwarding impls: no
+/// `C: ParallelExtend` bound is in scope, so this compiles only if the
+/// mutable-reference impl itself exists (issue #1089).
+fn par_extend_ref<C, I>(mut c: &mut C, par_iter: I)
+where
+    for<'c> &'c mut C: ParallelExtend<I::Item>,
+    I: IntoParallelIterator,
+{
+    ParallelExtend::par_extend(&mut c, par_iter);
+}
+
+#[test]
+fn check_extend_ref_items() {
+    fn check<C>()
+    where
+        C: Default + Eq + Debug + Extend<i32> + for<'a> Extend<&'a i32>,
+        for<'c> &'c mut C: ParallelExtend<i32>,
+        for<'c, 'a> &'c mut C: ParallelExtend<&'a i32>,
+    {
+        let mut serial = C::default();
+        let mut parallel = C::default();
+
+        // extend with references
+        let v: Vec<_> = (0..128).collect();
+        serial.extend(&v);
+        par_extend_ref(&mut parallel, &v);
+        assert_eq!(serial, parallel);
+
+        // extend with values
+        serial.extend(-128..0);
+        par_extend_ref(&mut parallel, -128..0);
+        assert_eq!(serial, parallel);
+    }
+
+    check::<BTreeSet<_>>();
+    check::<HashSet<_>>();
+    check::<LinkedList<_>>();
+    check::<Vec<_>>();
+    check::<VecDeque<_>>();
+}
+
+#[test]
+fn check_extend_ref_heap() {
+    let mut serial: BinaryHeap<_> = Default::default();
+    let mut parallel: BinaryHeap<_> = Default::default();
+
+    // extend with references
+    let v: Vec<_> = (0..128).collect();
+    serial.extend(&v);
+    par_extend_ref(&mut parallel, &v);
+    assert_eq!(
+        serial.clone().into_sorted_vec(),
+        parallel.clone().into_sorted_vec()
+    );
+
+    // extend with values
+    serial.extend(-128..0);
+    par_extend_ref(&mut parallel, -128..0);
+    assert_eq!(serial.into_sorted_vec(), parallel.into_sorted_vec());
+}
+
+#[test]
+fn check_extend_ref_pairs() {
+    fn check<C>()
+    where
+        C: Default + Eq + Debug + Extend<(usize, i32)> + for<'a> Extend<(&'a usize, &'a i32)>,
+        for<'c> &'c mut C: ParallelExtend<(usize, i32)>,
+        for<'c, 'a> &'c mut C: ParallelExtend<(&'a usize, &'a i32)>,
+    {
+        let mut serial = C::default();
+        let mut parallel = C::default();
+
+        // extend with references
+        let m: HashMap<_, _> = (0..128).enumerate().collect();
+        serial.extend(&m);
+        par_extend_ref(&mut parallel, &m);
+        assert_eq!(serial, parallel);
+
+        // extend with values
+        let v: Vec<(_, _)> = (-128..0).enumerate().collect();
+        serial.extend(v.clone());
+        par_extend_ref(&mut parallel, v);
+        assert_eq!(serial, parallel);
+    }
+
+    check::<BTreeMap<usize, i32>>();
+    check::<HashMap<usize, i32>>();
+}
+
+#[test]
+fn check_extend_ref_strings() {
+    let mut s = String::from("abc");
+    par_extend_ref(&mut s, vec!['d', 'e']);
+    par_extend_ref(&mut s, vec![&'f']);
+    par_extend_ref(&mut s, vec!["g"]);
+    par_extend_ref(&mut s, vec![String::from("h")]);
+    par_extend_ref(&mut s, vec![Box::<str>::from("i")]);
+    par_extend_ref(&mut s, vec![Cow::from("j")]);
+    assert_eq!(s, "abcdefghij");
+
+    let mut os = OsString::from("ab");
+    par_extend_ref(&mut os, vec![OsStr::new("c")]);
+    par_extend_ref(&mut os, vec![OsString::from("d")]);
+    par_extend_ref(&mut os, vec![Cow::from(OsStr::new("e"))]);
+    assert_eq!(os, OsString::from("abcde"));
+}
+
+#[test]
+fn check_extend_ref_tuple() {
+    // The motivating example from issue #1089: extend two collections that
+    // are not stored as a tuple, through a tuple of mutable references.
+    let mut vec1 = vec![1., 2., 3.];
+    let mut vec2 = vec!["1".to_string(), "2".to_string(), "3".to_string()];
+
+    let input = vec![4, 5, 6];
+    (&mut vec1, &mut vec2).par_extend(input.into_par_iter().map(|i| (i as f64, i.to_string())));
+
+    assert_eq!(vec1, [1., 2., 3., 4., 5., 6.]);
+    assert_eq!(vec2, ["1", "2", "3", "4", "5", "6"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the suggestion from #1089: `ParallelExtend` impls for `&mut` references to every collection that already has a by-value impl, so tuples of mutable references work:

```rust
let mut vec1 = vec![1., 2., 3.];
let mut vec2 = vec!["1".to_string(), "2".to_string(), "3".to_string()];

let input = vec![4, 5, 6];
(&mut vec1, &mut vec2).par_extend(input.into_par_iter().map(|i| (i as f64, i.to_string())));
```

This code from the issue now compiles and is one of the new tests (`check_extend_ref_tuple`).

## Approach

In the issue thread, @cuviper ruled out a blanket impl and suggested the per-type route:

> It might have been nice to add a blanket impl `for &mut T where T: ParallelExtend`, but it's a breaking change to add that now.  We possibly *could* add that for each upstream type we have implemented, like `&mut Vec<T>`, and that would make your example work.

So this PR adds a concrete forwarding impl next to each existing by-value impl in `src/iter/extend.rs` (25 impls: `Vec`, `VecDeque`, `BinaryHeap`, `BTreeMap`, `BTreeSet`, `HashMap`, `HashSet`, `LinkedList`, `String`, `OsString`, covering the same item types as the by-value impls).  Each body is a one-line delegation:

```rust
/// Extends a vector with items from a parallel iterator, through a mutable
/// reference.
impl<T> ParallelExtend<T> for &mut Vec<T>
where
    T: Send,
{
    fn par_extend<I>(&mut self, par_iter: I)
    where
        I: IntoParallelIterator<Item = T>,
    {
        (**self).par_extend(par_iter)
    }
}
```

The tuple impls in `src/iter/unzip.rs` need no change: `&mut Vec<T>` is `Send`, so `(&mut A, &mut B)` now satisfies the existing bounds.

Deliberately left out, easy to add if wanted:

- `&mut ()` for the unit impl (degenerate).
- `&mut Either<L, R>` (`src/par_either.rs`).
- The `ExtendRef` / `ExtendTuple` wrapper struct also discussed in the thread.  The forwarding impls do not preclude it;  it stays useful for collections outside this set.

## Testing

- `check_extend_ref_items` / `check_extend_ref_heap` / `check_extend_ref_pairs` / `check_extend_ref_strings` mirror the existing `check_extend_*` tests through `&mut C`.  They call through a `par_extend_ref` helper whose only bound is `for<'c> &'c mut C: ParallelExtend<_>`, so the tests compile only via the new impls (no silent auto-deref to the by-value impl).
- `check_extend_ref_tuple` is the example from the issue.
- `cargo test --lib`, `cargo clippy --all-targets`, and `cargo fmt` are clean locally.  As a sanity check, replacing one forwarder body with a no-op makes the new tests fail, so they do exercise the forwarding.

<sub>Drafted with AI assistance;  the approach, code, and tests were reviewed and run by me.</sub>
