### PR TITLE
Fix typo in README regarding thread states

### DIFF
--- a/rayon-core/src/sleep/README.md
+++ b/rayon-core/src/sleep/README.md
@@ -32,7 +32,7 @@ There are three main thread states:
   waiting to be awoken.
 
 We sometimes refer to the final two states collectively as **inactive**.
-Threads begin as idle but transition to idle and finally sleeping when
+Threads begin as idle but transition to sleepy and finally sleeping when
 they're unable to find work to do.
 
 ## Sleepy threads


### PR DESCRIPTION
README states thread begins at `idle` then transitions `idle`, that doesn't make sense here. It seems the likely state would have been `sleepy`, as the code backs that up